### PR TITLE
Move parallelization logic in convert into its own module

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -1,0 +1,43 @@
+from concurrent.futures import ProcessPoolExecutor
+import numpy as np
+
+""" A module for utilities useful for processing data in structured numpy arrays """
+
+
+def process_data(data, n_workers, func, **kwargs):
+    """
+    Process a structured numpy array in parallel for a given function and keyword arguments
+
+    Parameters
+    ----------
+    data : numpy structured array
+        The data to process.
+    n_workers : int
+        The number of workers to use for parallel processing.
+    func : function
+        The function to apply to each block of data within parallel.
+    **kwargs : dictionary
+        Extra arguments to pass to the function.
+
+    Returns
+    -------
+    res : numpy structured array
+        The processed data concatenated from each function result
+    """
+    if n_workers < 1:
+        raise ValueError(f"n_workers must be greater than 0, {n_workers} was provided.")
+
+    if len(data) == 0:
+        return data
+
+    # Divide our data into blocks to be processed by each worker
+    block_size = max(1, int(len(data) / n_workers))
+    # Create a list of tuples of the form (start, end) where start is the starting index of the block
+    # and end is the last index of the block + 1.
+    blocks = [(i, min(i + block_size, len(data))) for i in range(0, len(data), block_size)]
+
+    with ProcessPoolExecutor(max_workers=n_workers) as executor:
+        # Create a future applying the function to each block of data
+        futures = [executor.submit(func, data[start:end], **kwargs) for start, end in blocks]
+        # Concatenate all processed blocks together as our final result
+        return np.concatenate([future.result() for future in futures])

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -1,0 +1,128 @@
+import pytest
+from numpy.testing import assert_equal, assert_allclose
+
+import numpy as np
+
+from layup.utilities.data_processing_utilities import process_data
+from layup.utilities.data_utilities_for_tests import get_test_filepath
+
+
+def no_op(data):
+    # Returns the data unchanged
+    return data
+
+
+def increment_q(data):
+    # Slightly modifies the data by incrementing our q value by 1
+    data["q"] += 1
+    return data
+
+
+def count(data):
+    # Returns a structured array with a column for the length of the input data
+    return np.array([(len(data),)], dtype=[("cnt", "<i8")])
+
+
+def test_invalid_workers():
+    """Test that we fail if we try to use an invalid number of workers."""
+    data = np.array([(1, 2), (3, 4), (5, 6)], dtype=[("a", "O"), ("b", "O")])
+    with pytest.raises(ValueError):
+        _ = process_data(data, 0, no_op)
+    with pytest.raises(ValueError):
+        _ = process_data(data, -1, no_op)
+
+
+@pytest.mark.parametrize("n_workers", [1, 2, 4, 8])
+def test_empty(n_workers):
+    """Test that we can handle an empty file."""
+    data = np.array([], dtype=[("a", "O"), ("b", "O")])
+    processed_data = process_data(data, n_workers, no_op)
+    assert len(processed_data) == 0
+
+
+@pytest.mark.parametrize("n_workers", [1, 2, 4, 5, 8])
+@pytest.mark.parametrize("n_rows", [1, 10000, 1000000])
+def test_no_op(n_rows, n_workers):
+    """Test that we can apply simple functions on datasets of various sizes and numbers of workers."""
+    dtypes = [
+        ("ObjID", "O"),
+        ("q", "<f8"),
+    ]
+
+    # Generate a structured array with random values for nrows
+    data = np.empty(n_rows, dtype=dtypes)
+    data["ObjID"] = np.random.choice(["red", "fox", "hype"], n_rows)
+    data["q"] = np.random.rand(n_rows)
+
+    # Apply the no_op function to the data
+    processed_data = process_data(data, n_workers, no_op)
+    assert len(processed_data) == n_rows
+
+    # Check that the data is unchanged
+    assert_equal(processed_data, data)
+    assert_equal(processed_data.dtype, data.dtype)
+
+
+@pytest.mark.parametrize("n_workers", [1, 2, 4, 5, 8])
+@pytest.mark.parametrize("n_rows", [1, 10000, 1000000])
+def test_data_modify(n_rows, n_workers):
+    """Test that we can apply simple functions on datasets of various sizes and numbers of workers."""
+    dtypes = [
+        ("ObjID", "O"),
+        ("q", "<f8"),
+    ]
+
+    # Generate a structured array with random values for nrows
+    data = np.empty(n_rows, dtype=dtypes)
+    data["ObjID"] = np.random.choice(["red", "fox", "hype"], n_rows)
+    data["q"] = np.random.rand(n_rows)
+
+    # Apply the slightly_modify function to the data
+    processed_data = process_data(data, n_workers, increment_q)
+    assert len(processed_data) == n_rows
+    assert_equal(processed_data.dtype, data.dtype)
+    for i in range(n_rows):
+        assert processed_data["q"][i] == data["q"][i] + 1
+
+
+@pytest.mark.parametrize("n_workers", [1, 2, 4, 5, 8])
+@pytest.mark.parametrize("n_rows", [1, 10000, 1000000])
+def test_parallelization(n_rows, n_workers):
+    """Test that we can apply simple functions on datasets of various sizes and numbers of workers."""
+    dtypes = [
+        ("ObjID", "O"),
+        ("q", "<f8"),
+    ]
+
+    # Generate a structured array with random values for nrows
+    data = np.empty(n_rows, dtype=dtypes)
+    data["ObjID"] = np.random.choice(["red", "fox", "hype"], n_rows)
+    data["q"] = np.random.rand(n_rows)
+
+    # Apply the slightly_modify function to the data
+    """
+    processed_data = process_data(data, n_workers, slightly_modify)
+    assert len(processed_data) == n_rows
+    assert_equal(processed_data.dtype, data.dtype)
+    for i in range(n_rows):
+        assert processed_data["q"][i] == data["q"][i] + 1
+        assert processed_data["ObjID"][i] == data["ObjID"][i] + "_modified"
+    """
+
+    # Apply the count function to the data, since this only returns a
+    # single row, we can use the length of the returned result to test how
+    # the data was sharded across n_workers
+    processed_data = process_data(data, n_workers, count)
+    if n_workers == 1:
+        # All rows were reduced on a single worker
+        assert_equal(len(processed_data), 1)
+    elif n_rows < n_workers:
+        # Since we have less rows to shard than workers, n_rows workers
+        # each received a single row to process
+        assert_equal(len(processed_data), n_rows)
+    else:
+        # Each worker reduced its share of data down to a single row
+        assert_equal(len(processed_data), n_workers)
+
+    # Check that the sum of the "cnt" column is equal to the number of rows in the original data
+    assert_equal(sum(processed_data["cnt"]), len(data))

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -99,16 +99,6 @@ def test_parallelization(n_rows, n_workers):
     data["ObjID"] = np.random.choice(["red", "fox", "hype"], n_rows)
     data["q"] = np.random.rand(n_rows)
 
-    # Apply the slightly_modify function to the data
-    """
-    processed_data = process_data(data, n_workers, slightly_modify)
-    assert len(processed_data) == n_rows
-    assert_equal(processed_data.dtype, data.dtype)
-    for i in range(n_rows):
-        assert processed_data["q"][i] == data["q"][i] + 1
-        assert processed_data["ObjID"][i] == data["ObjID"][i] + "_modified"
-    """
-
     # Apply the count function to the data, since this only returns a
     # single row, we can use the length of the returned result to test how
     # the data was sharded across n_workers


### PR DESCRIPTION
Fixes #70 .

Moves the parallelization code called by layup convert into its own utilities file for shared functions for processing numpy structured arrays. This allows the code to be re-used by other layup verbs like orbitfit.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
