### PR TITLE
Updated orbit_fit.cpp to return OrbfitResult

### DIFF
--- a/src/lib/gauss/gauss.cpp
+++ b/src/lib/gauss/gauss.cpp
@@ -120,7 +120,7 @@ std::optional<std::vector<gauss_soln>> gauss(double MU_BARY, detection &o1_in, d
 
     std::vector<gauss_soln> res;
     for (double root : roots) {
-	std::cout << root << std::endl;
+	std::cout << "root: " << root << std::endl;
         double root3 = std::pow(root, 3);
 
         // Compute a1

--- a/src/lib/orbit_fit/orbit_fit_result.cpp
+++ b/src/lib/orbit_fit/orbit_fit_result.cpp
@@ -4,11 +4,11 @@ namespace py = pybind11;
 namespace orbit_fit {
 
 struct OrbfitResult {
-    float csq;   // Chi-square value
+    double csq;   // Chi-square value
     int ndof;    // Number of degrees of freedom
-    std::array<float, 6> state;  // State vector
-    float epoch;  // Epoch
-    std::array<float, 36> cov;  // Covariance matrix
+    std::array<double, 6> state;  // State vector
+    double epoch;  // Epoch
+    std::array<double, 36> cov;  // Covariance matrix
     int niter;  // Number of iterations
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #define MACRO_STRINGIFY(x) STRINGIFY(x)
 
 std::string hello_world() {
+    std::cout << "Hello hello" << std::endl;
     return "Hello, World!";
 }
 


### PR DESCRIPTION
Fixes # .

This PR incorporates a number of changes to orbit_fit.cpp.  In particular, the code now includes a 2-pass approach for orbit fitting.  The first pass uses a fraction of the data.  The second pass uses all the data.

Also, this uses the OrbfitResult struct and returns that to python.

## Review Checklist for Source Code Changes

- [x ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [x ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
