### PR TITLE
when orbitfit fails the orbit output parameters will be populated with nans

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -95,22 +95,21 @@ def _orbitfit(data, cache_dir: str):
         [
             (
                 data["provID"][0],
-                res.csq,
+                (res.csq if success else np.nan),
                 res.ndof,
             )
-            + tuple(res.state[i] for i in range(6))  # Flat state vector
+            + (tuple(res.state[i] for i in range(6)) if success else (np.nan,) * 6)  # Flat state vector
             + (
-                res.epoch - 2400000.5,
+                ((res.epoch - 2400000.5) if success else np.nan),
                 res.niter,
                 res.method,
                 res.flag,
-                "BCART",  # The base format returned by the C++ code
+                ("BCART" if success else np.nan),  # The base format returned by the C++ code
             )
             + cov_matrix  # Flat covariance matrix
         ],
         dtype=_RESULT_DTYPES,
     )
-
     return output
 
 

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -129,8 +129,8 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
     assert set(output_data.dtype.names) == set(expected_cols)
 
     # Verify that all of the output data is in the default BCART format for flag == 0 and is nan for flag !=0
-    assert np.all(output_data["FORMAT"][output_data["flag"]== 0] == "BCART")
-    assert (math.isnan(output_data["FORMAT"][output_data["flag"]!= 0] ))
+    assert np.all(output_data["FORMAT"][output_data["flag"] == 0] == "BCART")
+    assert math.isnan(output_data["FORMAT"][output_data["flag"] != 0])
     # For each row in the output data, check that there is a non-zero covariance matrix
     # if there was a successful fit
     for row in output_data:

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -130,7 +130,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
 
     # Verify that all of the output data is in the default BCART format for flag == 0 and is nan for flag !=0
     assert np.all(output_data["FORMAT"][output_data["flag"] == 0] == "BCART")
-    assert math.isnan(output_data["FORMAT"][output_data["flag"] != 0])
+    assert np.all(np.isnan(output_data["FORMAT"][output_data["flag"] != 0]))
     # For each row in the output data, check that there is a non-zero covariance matrix
     # if there was a successful fit
     for row in output_data:

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import math
 import pooch
 import pytest
 from numpy.testing import assert_equal
@@ -127,9 +128,9 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
     ]
     assert set(output_data.dtype.names) == set(expected_cols)
 
-    # Verify that all of the output data is in the default BCART format
-    assert np.all(output_data["FORMAT"] == "BCART")
-
+    # Verify that all of the output data is in the default BCART format for flag == 0 and is nan for flag !=0
+    assert np.all(output_data["FORMAT"][output_data["flag"]== 0] == "BCART")
+    assert (math.isnan(output_data["FORMAT"][output_data["flag"]!= 0] ))
     # For each row in the output data, check that there is a non-zero covariance matrix
     # if there was a successful fit
     for row in output_data:

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -130,7 +130,9 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
 
     # Verify that all of the output data is in the default BCART format for flag == 0 and is nan for flag !=0
     assert np.all(output_data["FORMAT"][output_data["flag"] == 0] == "BCART")
-    assert np.all(np.isnan(output_data["FORMAT"][output_data["flag"] != 0]))
+    for i in np.arange(len(output_data["FORMAT"][output_data["flag"] != 0])):
+        assert math.isnan(output_data["FORMAT"][output_data["flag"] != 0][i])
+
     # For each row in the output data, check that there is a non-zero covariance matrix
     # if there was a successful fit
     for row in output_data:


### PR DESCRIPTION


Fixes #180  .

changed so that when orbitfit fails the orbit output parameters will be populated with nans

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
