### PR TITLE
Implement `bootstrap` functionality

### DIFF
--- a/src/layup/config_setups/default_config.ini
+++ b/src/layup/config_setups/default_config.ini
@@ -22,8 +22,8 @@ leap_seconds_url = https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif00
 
 meta_kernel = meta_kernel.txt
 
-observatory_codes= ObsCodes.json.gz
-observatory_codes_url = https://minorplanetcenter.net/Extended_Files/obscodes_extended.json.gz
+observatory_codes_compressed = ObsCodes.json.gz
+observatory_codes_compressed_url = https://minorplanetcenter.net/Extended_Files/obscodes_extended.json.gz
 
 orientation_constants = pck00010.pck
 orientation_constants_url = https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/pck00010.tpc

--- a/src/layup/config_setups/default_config.ini
+++ b/src/layup/config_setups/default_config.ini
@@ -1,4 +1,6 @@
 [AUXILIARY]
+# If you want to download a different URL, you must change BOTH the URL and the file name.
+
 planet_ephemeris = de440s.bsp
 planet_ephemeris_url = https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp
 

--- a/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
+++ b/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
@@ -1,0 +1,81 @@
+import os
+import pooch
+
+from layup.utilities.layup_configs import AuxiliaryConfigs
+
+"""
+    An example output from running `build_meta_kernel_file` might look like
+    the following:
+
+    \begindata
+
+    PATH_VALUES = ('/Users/scientist/layup/data_files/assist_and_rebound')
+
+    PATH_SYMBOLS = ('A')
+
+    KERNELS_TO_LOAD=(
+        '$A/naif0012.tls',
+        '$A/earth_720101_230601.bpc',
+        '$A/earth_200101_990825_predict.bpc',
+        '$A/pck00010.pck',
+        '$A/de440s.bsp',
+        '$A/earth_latest_high_prec.bpc',
+    )
+
+    \begintext
+"""
+
+
+def build_meta_kernel_file(auxconfigs: AuxiliaryConfigs, retriever: pooch.Pooch) -> None:
+    """Builds a specific text file that will be fed into `spiceypy` that defines
+    the list of spice kernel to load, as well as the order to load them.
+
+    Parameters
+    ----------
+    auxconfigs: AuxiliaryConfigs
+        Dataclass of auxiliary configuration file arguments.
+    retriever : pooch
+        Pooch object that maintains the registry of files to download
+
+    Returns
+    ---------
+    None
+    """
+    # build meta_kernel file path
+    meta_kernel_file_path = os.path.join(retriever.abspath, auxconfigs.meta_kernel)
+
+    # build a meta_kernel.txt file
+    with open(meta_kernel_file_path, "w") as meta_file:
+        meta_file.write("\\begindata\n\n")
+        meta_file.write(f"PATH_VALUES = ('{retriever.abspath}')\n\n")
+        meta_file.write("PATH_SYMBOLS = ('A')\n\n")
+        meta_file.write("KERNELS_TO_LOAD=(\n")
+        for file_name in auxconfigs.ordered_kernel_files:
+            shortened_file_name = _build_file_name(retriever.abspath, retriever.fetch(file_name))
+            meta_file.write(f"    '{shortened_file_name}',\n")
+        meta_file.write(")\n\n")
+        meta_file.write("\\begintext\n")
+
+
+def _build_file_name(cache_dir: str, file_path: str) -> str:
+    """Given a string defining the cache directory, and a string defining the full
+    path to a given file. This function will strip out the cache directory from
+    the file path and replace it with the required meta_kernel directory
+    substitution character.
+
+    Parameters
+    ----------
+    cache_dir : string
+        The full path to the cache directory used when retrieving files for Assist
+        and Rebound.
+    file_path : string
+        The full file path for a given file that will have the cache directory
+        segment replace.
+
+    Returns
+    -------
+    : string
+        Shortened file path, appropriate for use in kernel_meta files.
+    """
+
+    return file_path.replace(str(cache_dir), "$A")

