### PR TITLE
Have orbitfit use --force cli arg rather than check for --overwrite

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -213,7 +213,7 @@ def orbitfit_cli(
 
     if cli_args is not None:
         cache_dir = cli_args.ar_data_file_path
-        overwrite = cli_args.overwrite
+        overwrite = cli_args.force
     else:
         cache_dir = None
         overwrite = False

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -30,9 +30,9 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
         f.write("")
 
     class FakeCliArgs:
-        def __init__(self, overwrite):
+        def __init__(self, force):
             self.ar_data_file_path = None
-            self.overwrite = overwrite
+            self.force = force
 
     with pytest.raises(FileExistsError):
         orbitfit_cli(
@@ -42,7 +42,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
             output_file_format="csv",
             chunk_size=chunk_size,
             num_workers=num_workers,
-            cli_args=FakeCliArgs(overwrite=False),
+            cli_args=FakeCliArgs(force=False),
         )
     # Now run the orbit_fit cli with overwrite set to True
     orbitfit_cli(
@@ -52,7 +52,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
         output_file_format="csv",
         chunk_size=chunk_size,
         num_workers=num_workers,
-        cli_args=FakeCliArgs(overwrite=True),
+        cli_args=FakeCliArgs(force=True),
     )
 
     # Verify the orbit fit produced an output file


### PR DESCRIPTION
The layup orbitfit commandline allows for --force command but instead we were checking for an --overwrite CLI argument. Here we correctly check for --force 

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
