### PR TITLE
Moved check for output already existing to layup_cmd_line checks

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -254,7 +254,6 @@ def orbitfit_cli(
 
     chunks = _create_chunks(reader, chunk_size)
 
-    first_write = True  # Flag to check if this is the first write to the output file
     for chunk in chunks:
         data = reader.read_objects(chunk)
 

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -267,7 +267,6 @@ def orbitfit_cli(
             primary_id_column_name=_primary_id_column_name,
         )
 
-        
         if cli_args.separate_flagged:
             # Split the results into two files: one for successful fits and one for failed fits
             success_mask = fit_orbits["flag"] == 0

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -267,19 +267,7 @@ def orbitfit_cli(
             primary_id_column_name=_primary_id_column_name,
         )
 
-        # Before writing our first chunk, check if the output file already exists.
-        if first_write and os.path.exists(output_file):
-            if overwrite:
-                logger.warning(f"Output file {output_file} already exists. Overwriting.")
-                os.remove(output_file)
-                if cli_args.separate_flagged and os.path.exists(output_file_flagged):
-                    logger.warning(f"Output file {output_file_flagged} already exists. Overwriting.")
-                    os.remove(output_file_flagged)
-            else:
-                logger.error(f"Output file {output_file} already exists")
-                raise FileExistsError(f"Output file {output_file} already exists")
-            first_write = False
-
+        
         if cli_args.separate_flagged:
             # Split the results into two files: one for successful fits and one for failed fits
             success_mask = fit_orbits["flag"] == 0

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -12,6 +12,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 def main():
     parser = LayupArgumentParser(
         prog="layup orbitfit",
@@ -130,8 +131,6 @@ def execute(args):
         find_directory_or_exit(args.ar_data_file_path, argname="--a --ar-data-path")
     if (args.type.lower()) not in ["mpc80col", "ades_csv", "ades_psv", "ades_xml", "ades_hdf5"]:
         sys.exit("Not a supported file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]")
-
-
 
     # check format of input file
     if args.output_format.lower() == "csv":

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -5,8 +5,12 @@ import argparse
 import sys
 
 from layup.utilities.file_access_utils import find_directory_or_exit, find_file_or_exit
+from layup.utilities.cli_utilities import warn_or_remove_file
 from layup_cmdline.layupargumentparser import LayupArgumentParser
+import logging
 
+
+logger = logging.getLogger(__name__)
 
 def main():
     parser = LayupArgumentParser(
@@ -127,6 +131,18 @@ def execute(args):
     if (args.type.lower()) not in ["mpc80col", "ades_csv", "ades_psv", "ades_xml", "ades_hdf5"]:
         sys.exit("Not a supported file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]")
 
+
+
+    # check format of input file
+    if args.output_format.lower() == "csv":
+        output_file = args.o + ".csv"
+    elif args.output_format.lower() == "hdf5":
+        output_file = args.o + ".h5"
+    else:
+        sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
+
+    # check for overwriting output file
+    warn_or_remove_file(str(output_file), args.force, logger)
     from layup.utilities.layup_configs import LayupConfigs
 
     if args.g is not None:

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -23,8 +23,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
     """Test that the orbit_fit cli works for a small CSV file."""
     # Since the orbit_fit CLI outputs to the current working directory, we need to change to our temp directory
     os.chdir(tmpdir)
-    output_file_stem = "test_output"
-    temp_out_file = os.path.join(tmpdir, f"{output_file_stem}.csv")
+    temp_out_file = "test_output"
 
     # Write an empty file to temp_out_file path to test the overwrite functionality
     with open(temp_out_file, "w") as f:
@@ -36,21 +35,11 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
             self.separate_flagged = False
             self.force = force
 
-    with pytest.raises(FileExistsError):
-        orbitfit_cli(
-            input=get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv"),
-            input_file_format="ADES_csv",
-            output_file_stem=output_file_stem,
-            output_file_format="csv",
-            chunk_size=chunk_size,
-            num_workers=num_workers,
-            cli_args=FakeCliArgs(force=False),
-        )
     # Now run the orbit_fit cli with overwrite set to True
     orbitfit_cli(
         input=get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv"),
         input_file_format="ADES_csv",
-        output_file_stem=output_file_stem,
+        output_file_stem=temp_out_file,
         output_file_format="csv",
         chunk_size=chunk_size,
         num_workers=num_workers,
@@ -60,7 +49,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
     # Verify the orbit fit produced an output file
     assert os.path.exists(temp_out_file)
     # Create a new CSV reader to read in our output file
-    output_csv_reader = CSVDataReader(temp_out_file, "csv", primary_id_column_name="provID")
+    output_csv_reader = CSVDataReader(temp_out_file + ".csv", "csv", primary_id_column_name="provID")
     output_data = output_csv_reader.read_rows()
 
     # Read the input data and get the provID column


### PR DESCRIPTION

Fixes #199  .

Moved check for output already existing to cmd line checks and used function warn_or_remove_file()

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
