### PR TITLE
added force cmd line arg to layup convert

### DIFF
--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -35,12 +35,17 @@ def main():
         default=10000,
         required=False,
     )
-
     optional.add_argument(
         "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite output file",
+    )
+    optional.add_argument(
+        "--fo",
         "--format",
         help="format of input file",
-        dest="f",
+        dest="fo",
         type=str,
         default="csv",
         required=False,


### PR DESCRIPTION
Fixes #64 .
added cmd line argument -f force for deleting and overwritng the output file. Changed format argument to --fo.
## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
