### PR TITLE
Changed output columns for orbitfit to match convert output columns

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -213,7 +213,7 @@ def orbitfit_cli(
 
     if cli_args is not None:
         cache_dir = cli_args.ar_data_file_path
-        overwrite = cli_args.force
+        overwrite = cli_args.overwrite
     else:
         cache_dir = None
         overwrite = False

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -7,7 +7,6 @@ import numpy as np
 import pooch
 import spiceypy as spice
 from numpy.lib import recfunctions as rfn
-from astropy.time import Time
 
 from layup.routines import Observation, get_ephem, run_from_vector
 from layup.utilities.data_processing_utilities import LayupObservatory, process_data_by_id
@@ -91,7 +90,6 @@ def _orbitfit(data, cache_dir: str):
     # Populate our output structured array with the orbit fit results
     success = res.flag == 0
     cov_matrix = tuple(res.cov[i] for i in range(36)) if success else (np.nan,) * 36
-    res.epoch = float(Time(res.epoch, format='jd', scale='tdb').mjd) # converting from jd to mjd
     output = np.array(
         [
             (
@@ -101,7 +99,7 @@ def _orbitfit(data, cache_dir: str):
             )
             + tuple(res.state[i] for i in range(6))  # Flat state vector
             + (
-                res.epoch,
+                res.epoch - 2400000.5,
                 res.niter,
                 res.method,
                 res.flag,
@@ -215,7 +213,7 @@ def orbitfit_cli(
 
     if cli_args is not None:
         cache_dir = cli_args.ar_data_file_path
-        overwrite = cli_args.overwrite
+        overwrite = cli_args.force
     else:
         cache_dir = None
         overwrite = False

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -7,6 +7,7 @@ import numpy as np
 import pooch
 import spiceypy as spice
 from numpy.lib import recfunctions as rfn
+from astropy.time import Time
 
 from layup.routines import Observation, get_ephem, run_from_vector
 from layup.utilities.data_processing_utilities import LayupObservatory, process_data_by_id
@@ -32,10 +33,10 @@ _RESULT_DTYPES = np.dtype(
         ("x", "f8"),  # The first of 6 state vector elements
         ("y", "f8"),
         ("z", "f8"),
-        ("vx", "f8"),
-        ("vy", "f8"),
-        ("vz", "f8"),  # The last of 6 state vector elements
-        ("epoch", "f8"),  # Epoch
+        ("xdot", "f8"),
+        ("ydot", "f8"),
+        ("zdot", "f8"),  # The last of 6 state vector elements
+        ("epochMJD_TDB", "f8"),  # Epoch
         ("niter", "i4"),  # Number of iterations
         ("method", "O"),  # Method used for orbit fitting
         ("flag", "i4"),  # Single-character flag indicating success of the fit
@@ -90,6 +91,7 @@ def _orbitfit(data, cache_dir: str):
     # Populate our output structured array with the orbit fit results
     success = res.flag == 0
     cov_matrix = tuple(res.cov[i] for i in range(36)) if success else (np.nan,) * 36
+    res.epoch = float(Time(res.epoch, format='jd', scale='tdb').mjd) # converting from jd to mjd
     output = np.array(
         [
             (


### PR DESCRIPTION

Fixes #185, #179, #168.


Changed output columns for orbitfit to match convert output columns. vx,vy,vz ----> xdot,ydot,zdot

converts epoch from JD to MJD.
epoch ----> epochMJD_TDB


## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
