### PR TITLE
Predict verb cmd_line args draft

### DIFF
--- a/src/layup/utilities/file_access_utils.py
+++ b/src/layup/utilities/file_access_utils.py
@@ -47,8 +47,7 @@ def find_directory_or_exit(arg_fn, argname):
     """
 
     file_path = Path(f"{arg_fn}")
-    # file_path = file_path.parent.resolve()
+    file_path = file_path.parent.resolve()
 
     if not file_path.is_dir():
-        print("\n is this working \n")
         sys.exit("ERROR: filepath {} supplied for {} argument does not exist.".format(arg_fn, argname))

--- a/src/layup_cmdline/comet.py
+++ b/src/layup_cmdline/comet.py
@@ -23,7 +23,7 @@ def main():
     optional.add_argument(
         "--ar",
         "--ar-data-path",
-        help="Directory path where Assist+Rebound data files where stored when running bootstrap_sorcha_data_files from the command line.",
+        help="Directory path where Assist+Rebound data files were stored when running `layup bootstrap` from the command line.",
         type=str,
         dest="ar",
         required=False,

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -33,7 +33,7 @@ def main():
     optional.add_argument(
         "--ar",
         "--ar-data-path",
-        help="Directory path where Assist+Rebound data files where stored when running bootstrap_sorcha_data_files from the command line.",
+        help="Directory path where Assist+Rebound data files were stored when running `layup bootstrap` from the command line.",
         type=str,
         dest="ar_data_file_path",
         required=False,

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -30,7 +30,7 @@ def main():
     optional.add_argument(
         "--ar",
         "--ar-data-path",
-        help="Directory path where Assist+Rebound data files where stored when running bootstrap_layup_data_files from the command line.",
+        help="Directory path where Assist+Rebound data files were stored when running `layup bootstrap` from the command line.",
         type=str,
         dest="ar_data_file_path",
         required=False,

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -3,6 +3,12 @@
 #
 import argparse
 from layup_cmdline.layupargumentparser import LayupArgumentParser
+from astropy.time import Time
+from datetime import datetime, timezone
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -11,26 +17,123 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description="This would start predict",
     )
-    optional = parser.add_argument_group("Optional arguments")
-    optional.add_argument(
-        "-p",
-        "--print",
-        help="Prints statement to terminal.",
-        dest="p",
-        action="store_true",
-        required=False,
+
+    positionals = parser.add_argument_group("Positional arguments")
+    positionals.add_argument(
+        help="input orbit file",
+        dest="input",
+        type=str,
     )
 
+    optional = parser.add_argument_group("Optional arguments")
+    optional.add_argument(
+        "-s",
+        "--start-date",
+        help="start date mjd_UTC. If not specified default wil be current date",
+        dest="s",
+        type=str,
+        default=str(
+            Time(datetime.now(timezone.utc), format="datetime", scale="utc").mjd
+        ),  # gives current time in mjd_UTC
+        required=False,
+    )
+    optional.add_argument(
+        "-n",
+        "--num-nights",
+        help="number of nights to predict on sky positions",
+        dest="n",
+        type=int,
+        default=14,
+        required=False,
+    )
+    optional.add_argument(
+        "-e",
+        "--end-date",
+        help="end date, mjd",
+        dest="e",
+        type=str,
+        default=None,
+        required=False,
+    )
+    optional.add_argument(
+        "-o",
+        "--output",
+        help="output file stem. default path is current working directory",
+        dest="o",
+        type=str,
+        default="predicted_output",
+        required=False,
+    )
+    optional.add_argument(
+        "-t",
+        "--timestep",
+        help="timestep for predict. must be string consisting of float and unit [min,day,sec,h] with no spaces",
+        dest="t",
+        type=str,
+        default="1min",  # we would want to parse the float and the unit, and convert into day unit
+        required=False,
+    )
+    optional.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite output file",
+    )
     args = parser.parse_args()
 
     return execute(args)
 
 
 def execute(args):
-    if args.p:
-        print("print statement used for predict")
-    else:
-        print("Hello world this would start predict")
+    import astropy.units as u
+    import re
+    from layup.utilities.cli_utilities import warn_or_remove_file
+    from layup.utilities.file_access_utils import find_file_or_exit, find_directory_or_exit
+    import sys
+
+    # check input exists
+    find_file_or_exit(args.input, "input")
+
+    # Check that output directory exists
+    find_directory_or_exit(args.o, "-o, --")
+
+    # check for overwriting output file
+    warn_or_remove_file(str(args.o), args.force, logger)
+
+    # converting timestep argument args.t into a float in day units.
+    timestep_str = args.t
+    match = re.match(
+        r"(?P<float>\d+(\.\d*)?)(?P<unit>\w+)", timestep_str.strip()
+    )  # parses float/int and unit
+    if not match:
+        sys.exit(f"Could not parse timestep: {timestep_str}")
+    value = float(match.group("float"))
+    unit_str = match.group("unit").lower()
+
+    unit_dict = {
+        "second": u.s,
+        "seconds": u.s,
+        "sec": u.s,
+        "s": u.s,
+        "minute": u.min,
+        "minutes": u.min,
+        "min": u.min,
+        "m": u.min,
+        "hour": u.h,
+        "hours": u.h,
+        "hr": u.h,
+        "h": u.h,
+        "day": u.day,
+        "days": u.day,
+        "d": u.day,
+    }  # used to convert unit_str to an astropy.unit
+
+    if unit_str not in unit_dict:
+        sys.exit(f"Unsupported unit: {unit_str}")
+
+    timestep_day = (value * unit_dict[unit_str]).to(u.day).value  # converting value into day units
+
+    print("Hello world this would start predict")
 
 
 if __name__ == "__main__":

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -19,6 +19,7 @@ def main():
     )
 
     positionals = parser.add_argument_group("Positional arguments")
+
     positionals.add_argument(
         help="input orbit file",
         dest="input",
@@ -26,6 +27,89 @@ def main():
     )
 
     optional = parser.add_argument_group("Optional arguments")
+
+    optional.add_argument(
+        "--ar",
+        "--ar-data-path",
+        help="Directory path where Assist+Rebound data files where stored when running bootstrap_sorcha_data_files from the command line.",
+        type=str,
+        dest="ar_data_file_path",
+        required=False,
+    )
+    optional.add_argument(
+        "-c",
+        "--conf",
+        help="optional configuration file",
+        type=str,
+        dest="c",
+        required=False,
+    )
+    optional.add_argument(
+        "-ch",
+        "--chunksize",
+        help="number of orbits to be processed at once",
+        dest="chunk",
+        type=int,
+        default=10000,
+        required=False,
+    )
+
+    optional.add_argument(
+        "-d",
+        "--days",
+        help="number of days to predict on sky positions. Only used if the end date is not specified on the command line",
+        dest="days",
+        type=int,
+        default=14,
+        required=False,
+    )
+    optional.add_argument(
+        "-e",
+        "--end-date",
+        help="end date, mjd. Only specified if not specifying the number of days",
+        dest="e",
+        type=str,
+        default=None,
+        required=False,
+    )
+
+    optional.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite output file",
+    )
+
+    optional.add_argument(
+        "-i",
+        "--input-type",
+        help="input format type of file (csv or hdf5)",
+        dest="i",
+        type=str,
+        default="csv",
+        required=False,
+    )
+
+    optional.add_argument(
+        "-n",
+        "--num-workers",
+        help="Number of CPU workers to use for parallel processing each chunk. -1 uses all available CPUs.",
+        dest="n",
+        type=int,
+        default=-1,
+        required=False,
+    )
+
+    optional.add_argument(
+        "-o",
+        "--output",
+        help="output file stem. default path is current working directory",
+        dest="o",
+        type=str,
+        default="predicted_output",
+        required=False,
+    )
+
     optional.add_argument(
         "-s",
         "--start-date",
@@ -37,48 +121,17 @@ def main():
         ),  # gives current time in mjd_UTC
         required=False,
     )
-    optional.add_argument(
-        "-n",
-        "--num-nights",
-        help="number of nights to predict on sky positions",
-        dest="n",
-        type=int,
-        default=14,
-        required=False,
-    )
-    optional.add_argument(
-        "-e",
-        "--end-date",
-        help="end date, mjd",
-        dest="e",
-        type=str,
-        default=None,
-        required=False,
-    )
-    optional.add_argument(
-        "-o",
-        "--output",
-        help="output file stem. default path is current working directory",
-        dest="o",
-        type=str,
-        default="predicted_output",
-        required=False,
-    )
+
     optional.add_argument(
         "-t",
         "--timestep",
-        help="timestep for predict. must be string consisting of float and unit [min,day,sec,h] with no spaces",
+        help="timestep for predict. must be string consisting of float followed by the unit (d for day, h for hour, m for minutes, s for seconds) e.g. 1h or 30m",
         dest="t",
         type=str,
-        default="1min",  # we would want to parse the float and the unit, and convert into day unit
+        default="1h",  # we would want to parse the float and the unit, and convert into day unit
         required=False,
     )
-    optional.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="Overwrite output file",
-    )
+
     args = parser.parse_args()
 
     return execute(args)
@@ -99,6 +152,11 @@ def execute(args):
 
     # check for overwriting output file
     warn_or_remove_file(str(args.o), args.force, logger)
+
+    # check that days is greater than zero if being used
+
+    if (args.e == None) and args.days <= 0:
+        sys.exit(f"Number of days must be greater than 0. Value entered was : {args.days}")
 
     # converting timestep argument args.t into a float in day units.
     timestep_str = args.t

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -52,7 +52,7 @@ def main():
     optional = parser.add_argument_group("Optional arguments")
 
     optional.add_argument(
-        "--ar",
+        "-ar",
         "--ar-data-path",
         help="Directory path where Assist+Rebound data files were stored when running `layup bootstrap` from the command line.",
         type=str,

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -4,11 +4,30 @@
 import argparse
 from layup_cmdline.layupargumentparser import LayupArgumentParser
 from astropy.time import Time
+import astropy.units as u
 from datetime import datetime, timezone
 import logging
 
 
 logger = logging.getLogger(__name__)
+
+UNIT_DICT = {
+    "second": u.s,
+    "seconds": u.s,
+    "sec": u.s,
+    "s": u.s,
+    "minute": u.min,
+    "minutes": u.min,
+    "min": u.min,
+    "m": u.min,
+    "hour": u.h,
+    "hours": u.h,
+    "hr": u.h,
+    "h": u.h,
+    "day": u.day,
+    "days": u.day,
+    "d": u.day,
+}  # used to convert unit_str to an astropy.unit
 
 
 def main():
@@ -31,23 +50,25 @@ def main():
     optional.add_argument(
         "--ar",
         "--ar-data-path",
-        help="Directory path where Assist+Rebound data files where stored when running bootstrap_sorcha_data_files from the command line.",
+        help="Directory path where Assist+Rebound data files were stored when running `layup bootstrap` from the command line.",
         type=str,
         dest="ar_data_file_path",
         required=False,
     )
+
     optional.add_argument(
         "-c",
         "--conf",
-        help="optional configuration file",
+        help="Optional configuration file",
         type=str,
         dest="c",
         required=False,
     )
+
     optional.add_argument(
         "-ch",
         "--chunksize",
-        help="number of orbits to be processed at once",
+        help="Number of orbits to be processed at once",
         dest="chunk",
         type=int,
         default=10000,
@@ -57,16 +78,17 @@ def main():
     optional.add_argument(
         "-d",
         "--days",
-        help="number of days to predict on sky positions. Only used if the end date is not specified on the command line",
+        help="Number of days to predict on sky positions. Ignored if end-date is specified on the command line.",
         dest="days",
         type=int,
         default=14,
         required=False,
     )
+
     optional.add_argument(
         "-e",
         "--end-date",
-        help="end date, mjd. Only specified if not specifying the number of days",
+        help="End date as JD_TDB float or date string YYYY-mm-dd that will be converted to JD_TDB. Only required if not specifying the number of days",
         dest="e",
         type=str,
         default=None,
@@ -83,7 +105,7 @@ def main():
     optional.add_argument(
         "-i",
         "--input-type",
-        help="input format type of file (csv or hdf5)",
+        help="Input format type of file (csv or hdf5)",
         dest="i",
         type=str,
         default="csv",
@@ -103,7 +125,7 @@ def main():
     optional.add_argument(
         "-o",
         "--output",
-        help="output file stem. default path is current working directory",
+        help="Output file stem. Default path is the current working directory",
         dest="o",
         type=str,
         default="predicted_output",
@@ -113,19 +135,17 @@ def main():
     optional.add_argument(
         "-s",
         "--start-date",
-        help="start date as jd_TDB or date string YYYY-mm-dd that will be converted to jd_TDB. If not specified default wil be current date",
+        help="Start date as JD_TDB float or date string YYYY-mm-dd that will be converted to JD_TDB. Defaults to current UTC date",
         dest="s",
         type=str,
-        default=str(
-            Time(datetime.now(timezone.utc), format="datetime", scale="utc").tdb.jd
-        ),  # gives current time in jd_TDB
+        default=str(datetime.now(timezone.utc).date()),  # current UTC date as YYYY-mm-dd
         required=False,
     )
 
     optional.add_argument(
         "-t",
         "--timestep",
-        help="timestep for predict. must be string consisting of float followed by the unit (d for day, h for hour, m for minutes, s for seconds) e.g. 1h or 30m",
+        help="Timestep for predict. Must be string consisting of float followed by the unit (d=day, h=hour, m=minute, s=second) e.g. 1.3h or 30m",
         dest="t",
         type=str,
         default="1h",  # we would want to parse the float and the unit, and convert into day unit
@@ -137,9 +157,9 @@ def main():
     return execute(args)
 
 
-def convert_input_to_jd_TDB(input_str: str) -> float:
+def convert_input_to_JD_TDB(input_str: str) -> float:
     """
