### PR TITLE
cmd line args for layup visualize

### DIFF
--- a/src/layup_cmdline/visualize.py
+++ b/src/layup_cmdline/visualize.py
@@ -35,7 +35,7 @@ def main():
         help="random number of orbits to take from input file",
         dest="n",
         type=str,
-        default=50,
+        default=1000,
         required=False,
     )
     optional.add_argument(

--- a/src/layup_cmdline/visualize.py
+++ b/src/layup_cmdline/visualize.py
@@ -12,13 +12,39 @@ def main():
         description="This would start visualize",
     )
 
+    positionals = parser.add_argument_group("Positional arguments")
+    positionals.add_argument(
+        help="input orbit file",
+        dest="input",
+        type=str,
+    )
+
     optional = parser.add_argument_group("Optional arguments")
     optional.add_argument(
-        "-p",
-        "--print",
-        help="Prints statement to terminal.",
-        dest="p",
-        action="store_true",
+        "-i",
+        "--input-type",
+        help="input format type of file",
+        dest="i",
+        type=str,
+        default="csv",
+        required=False,
+    )
+    optional.add_argument(
+        "-n",
+        "--num",
+        help="random number of orbits to take from input file",
+        dest="n",
+        type=str,
+        default=50,
+        required=False,
+    )
+    optional.add_argument(
+        "-o",
+        "--output",
+        help="output file stem. default path is current working directory",
+        dest="o",
+        type=str,
+        default="output",
         required=False,
     )
 
@@ -28,10 +54,7 @@ def main():
 
 
 def execute(args):
-    if args.p:
-        print("print statement used for visualize")
-    else:
-        print("Hello world this would start visualize")
+    print("Hello world this would start visualise")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes # .

Created cmd line args for layup visualize.
```
layup visualize --help
usage: layup visualize [-h] [-i I] [-n N] [-o O] input

This would start visualize

options:
  -h, --help            show this help message and exit

Positional arguments:
  input                 input orbit file

Optional arguments:
  -i I, --input-type I  input format type of file (default:
                        csv)
  -n N, --num N         random number of orbits to take from
                        input file (default: 50)
  -o O, --output O      output file stem. default path is
                        current working directory (default:
                        output)
```


## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
