### PR TITLE
Issue/132

### DIFF
--- a/src/lib/gauss/gauss.cpp
+++ b/src/lib/gauss/gauss.cpp
@@ -69,9 +69,9 @@ namespace orbit_fit
 
         // this will need to be generalized better and not assume it's astrometry
         // could we make ObservationType a parent class?
-        Eigen::Vector3d rho1 = std::get<orbit_fit::AstrometryObservation>(triplet[0].observation_type).rho_hat;
-        Eigen::Vector3d rho2 = std::get<orbit_fit::AstrometryObservation>(triplet[1].observation_type).rho_hat;
-        Eigen::Vector3d rho3 = std::get<orbit_fit::AstrometryObservation>(triplet[2].observation_type).rho_hat;
+        Eigen::Vector3d rho1 = triplet[0].rho_hat;
+        Eigen::Vector3d rho2 = triplet[1].rho_hat;
+        Eigen::Vector3d rho3 = triplet[2].rho_hat;
 
         double t1 = triplet[0].epoch;
         double t2 = triplet[1].epoch;

--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -248,8 +248,8 @@ namespace orbit_fit
         double ye = this_det.observer_position[1];
         double ze = this_det.observer_position[2];
 
-        Eigen::Vector3d Av = std::get<AstrometryObservation>(this_det.observation_type).a_vec;
-        Eigen::Vector3d Dv = std::get<AstrometryObservation>(this_det.observation_type).d_vec;
+        Eigen::Vector3d Av = this_det.a_vec;
+        Eigen::Vector3d Dv = this_det.d_vec;
 
         double Ax = Av.x();
         double Ay = Av.y();
@@ -368,8 +368,8 @@ namespace orbit_fit
         double ye = this_det.observer_position[1];
         double ze = this_det.observer_position[2];
 
-        Eigen::Vector3d Av = std::get<AstrometryObservation>(this_det.observation_type).a_vec;
-        Eigen::Vector3d Dv = std::get<AstrometryObservation>(this_det.observation_type).d_vec;
+        Eigen::Vector3d Av = this_det.a_vec;
+        Eigen::Vector3d Dv = this_det.d_vec;
 
         double Ax = Av.x();
         double Ay = Av.y();

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -80,4 +80,4 @@ def test_orbit_fit_mixed_inputs():
 
     result = run_from_vector(get_ephem(str(pooch.os_cache("layup"))), observations)
 
-    assert result.niter > 0
+    assert result is not None


### PR DESCRIPTION
Resolves #132 , resolves #139 

Moved `rho_hat`, `a_vec`, and `d_vec` out of `AstrometryObservation` and `StreakObvservation` and into their own methods that are now called from `Observation`.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
