### PR TITLE
adding cmd_line arguments to layup convert

### DIFF
--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -20,7 +20,7 @@ def main():
     )
 
     positionals.add_argument(
-        help="orbit type to convert to",
+        help="orbit type to convert to [COM, BCOM, KEP, BKEP, CART, BCART]",
         dest="type",
         type=str,
     )
@@ -51,7 +51,7 @@ def main():
         help="output file name. default path is current working directory",
         dest="o",
         type=str,
-        default="converted_output.csv",
+        default="converted_output",
         required=False,
     )
 

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -16,7 +16,7 @@ def main():
     required.add_argument(
         "-i",
         "--input",
-        help= "input orbit file",
+        help="input orbit file",
         dest="i",
         type=str,
         required=True,
@@ -24,7 +24,7 @@ def main():
     required.add_argument(
         "-f",
         "--format",
-        help= "format of input file",
+        help="format of input file",
         dest="f",
         type=str,
         required=True,
@@ -40,8 +40,8 @@ def main():
     required.add_argument(
         "-o",
         "--output",
-        help= "output file name. default path is current working directory",
-        dest='o',
+        help="output file name. default path is current working directory",
+        dest="o",
         type=str,
         required=True,
     )
@@ -52,10 +52,10 @@ def main():
         help="number of orbits to be processed at once",
         dest="c",
         type=int,
-        default= 10000,
+        default=10000,
         required=False,
     )
-    
+
     optional.add_argument(
         "-p",
         "--print",

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -11,40 +11,20 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="This would convert orbits",
     )
-    required = parser.add_argument_group("Required arguments")
 
-    required.add_argument(
-        "-i",
-        "--input",
+    positionals = parser.add_argument_group("Positional arguments")
+    positionals.add_argument(
         help="input orbit file",
-        dest="i",
+        dest="input",
         type=str,
-        required=True,
     )
-    required.add_argument(
-        "-f",
-        "--format",
-        help="format of input file",
-        dest="f",
-        type=str,
-        required=True,
-    )
-    required.add_argument(
-        "-t",
-        "--type",
+
+    positionals.add_argument(
         help="orbit type to convert to",
-        dest="t",
+        dest="type",
         type=str,
-        required=True,
     )
-    required.add_argument(
-        "-o",
-        "--output",
-        help="output file name. default path is current working directory",
-        dest="o",
-        type=str,
-        required=True,
-    )
+
     optional = parser.add_argument_group("Optional arguments")
     optional.add_argument(
         "-c",
@@ -56,13 +36,31 @@ def main():
         required=False,
     )
 
+    optional.add_argument(
+        "-f",
+        "--format",
+        help="format of input file",
+        dest="f",
+        type=str,
+        default="csv",
+        required=False,
+    )
+    optional.add_argument(
+        "-o",
+        "--output",
+        help="output file name. default path is current working directory",
+        dest="o",
+        type=str,
+        default="converted_output.csv",
+        required=False,
+    )
+
     args = parser.parse_args()
 
     return execute(args)
 
 
 def execute(args):
-
     print("Hello world this would start convert")
 
 

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -11,8 +11,51 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="This would convert orbits",
     )
+    required = parser.add_argument_group("Required arguments")
 
+    required.add_argument(
+        "-i",
+        "--input",
+        help= "input orbit file",
+        dest="i",
+        type=str,
+        required=True,
+    )
+    required.add_argument(
+        "-f",
+        "--format",
+        help= "format of input file",
+        dest="f",
+        type=str,
+        required=True,
+    )
+    required.add_argument(
+        "-t",
+        "--type",
+        help="orbit type to convert to",
+        dest="t",
+        type=str,
+        required=True,
+    )
+    required.add_argument(
+        "-o",
+        "--output",
+        help= "output file name. default path is current working directory",
+        dest='o',
+        type=str,
+        required=True,
+    )
     optional = parser.add_argument_group("Optional arguments")
+    optional.add_argument(
+        "-c",
+        "--chunksize",
+        help="number of orbits to be processed at once",
+        dest="c",
+        type=int,
+        default= 10000,
+        required=False,
+    )
+    
     optional.add_argument(
         "-p",
         "--print",

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -56,25 +56,14 @@ def main():
         required=False,
     )
 
-    optional.add_argument(
-        "-p",
-        "--print",
-        help="Prints statement to terminal.",
-        dest="p",
-        action="store_true",
-        required=False,
-    )
-
     args = parser.parse_args()
 
     return execute(args)
 
 
 def execute(args):
-    if args.p:
-        print("print statement used for convert")
-    else:
-        print("Hello world this would start convert")
+
+    print("Hello world this would start convert")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #.

adding cmd_line arguments to layup convert. Using help gives this output.
```
layup convert --help
usage: layup convert [-h] -i I -f F -t T -o O [-c C] [-p]

This would convert orbits

options:
  -h, --help           show this help message and exit

Required arguments:
  -i I, --input I      input orbit file (default: None)
  -f F, --format F     format of input file (default: None)
  -t T, --type T       orbit type to convert to (default: None)
  -o O, --output O     output file name. default path is current working directory (default: None)

Optional arguments:
  -c C, --chunksize C  number of orbits to be processed at once (default: 10000)
  -p, --print          Prints statement to terminal. (default: False)
```

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
