### PR TITLE
Prechecks before orbitfit

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -65,7 +65,6 @@ def _orbitfit(data, cache_dir: str, sort_array=True):
 
     if _is_valid_data(data):  # checks data being supplied to c ++ code is valid
 
-
         # sort the observations by the obstime if specified by the user
         if sort_array:
             data = np.sort(data, order="obstime", kind="mergesort")

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -62,55 +62,75 @@ def _orbitfit(data, cache_dir: str):
     cache_dir : str
         The directory where the required orbital files are stored
     """
-    if len(data) == 0:
-        return np.array([], dtype=_RESULT_DTYPES)
 
-    # Convert the astrometry data to a list of Observations
-    # Reminder to label the units.  Within an Observation struct,
-    # and internal to the C++ code in general, we are using
-    # radians.
-    observations = [
-        Observation.from_astrometry(
-            d["ra"] * np.pi / 180.0,
-            d["dec"] * np.pi / 180.0,
-            convert_tdb_date_to_julian_date(d["obstime"], cache_dir),  # Convert obstime to JD TDB
-            [d["x"], d["y"], d["z"]],  # Barycentric position
-            [d["vx"], d["vy"], d["vz"]],  # Barycentric velocity
+    if _is_valid_data(data):  # checks data being supplied to c ++ code is valid
+
+        # Convert the astrometry data to a list of Observations
+        # Reminder to label the units.  Within an Observation struct,
+        # and internal to the C++ code in general, we are using
+        # radians.
+        observations = [
+            Observation.from_astrometry(
+                d["ra"] * np.pi / 180.0,
+                d["dec"] * np.pi / 180.0,
+                convert_tdb_date_to_julian_date(d["obstime"], cache_dir),  # Convert obstime to JD TDB
+                [d["x"], d["y"], d["z"]],  # Barycentric position
+                [d["vx"], d["vy"], d["vz"]],  # Barycentric velocity
+            )
+            for d in data
+        ]
+
+        # if cache_dir is not provided, use the default os_cache
+        if cache_dir is None:
+            kernels_loc = str(pooch.os_cache("layup"))
+        else:
+            kernels_loc = str(cache_dir)
+
+        # Perform the orbit fitting
+        res = run_from_vector(get_ephem(kernels_loc), observations)
+        # Populate our output structured array with the orbit fit results
+        success = res.flag == 0
+        cov_matrix = tuple(res.cov[i] for i in range(36)) if success else (np.nan,) * 36
+        output = np.array(
+            [
+                (
+                    data["provID"][0],
+                    (res.csq if success else np.nan),
+                    res.ndof,
+                )
+                + (tuple(res.state[i] for i in range(6)) if success else (np.nan,) * 6)  # Flat state vector
+                + (
+                    ((res.epoch - 2400000.5) if success else np.nan),
+                    res.niter,
+                    res.method,
+                    res.flag,
+                    ("BCART" if success else np.nan),  # The base format returned by the C++ code
+                )
+                + cov_matrix  # Flat covariance matrix
+            ],
+            dtype=_RESULT_DTYPES,
         )
-        for d in data
-    ]
-
-    # if cache_dir is not provided, use the default os_cache
-    if cache_dir is None:
-        kernels_loc = str(pooch.os_cache("layup"))
     else:
-        kernels_loc = str(cache_dir)
+        output = np.array(
+            [
+                (
+                    data["provID"][0],
+                    np.nan,  # csq
+                    0,  # ndof
+                )
+                + (np.nan,) * 6  # Flat state vector
+                + (
+                    np.nan,  # epoch
+                    0,  # niter
+                    np.nan,  # method
+                    -1,  # flag
+                    np.nan,  # format
+                )
+                + (np.nan,) * 36  # Flat covariance matrix
+            ],
+            dtype=_RESULT_DTYPES,
+        )
 
-    # Perform the orbit fitting
-    res = run_from_vector(get_ephem(kernels_loc), observations)
-
-    # Populate our output structured array with the orbit fit results
-    success = res.flag == 0
-    cov_matrix = tuple(res.cov[i] for i in range(36)) if success else (np.nan,) * 36
-    output = np.array(
-        [
-            (
-                data["provID"][0],
-                (res.csq if success else np.nan),
-                res.ndof,
-            )
-            + (tuple(res.state[i] for i in range(6)) if success else (np.nan,) * 6)  # Flat state vector
-            + (
-                ((res.epoch - 2400000.5) if success else np.nan),
-                res.niter,
-                res.method,
-                res.flag,
-                ("BCART" if success else np.nan),  # The base format returned by the C++ code
-            )
-            + cov_matrix  # Flat covariance matrix
-        ],
-        dtype=_RESULT_DTYPES,
-    )
     return output
 
 
@@ -355,3 +375,37 @@ def _create_chunks(reader, chunk_size):
         chunks.append(obj_ids_in_chunk)
 
     return chunks
+
+
+def _is_valid_data(data):
+    """
+    Check if the input data contains all valid values.
+
+    Parameters
+    ----------
+    data : numpy structured array
+        The object data to validate.
+
+    Returns
+    -------
+    bool
+        True if the data is valid, False otherwise.
+    """
+    valid_conditions = [
+        len(data) >= 3,
+        np.all(data["et"] >= 0),
+        np.all(is_numeric(data["ra"])),
+        np.all(is_numeric(data["dec"])),
+        np.all(is_numeric(data["x"])),
+        np.all(is_numeric(data["y"])),
+        np.all(is_numeric(data["z"])),
+        np.all(is_numeric(data["vx"])),
+        np.all(is_numeric(data["vy"])),
+        np.all(is_numeric(data["vz"])),
+    ]
+    return all(valid_conditions)
+
+
+def is_numeric(obj):  # checks object is numeric by checking object has all required attributes
+    attrs = ["__add__", "__sub__", "__mul__", "__truediv__", "__pow__"]
+    return all(hasattr(obj, attr) for attr in attrs)

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -71,7 +71,6 @@ def _orbitfit(data, cache_dir: str, primary_id_column_name: str, sort_array: boo
     """
     _RESULT_DTYPES = _get_result_dtypes(primary_id_column_name)
 
-
     if _is_valid_data(data):  # checks data being supplied to c ++ code is valid
 
         # sort the observations by the obstime if specified by the user
@@ -91,7 +90,6 @@ def _orbitfit(data, cache_dir: str, primary_id_column_name: str, sort_array: boo
             )
             for d in data
         ]
-
 
         # if cache_dir is not provided, use the default os_cache
         if cache_dir is None:
@@ -144,7 +142,6 @@ def _orbitfit(data, cache_dir: str, primary_id_column_name: str, sort_array: boo
             ],
             dtype=_RESULT_DTYPES,
         )
-
 
     return output
 

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -146,8 +146,8 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
         if nan_mask.any():
             # If any values are NaN, all should be NaN
             assert np.all(nan_mask)
-            # Since the fit failed, check that the flag is set to 1
-            assert row["flag"] == 1
+            # Since the fit failed, check that the flag is set to 1 or -1
+            assert row["flag"] == 1 or row["flag"] == -1
         else:
             # Since no values are NaN, check that the flag is set to 0
             assert row["flag"] == 0


### PR DESCRIPTION
Fixes #181 .

Added prechecks to data in python before sentind data to c++. 

if prechecks failed the output for the object is filled with nans and flag = -1

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
