### PR TITLE
Added optional cmd line arg for orbitfit. orbit format

### DIFF
--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -121,6 +121,15 @@ def main():
         required=False,
     )
 
+    optional.add_argument(
+        "-of",
+        "--orbit-format",
+        help="Orbit format for output file. [KEP, CART, COM, BKEP, BCART, BCOM]",
+        default="BCART",
+        dest="of",
+        required=False,
+    )
+
     args = parser.parse_args()
 
     return execute(args)
@@ -142,6 +151,9 @@ def execute(args):
     if (args.type.lower()) not in ["mpc80col", "ades_csv", "ades_psv", "ades_xml", "ades_hdf5"]:
         sys.exit("Not a supported file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]")
 
+    # check orbit format
+    if args.of not in ["BCART", "BCOM", "BKEP", "CART", "COM", "KEP"]:
+        logger.error("ERROR: output orbit format must be 'BCART', 'BCOM', 'BKEP', 'CART', 'COM', or 'KEP'")
     # check format of input file
     if args.output_format.lower() == "csv":
         output_file = args.o + ".csv"

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -123,10 +123,10 @@ def main():
 
     optional.add_argument(
         "-of",
-        "--orbit-format",
+        "--output-orbit-format",
         help="Orbit format for output file. [KEP, CART, COM, BKEP, BCART, BCOM]",
         default="BCART",
-        dest="of",
+        dest="output_orbit_format",
         required=False,
     )
 
@@ -152,7 +152,7 @@ def execute(args):
         sys.exit("Not a supported file type [MPC80col, ADES_csv, ADES_psv, ADES_xml, ADES_hdf5]")
 
     # check orbit format
-    if args.of not in ["BCART", "BCOM", "BKEP", "CART", "COM", "KEP"]:
+    if args.output_orbit_format not in ["BCART", "BCOM", "BKEP", "CART", "COM", "KEP"]:
         logger.error("ERROR: output orbit format must be 'BCART', 'BCOM', 'BKEP', 'CART', 'COM', or 'KEP'")
     # check format of input file
     if args.output_format.lower() == "csv":


### PR DESCRIPTION
Fixes #182 .

Added optional cmd line arg for orbitfit. orbit format and added cmd_line check

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
