### PR TITLE
Using pandas to read in the CSV file rows.

### DIFF
--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -227,7 +227,7 @@ def convert_cli(
     convert_to: Literal["BCART", "BCOM", "BKEP", "CART", "COM", "KEP"],
     file_format: Literal["csv", "hdf5"] = "csv",
     chunk_size: int = 10_000,
-    num_workers: int = 1,
+    num_workers: int = -1,
     cli_args: dict = None,
 ):
     """

--- a/tests/layup/test_file_readers.py
+++ b/tests/layup/test_file_readers.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_allclose
 
 from layup.utilities.file_io.CSVReader import CSVDataReader
 from layup.utilities.file_io.HDF5Reader import HDF5DataReader
@@ -16,7 +16,25 @@ def test_file_readers_produce_identical_values(orbit_format):
     csv_reader = CSVDataReader(get_test_filepath(f"{orbit_format}.csv"))
     csv_data = csv_reader.read_rows()
 
-    assert_equal(hdf5_data, csv_data)
+    for column_name in hdf5_data.dtype.names:
+        # For non-numeric columns, we can't use assert_allclose, so we use assert_equal.
+        if (
+            hdf5_data[column_name].dtype.kind == "S"
+            or hdf5_data[column_name].dtype.kind == "U"
+            or hdf5_data[column_name].dtype.kind == "O"
+        ):
+            assert_equal(
+                hdf5_data[column_name],
+                csv_data[column_name],
+                err_msg=f"Column {column_name} not equal with dtype {hdf5_data[column_name].dtype}",
+            )
+        else:
+            # Test that we convert back to our original numeric values within a small tolerance of lost precision.
+            assert_allclose(
+                hdf5_data[column_name],
+                csv_data[column_name],
+                err_msg=f"Column {column_name} not equal with dtype {hdf5_data[column_name].dtype}",
+            )
 
 
 @pytest.mark.parametrize("orbit_format", ["BCOM", "CART", "KEP"])
@@ -29,4 +47,22 @@ def test_file_readers_produce_identical_values_with_cache(orbit_format):
     csv_reader = CSVDataReader(get_test_filepath(f"{orbit_format}.csv"), cache_table=True)
     csv_data = csv_reader.read_rows()
 
-    assert_equal(hdf5_data, csv_data)
+    for column_name in hdf5_data.dtype.names:
+        # For non-numeric columns, we can't use assert_allclose, so we use assert_equal.
+        if (
+            hdf5_data[column_name].dtype.kind == "S"
+            or hdf5_data[column_name].dtype.kind == "U"
+            or hdf5_data[column_name].dtype.kind == "O"
+        ):
+            assert_equal(
+                hdf5_data[column_name],
+                csv_data[column_name],
+                err_msg=f"Column {column_name} not equal with dtype {hdf5_data[column_name].dtype}",
+            )
+        else:
+            # Test that we convert back to our original numeric values within a small tolerance of lost precision.
+            assert_allclose(
+                hdf5_data[column_name],
+                csv_data[column_name],
+                err_msg=f"Column {column_name} not equal with dtype {hdf5_data[column_name].dtype}",
+            )


### PR DESCRIPTION


Attempting to remove pandas initially resulting is some performance degradation, reintroducing pandas for CSV file reading here (and converting dataframe to structured array) results in significant speed up. 

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