--- a/src/layup/utilities/bootstrap_utilties/download_utilities.py
+++ b/src/layup/utilities/bootstrap_utilties/download_utilities.py
@@ -1,0 +1,113 @@
+import os
+import pooch
+from typing import Optional
+from layup.utilities.layup_configs import AuxiliaryConfigs
+
+
+def make_retriever(aux_config: AuxiliaryConfigs, directory_path: Optional[str] = None) -> pooch.Pooch:
+    """Create a Pooch object to track and retrieve ephemeris files.
+
+    Parameters
+    ----------
+    aux_config: AuxiliaryConfigs
+        Dataclass of auxiliary configuration file arguments.
+    directory_path : string, optional
+        The base directory to place all downloaded files. Default = None
+
+    Returns
+    -------
+    : pooch.Pooch
+        The instance of a Pooch object used to track and retrieve files.
+    """
+    dir_path = directory_path if directory_path else pooch.os_cache("layup")
+
+    return pooch.create(
+        path=dir_path,
+        base_url="",
+        urls=aux_config.urls,
+        registry=aux_config.registry,
+        retry_if_failed=25,
+    )
+
+
+def _check_for_existing_files(aux_config: AuxiliaryConfigs, retriever: pooch.Pooch) -> bool:
+    """Will check for existing local files, any file not found will be printed
+    to the terminal.
+
+    Parameters
+    -------------
+    aux_configs: AuxiliaryConfigs
+        Dataclass of auxiliary configuration file arguments.
+    retriever : pooch.Pooch
+        Pooch object that maintains the registry of files to download.
+
+    Returns
+    ----------
+    :  bool
+        Returns True if all files are found in the local cache, False otherwise.
+    """
+
+    file_list = aux_config.data_file_list
+
+    found_all_files = True
+    missing_files = []
+    for file_name in file_list:
+        if not os.path.exists(os.path.join(retriever.abspath, file_name)):
+            missing_files.append(file_name)
+            found_all_files = False
+
+    if found_all_files:
+        print(f"All expected files were found in the local cache: {retriever.abspath}/")
+    else:
+        print(f"The following file(s) were not found in the local cache: {retriever.abspath}/")
+        for file_name in missing_files:
+            print(f"- {file_name}")
+
+    return found_all_files
+
+
+def _decompress(fname: str, action: str, pup: pooch.Pooch) -> None:  # pragma: no cover
+    """Override the functionality of Pooch's `Decompress` class so that the resulting
+    decompressed file uses the original file name without the compression extension.
+    For instance `filename.json.bz` will be decompressed and saved as `filename.json`.
+
+    Parameters
+    ------------
+    fname : str
+        Original filename
+    action : str
+        One of ["download", "update", "fetch"]
+    pup : pooch.Pooch
+        The Pooch object that defines the location of the file.
+
+    Returns
+    ----------
+    None
+    """
+    known_extentions = [".gz", ".bz2", ".xz"]
+    if os.path.splitext(fname)[-1] in known_extentions:
+        pooch.Decompress(method="auto", name=os.path.splitext(fname)[0]).__call__(fname, action, pup)
+
+
+def _remove_files(aux_config: AuxiliaryConfigs, retriever: pooch.Pooch) -> None:
+    """Utility to remove all the files tracked by the pooch retriever. This includes
+    the decompressed ObservatoryCodes.json file as well as the META_KERNEL file
+    that are created after downloading the files in the DATA_FILES_TO_DOWNLOAD
+    list.
+
+    Parameters
+    ------------
+    aux_config: AuxiliaryConfigs
+        Dataclass of auxiliary configuration file arguments.
+    retriever : pooch.Pooch
+        Pooch object that maintains the registry of files to download.
+
+    Returns
+    ----------
+    None
+    """
+
+    for file_name in aux_config.data_file_list:
+        file_path = retriever.fetch(file_name)
+        print(f"Deleting file: {file_path}")
+        os.remove(file_path)

