### PR TITLE
scikit-build-core and pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Require CMake 3.15+ (matching scikit-build-core) Use new versions of all
+# policies up to CMake 3.27
+cmake_minimum_required(VERSION 3.15...3.27)
+
+# Scikit-build-core sets these values for you, or you can just hard-code the
+# name and version.
+project(
+  ${SKBUILD_PROJECT_NAME}
+  VERSION ${SKBUILD_PROJECT_VERSION}
+  LANGUAGES CXX)
+
+# Find the module development requirements (requires FindPython from 3.17 or
+# scikit-build-core's built-in backport)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(pybind11 CONFIG REQUIRED)
+
+# Add a library using FindPython's tooling (pybind11 also provides a helper like
+# this)
+python_add_library(_core MODULE src/main.cpp WITH_SOABI)
+target_link_libraries(_core PRIVATE pybind11::headers)
+
+# This is passing in the version as a define just as an example
+target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
+
+# The install directory is the output (wheel) directory
+install(TARGETS _core DESTINATION layup_cpp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,10 @@ dev = [
 
 [build-system]
 requires = [
-    "setuptools>=62", # Used to build and package the Python project
-    "setuptools_scm>=6.2", # Gets release version from git. Makes it available programmatically
+    "scikit-build-core>=0.10",
+    "pybind11"
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "scikit_build_core.build"
 
 [tool.setuptools_scm]
 write_to = "src/layup/_version.py"

--- a/src/layup/routines/__init__.py
+++ b/src/layup/routines/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from layup_cpp._core import __doc__, __version__, hello_world
+
+__all__ = ["__doc__", "__version__", "hello_world"]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,38 @@
+#include <pybind11/pybind11.h>
+
+#include <string>
+
+#define STRINGIFY(x) #x
+#define MACRO_STRINGIFY(x) STRINGIFY(x)
+
+std::string hello_world() {
+    return "Hello, World!";
+}
+
+namespace py = pybind11;
+
+
+PYBIND11_MODULE(_core, m) {
+    m.doc() = R"pbdoc(
+        Pybind11 example plugin
+        -----------------------
+
+        .. currentmodule:: scikit_build_example
+
+        .. autosummary::
+           :toctree: _generate
+
+           add
+           subtract
+    )pbdoc";
+
+    m.def("hello_world", &hello_world, R"pbdoc(
+        Say 'Hello, World!'
+    )pbdoc");
+
+#ifdef VERSION_INFO
+    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+#else
+    m.attr("__version__") = "dev";
+#endif
+}

--- a/tests/layup/test_cpp_import.py
+++ b/tests/layup/test_cpp_import.py
@@ -1,0 +1,6 @@
+from layup import routines
+
+
+def test_hello_world() -> None:
+    output = routines.hello_world()
+    assert output == "Hello, World!"


### PR DESCRIPTION
Fixes #31 .

This solution uses `scikit-build-core` and pip installed `pybind11` to build a C++ hello world function and then surface that through the `layup` api.

`scikit-build-core` replaces `setuptools` as the building engine for the package and handles all of the pybind integration as long as we specify everything in the `CMakeLists.txt`. This approach has the benefit of being easier to maintain than having a manual `CMake` implementation as well as not keeping `pybind11` as a submodule, hopefully making it easier to package for other users.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
