### PR TITLE
Layup orbitfit cmdline args 

### DIFF
--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -53,7 +53,7 @@ def main():
     optional.add_argument(
         "-o",
         "--output",
-        help="output file name. default path is current working directory",
+        help="output file stem. default path is current working directory",
         dest="o",
         type=str,
         default="converted_output",

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -63,7 +63,7 @@ def main():
     optional.add_argument(
         "-o",
         "--output",
-        help="output file name. default path is current working directory",
+        help="output file stem. default path is current working directory",
         dest="o",
         type=str,
         default="output",

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -2,6 +2,7 @@
 # The `layup orbitfit` subcommand implementation
 #
 import argparse
+import sys
 from layup_cmdline.layupargumentparser import LayupArgumentParser
 from layup.utilities.file_access_utils import find_file_or_exit
 
@@ -19,7 +20,7 @@ def main():
         type=str,
     )
     positionals.add_argument(
-        help = "input file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]",
+        help="input file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]",
         dest="type",
         type=str,
     )
@@ -50,13 +51,7 @@ def main():
         help="Overwrite output file",
         required=False,
     )
-    optional.add_argument(
-        "-g",
-        "--guess",
-        help="initial guess file",
-        dest="g",
-        required=False
-        )
+    optional.add_argument("-g", "--guess", help="initial guess file", dest="g", required=False)
     optional.add_argument(
         "-i",
         "--iod",
@@ -83,10 +78,8 @@ def main():
         default="csv",
         required=False,
     )
-    
+
     args = parser.parse_args()
-    if args.g:
-        args.i = None
 
     return execute(args)
 
@@ -94,9 +87,21 @@ def main():
 def execute(args):
     print("Hello world this would start orbitfit")
 
+    if args.g and args.i == "gauss":
+        args.i = None
+    elif args.g and args.i != None:
+
+        sys.exit("ERROR: IOD and initial guess file cannot be called together")
+
+    find_file_or_exit(arg_fn=args.input, argname="positional input")
+
+    if not ((args.type.lower()) in ["mpc80col", "ades_csv", "ades_psv", "ades_xml", "ades_hdf5"]):
+        sys.exit("Not a supported file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]")
     from layup.utilities.layup_configs import LayupConfigs
 
-    # Showing how Configs file is called and how parameters are used
+    if args.g is not None:
+        find_file_or_exit(args.g, "-g, --guess")
+
     if args.c:
         find_file_or_exit(args.c, "-c, --config")
         configs = LayupConfigs(args.c)

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -90,7 +90,6 @@ def execute(args):
     if args.g and args.i == "gauss":
         args.i = None
     elif args.g and args.i != None:
-
         sys.exit("ERROR: IOD and initial guess file cannot be called together")
 
     find_file_or_exit(arg_fn=args.input, argname="positional input")

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -12,35 +12,87 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="This would start orbitfit",
     )
+    positionals = parser.add_argument_group("Positional arguments")
+    positionals.add_argument(
+        help="astrometry input file",
+        dest="input",
+        type=str,
+    )
+    positionals.add_argument(
+        help = "input file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]",
+        dest="type",
+        type=str,
+    )
+
     optional = parser.add_argument_group("Optional arguments")
     optional.add_argument(
         "-c",
-        "--config",
-        help="Input configuration file name",
+        "--conf",
+        help="optional configuration file",
         type=str,
         dest="c",
         required=False,
     )
-
     optional.add_argument(
-        "-p",
-        "--print",
-        help="Prints statement to terminal.",
-        dest="p",
-        action="store_true",
+        "-ch",
+        "--chunksize",
+        help="number of orbits to be processed at once",
+        dest="c",
+        type=int,
+        default=10000,
         required=False,
     )
 
+    optional.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite output file",
+        required=False,
+    )
+    optional.add_argument(
+        "-g",
+        "--guess",
+        help="initial guess file",
+        dest="g",
+        required=False
+        )
+    optional.add_argument(
+        "-i",
+        "--iod",
+        help="IOD choice",
+        dest="i",
+        default="gauss",
+        required=False,
+    )
+    optional.add_argument(
+        "-o",
+        "--output",
+        help="output file name. default path is current working directory",
+        dest="o",
+        type=str,
+        default="output",
+        required=False,
+    )
+    optional.add_argument(
+        "-of",
+        "--output_format",
+        help="output file format.",
+        dest="of",
+        type=str,
+        default="csv",
+        required=False,
+    )
+    
     args = parser.parse_args()
+    if args.g:
+        args.i = None
 
     return execute(args)
 
 
 def execute(args):
-    if args.p:
-        print("print statement used for orbitfit")
-    else:
-        print("Hello world this would start orbitfit")
+    print("Hello world this would start orbitfit")
 
     from layup.utilities.layup_configs import LayupConfigs
 


### PR DESCRIPTION
Fixes #65 .

Added layup orbitfit cmd line args.
```
layup orbitfit --help
usage: layup orbitfit [-h] [-c C] [-ch C] [-f] [-g G] [-i I] [-o O] [-of OF] input type

This would start orbitfit

options:
  -h, --help            show this help message and exit

Positional arguments:
  input                 astrometry input file
  type                  input file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]

Optional arguments:
  -c C, --conf C        optional configuration file (default: None)
  -ch C, --chunksize C  number of orbits to be processed at once (default: 10000)
  -f, --force           Overwrite output file (default: False)
  -g G, --guess G       initial guess file (default: None)
  -i I, --iod I         IOD choice (default: gauss)
  -o O, --output O      output file name. default path is current working directory (default: output)
  -of OF, --output_format OF
                        output file format. (default: csv)
```

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
