### PR TITLE
WIP - Creating `predict` verb scaffolding.

### DIFF
--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -1,0 +1,44 @@
+import os
+from argparse import Namespace
+from pathlib import Path
+from layup.utilities.data_processing_utilities import process_data
+
+
+def _predict(data, other_arg_1=None):
+    """This function is called by the parallelization function to call the C++ code."""
+    for row in data:
+        # Here you would call the C++ prediction code with the row data.
+        # cpp_predict_function(row, other_arg_1)
+        pass
+    pass
+
+
+def predict(data, num_workers=-1):
+    """This is the stub that will be used when calling predict from a notebook"""
+    if num_workers < 0:
+        num_workers = os.cpu_count()
+
+    return process_data(data, n_workers=num_workers, func=_predict, other_arg_1=None)
+
+
+def predict_cli(
+    cli_args: Namespace,
+    start_date: float,
+    end_date: float,
+    timestep_day: float,
+    output_file: str,
+    cache_dir: Path,
+):
+    """This is the stub that will used when calling predict from the command line"""
+
+    num_workers = cli_args.n
+
+    if num_workers < 0:
+        num_workers = os.cpu_count()
+
+    data = None
+
+    results = predict(data, num_workers=num_workers)
+
+    # Write the results to the output file
+    pass

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -227,6 +227,7 @@ def convert_input_to_JD_TDB(input_str: str, cache_path: Path) -> float:
 def execute(args):
     import astropy.units as u
     import re
+    from layup.predict import predict_cli
     from layup.utilities.cli_utilities import warn_or_remove_file
     from layup.utilities.file_access_utils import find_file_or_exit, find_directory_or_exit
     import sys
@@ -282,7 +283,14 @@ def execute(args):
 
     timestep_day = (value * UNIT_DICT[unit_str]).to(u.day).value  # converting value into day units
 
-    print("Hello world this would start predict")
+    predict_cli(
+        cli_args=args,
+        start_date=start_date,
+        end_date=end_date,
+        timestep_day=timestep_day,
+        output_file=output_file,
+        cache_dir=cache_dir,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #88  .

Describe your changes.
Building out the scaffolding for the `predict` verb that will call the C++ code. Works similarly to convert and orbitfit, in that it can be called both from command line and notebook. 

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