-    Convert a string to a jd_TDB date. The string can be in the format of a
+    Convert a string to a JD_TDB date. The string can be in the format of a
     Julian date TDB for or a date string in the format YYYY-mm-dd.
 
     Parameters
@@ -155,26 +175,25 @@ def convert_input_to_jd_TDB(input_str: str) -> float:
     Returns
     -------
     float
-        The converted jd_TDB date.
+        The converted JD_TDB date.
     """
-    import spiceypy as spice
-
     try:
-        # Assume that input is a jd_TDB float that was converted to string. Attempt
+        # Assume that input is a JD_TDB float that was converted to string. Attempt
         # to convert it back to a float.
-        start_time = float(input_str)
-        start_time = spice.j2000() + start_time / (24 * 60 * 60)
+        date_JD_TDB = float(input_str)
     except ValueError:
         # If conversion to float fails, assume that the input was a date string
         # with a format like YYYY-mm-dd. Convert that to a datetime and then to
-        # a float representation of a jd_TDB date.
+        # a float representation of a JD_TDB date.
         try:
-            start_time = Time(datetime.strptime(input_str, "%Y-%m-%d"), format="datetime", scale="utc").tdb.jd
+            date_JD_TDB = Time(
+                datetime.strptime(input_str, "%Y-%m-%d"), format="datetime", scale="tdb"
+            ).tdb.jd
         except ValueError:
             # If the date string is not in the expected format, raise an error.
             raise ValueError(f"Invalid date string format: {input_str}. Expected format is YYYY-mm-dd.")
 
-    return start_time
+    return date_JD_TDB
 
 
 def execute(args):
@@ -184,9 +203,9 @@ def execute(args):
     from layup.utilities.file_access_utils import find_file_or_exit, find_directory_or_exit
     import sys
 
-    start_time = convert_input_to_jd_TDB(args.s)
+    start_date = convert_input_to_JD_TDB(args.s)
 
-    end_time = convert_input_to_jd_TDB(args.e) if args.e else start_time + args.days
+    end_date = convert_input_to_JD_TDB(args.e) if args.e else start_date + args.days
 
     # check input exists
     find_file_or_exit(args.input, "input")
@@ -197,10 +216,24 @@ def execute(args):
     # check for overwriting output file
     warn_or_remove_file(str(args.o), args.force, logger)
 
-    # check that days is greater than zero if being used
+    # check ar directory exists if specified
+    if args.ar_data_file_path:
+        find_directory_or_exit(args.ar_data_file_path, "-ar, --ar_data_path")
 
-    if (args.e == None) and args.days <= 0:
-        sys.exit(f"Number of days must be greater than 0. Value entered was : {args.days}")
+    # check format of input file
+    if args.i.lower() == "csv":
+        output_file = args.o + ".csv"
+    elif args.i.lower() == "hdf5":
+        output_file = args.o + ".h5"
+    else:
+        sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
+
+    # check for overwriting output file
+    warn_or_remove_file(str(output_file), args.force, logger)
+
+    # check that start date is before end date
+    if end_date <= start_date:
+        sys.exit(f"Start date {start_date} is after than end date {end_date}")
 
     # converting timestep argument args.t into a float in day units.
     timestep_str = args.t
@@ -212,28 +245,10 @@ def execute(args):
     value = float(match.group("float"))
     unit_str = match.group("unit").lower()
 
-    unit_dict = {
-        "second": u.s,
-        "seconds": u.s,
-        "sec": u.s,
-        "s": u.s,
-        "minute": u.min,
-        "minutes": u.min,
-        "min": u.min,
-        "m": u.min,
-        "hour": u.h,
-        "hours": u.h,
-        "hr": u.h,
-        "h": u.h,
-        "day": u.day,
-        "days": u.day,
-        "d": u.day,
-    }  # used to convert unit_str to an astropy.unit
+    if unit_str not in UNIT_DICT:
+        sys.exit(f"Unsupported unit, {unit_str}, for timestep: {timestep_str}.")
 
-    if unit_str not in unit_dict:
-        sys.exit(f"Unsupported unit: {unit_str}")
-
-    timestep_day = (value * unit_dict[unit_str]).to(u.day).value  # converting value into day units
+    timestep_day = (value * UNIT_DICT[unit_str]).to(u.day).value  # converting value into day units
 
     print("Hello world this would start predict")
 

--- a/tests/layup/test_file_access_utils.py
+++ b/tests/layup/test_file_access_utils.py
@@ -27,9 +27,9 @@ def test_find_directory_or_exit():
     from layup.utilities.file_access_utils import find_directory_or_exit
 
     with pytest.raises(SystemExit) as e:
-        find_directory_or_exit("./fake_dir/", "test")
+        find_directory_or_exit("fake_dir/file.csv", "test")
 
     assert e.type == SystemExit
-    assert e.value.code == "ERROR: filepath ./fake_dir/ supplied for test argument does not exist."
+    assert e.value.code == "ERROR: filepath fake_dir/file.csv supplied for test argument does not exist."
 
     return

--- a/tests/layup/test_layup_copy_configs.py
+++ b/tests/layup/test_layup_copy_configs.py
@@ -14,7 +14,7 @@ def test_layupCopyConfigs(tmp_path):
     copy_demo_configs(tmp_path, "Default", True)
 
     # test the error message if user supplies non-existent directory
-    dummy_folder = os.path.join(tmp_path, "dummy_folder")
+    dummy_folder = os.path.join(tmp_path, "dummy_folder/file.csv")
     with pytest.raises(SystemExit) as e:
         copy_demo_configs(dummy_folder, "all", False)
 


### PR DESCRIPTION


Fixes #89  .

Added command-line arguments for the predict verb.
Fixed bug in find_directory_or_exit and its unit tests.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
