### PR TITLE
Implement orbit fit commandline overwrite

### DIFF
--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -3,9 +3,9 @@
 #
 import argparse
 import sys
+
+from layup.utilities.file_access_utils import find_directory_or_exit, find_file_or_exit
 from layup_cmdline.layupargumentparser import LayupArgumentParser
-from layup.utilities.file_access_utils import find_file_or_exit
-from layup.utilities.file_access_utils import find_directory_or_exit
 
 
 def main():
@@ -115,7 +115,7 @@ def execute(args):
     find_file_or_exit(arg_fn=args.input, argname="positional input")
     if args.ar_data_file_path:
         find_directory_or_exit(args.ar_data_file_path, argname="--a --ar-data-path")
-    if not ((args.type.lower()) in ["mpc80col", "ades_csv", "ades_psv", "ades_xml", "ades_hdf5"]):
+    if (args.type.lower()) not in ["mpc80col", "ades_csv", "ades_psv", "ades_xml", "ades_hdf5"]:
         sys.exit("Not a supported file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]")
 
     from layup.utilities.layup_configs import LayupConfigs

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -25,6 +25,26 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
     output_file_stem = "test_output"
     temp_out_file = os.path.join(tmpdir, f"{output_file_stem}.csv")
 
+    # Write an empty file to temp_out_file path to test the overwrite functionality
+    with open(temp_out_file, "w") as f:
+        f.write("")
+
+    class FakeCliArgs:
+        def __init__(self, overwrite):
+            self.ar_data_file_path = None
+            self.overwrite = overwrite
+
+    with pytest.raises(FileExistsError):
+        orbitfit_cli(
+            input=get_test_filepath("100_random_mpc_ADES_provIDs_no_sats.csv"),
+            input_file_format="ADES_csv",
+            output_file_stem=output_file_stem,
+            output_file_format="csv",
+            chunk_size=chunk_size,
+            num_workers=num_workers,
+            cli_args=FakeCliArgs(overwrite=False),
+        )
+    # Now run the orbit_fit cli with overwrite set to True
     orbitfit_cli(
         input=get_test_filepath("100_random_mpc_ADES_provIDs_no_sats.csv"),
         input_file_format="ADES_csv",
@@ -32,6 +52,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
         output_file_format="csv",
         chunk_size=chunk_size,
         num_workers=num_workers,
+        cli_args=FakeCliArgs(overwrite=True),
     )
 
     # Verify the orbit fit produced an output file


### PR DESCRIPTION
This wires in the --force argument from the orbit fit commandline. 

If force is not true, if the output file from orbit fit already exists, we raise an error. Otherwise, we delete and overwrite the existing file.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