--- a/src/layup/utilities/bootstrap_utilties/download_utilities.py
+++ b/src/layup/utilities/bootstrap_utilties/download_utilities.py
@@ -108,6 +108,7 @@ def _remove_files(aux_config: AuxiliaryConfigs, retriever: pooch.Pooch) -> None:
     """
 
     for file_name in aux_config.data_file_list:
-        file_path = retriever.fetch(file_name)
-        print(f"Deleting file: {file_path}")
-        os.remove(file_path)
+        file_path = os.path.join(retriever.abspath, file_name)
+        if os.path.exists(file_path):
+            print(f"Deleting file: {file_path}")
+            os.remove(file_path)

--- a/src/layup_cmdline/bootstrap.py
+++ b/src/layup_cmdline/bootstrap.py
@@ -2,6 +2,7 @@
 # The `layup bootstrap` subcommand implementation
 #
 import argparse
+import pooch
 from layup_cmdline.layupargumentparser import LayupArgumentParser
 
 from layup.utilities.file_access_utils import find_file_or_exit
@@ -14,14 +15,6 @@ def main():
         description="This would start bootstrap",
     )
     optional = parser.add_argument_group("Optional arguments")
-    optional.add_argument(
-        "-p",
-        "--print",
-        help="Prints statement to terminal.",
-        dest="p",
-        action="store_true",
-        required=False,
-    )
 
     optional.add_argument(
         "-c",
@@ -32,27 +25,76 @@ def main():
         required=False,
     )
 
+    parser.add_argument(
+        "--cache",
+        type=str,
+        default=pooch.os_cache("layup"),
+        help="Local directory where downloaded files will be stored.",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Delete and re-download data files.",
+    )
+
     args = parser.parse_args()
 
     return execute(args)
 
 
 def execute(args):
-    if args.p:
-        print("print statement used for bootstrap")
-    else:
-        print("Hello world this would start bootstrap")
-    # Showing how Configs file is called and how parameters are used
+    import concurrent.futures
+    from functools import partial
 
     from layup.utilities.layup_configs import LayupConfigs
+    from layup.utilities.bootstrap_utilties.create_meta_kernel import (
+        build_meta_kernel_file,
+    )
+    from layup.utilities.bootstrap_utilties.download_utilities import (
+        make_retriever,
+        _remove_files,
+        _check_for_existing_files,
+        _decompress,
+    )
 
+    # Bootstrap will always take the default filenames and urls (stored in
+    # layup.AuxiliaryConfigs) for the current version of layup. A user can
+    # download new files by running layup and specifying in the config file
+    # under the section [AUXILIARY] a new filename and url.
     if args.c:
         find_file_or_exit(args.c, "-c, --config")
         configs = LayupConfigs(args.c)
-        print("printing the config file filename of jpl_planets:", configs.auxiliary.jpl_planets)
     else:
         configs = LayupConfigs()
-        print("printing the default filename of jpl_planets:", configs.auxiliary.jpl_planets)
+
+    aux_config = configs.auxiliary
+
+    # create the Pooch retriever that tracks and retrieves the requested files
+    retriever = make_retriever(aux_config, args.cache)
+
+    # determine if we should attempt to download or create any files.
+    found_all_files = False
+    if args.force:
+        _remove_files(aux_config, retriever)
+    else:
+        print("Checking cache for existing files.")
+        found_all_files = _check_for_existing_files(aux_config, retriever)
+
+    if not found_all_files:
+        # create a partial function of `Pooch.fetch` including the `_decompress` method
+        fetch_partial = partial(retriever.fetch, processor=_decompress, progressbar=True)
+
+        # download the data files in parallel
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            executor.map(fetch_partial, aux_config.data_files_to_download)
+
+        # build the meta_kernel.txt file
+        build_meta_kernel_file(aux_config, retriever)
+
+        print("Checking cache after attempting to download and create files.")
+        _check_for_existing_files(aux_config, retriever)
 
 
 if __name__ == "__main__":

--- a/tests/layup/test_layup_configs.py
+++ b/tests/layup/test_layup_configs.py
@@ -67,6 +67,9 @@ def test_layup_configs():
     ],
 )
 def test_auxiliary_config_url_given_filename_not(file):
+    """Users can update the filenames in the config file as desired, but if they
+    update the URL for a file, they must also update the filename for that file
+    as well. This test checks that the user cannot update just the URL."""
     aux_configs = {file + "_url": "new_url"}
     with pytest.raises(SystemExit) as error_text:
         AuxiliaryConfigs(**aux_configs)

--- a/tests/layup/test_layup_configs.py
+++ b/tests/layup/test_layup_configs.py
@@ -27,6 +27,7 @@ correct_auxciliary_filenames = [
     "naif0012.tls",
     "meta_kernel.txt",
     "ObsCodes.json.gz",
+    "ObsCodes.json",
     "pck00010.pck",
 ]
 
@@ -37,7 +38,7 @@ correct_auxciliary_filenames = [
 
 def test_layup_configs():
     """
-    tests that sorchaConfigs reads in config file correctly
+    tests that LayupConfigs reads in config file correctly
     """
     # general test to make sure, overall, everything works. checks just one file: "default_config.ini"
 
@@ -61,7 +62,7 @@ def test_layup_configs():
         "earth_historical",
         "jpl_planets",
         "leap_seconds",
-        "observatory_codes",
+        "observatory_codes_compressed",
         "orientation_constants",
     ],
 )
@@ -80,7 +81,7 @@ def test_auxiliary_config_url_given_filename_not(file):
         "earth_historical",
         "jpl_planets",
         "leap_seconds",
-        "observatory_codes",
+        "observatory_codes_compressed",
         "orientation_constants",
     ],
 )


### PR DESCRIPTION
Fixes #13 

The work here is very similar (and often identical) to what was implemented for Sorcha. A set of files is downloaded to the default cache directory using `pooch`. The file names and URLs can be changed if the user updates those in a local config file. Additionally, the user can select a different caching directory and/or force redownloading files if needed.

## Example usage
```
>> layup bootstrap  # download all files to the default cache directory
>> layup bootstrap --cache ./some/directory  # download to a specific directory
>> layup bootstrap --force # remove any downloaded and generated files from the default cache, and redownload
>> layup bootstrap -c/--config ./config.ini # download files specified in the local config file.

# Command can be nested
>> layup bootstrap -c ./config.ini --force --cache ./some/directory
```

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
