### PR TITLE
fixed cov output columns in orbitfit

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -46,8 +46,12 @@ def _get_result_dtypes(primary_id_column_name: str):
             ("flag", "i4"),  # Single-character flag indicating success of the fit
             ("FORMAT", "O"),  # Orbit format
         ]
-        + [(f"cov_0{i}", "f8") for i in range(10)]  # Flat covariance matrix (first 10 elements)
-        + [(f"cov_{i}", "f8") for i in range(10, 36)]  # Flat covariance matrix (remaining 26 elements)
+        + [(f"cov_0{i}", "f8") for i in range(6)]  # Flat covariance matrix (6x6)
+        + [(f"cov_1{i}", "f8") for i in range(6)]
+        + [(f"cov_2{i}", "f8") for i in range(6)]
+        + [(f"cov_3{i}", "f8") for i in range(6)]
+        + [(f"cov_4{i}", "f8") for i in range(6)]
+        + [(f"cov_5{i}", "f8") for i in range(6)]
     )
 
 

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -46,12 +46,7 @@ def _get_result_dtypes(primary_id_column_name: str):
             ("flag", "i4"),  # Single-character flag indicating success of the fit
             ("FORMAT", "O"),  # Orbit format
         ]
-        + [(f"cov_0{i}", "f8") for i in range(6)]  # Flat covariance matrix (6x6)
-        + [(f"cov_1{i}", "f8") for i in range(6)]
-        + [(f"cov_2{i}", "f8") for i in range(6)]
-        + [(f"cov_3{i}", "f8") for i in range(6)]
-        + [(f"cov_4{i}", "f8") for i in range(6)]
-        + [(f"cov_5{i}", "f8") for i in range(6)]
+        + [(f"cov_{i}{j}", "f8") for i in range(6) for j in range(6)]  # Flat covariance matrix (6x6)
     )
 
 

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -127,14 +127,7 @@ def parse_fit_result(fit_result_row):
     res.epoch = fit_result_row["epochMJD_TDB"] + 2400000.5
 
     # Construct the flattened covariance matrix from the columns of the fit result
-    res.cov = np.array(
-        [fit_result_row[f"cov_0{i}"] for i in range(6)]
-        + [fit_result_row[f"cov_1{i}"] for i in range(6)]
-        + [fit_result_row[f"cov_2{i}"] for i in range(6)]
-        + [fit_result_row[f"cov_3{i}"] for i in range(6)]
-        + [fit_result_row[f"cov_4{i}"] for i in range(6)]
-        + [fit_result_row[f"cov_5{i}"] for i in range(6)]
-    )
+    res.cov = np.array([fit_result_row[f"cov_{j}{i}"] for j in range(6) for i in range(6)])
     # The number of iterations used during the fitting process.
     res.niter = fit_result_row["niter"]
     return res

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -128,7 +128,12 @@ def parse_fit_result(fit_result_row):
 
     # Construct the flattened covariance matrix from the columns of the fit result
     res.cov = np.array(
-        [fit_result_row[f"cov_0{i}"] for i in range(10)] + [fit_result_row[f"cov_{i}"] for i in range(10, 36)]
+        [fit_result_row[f"cov_0{i}"] for i in range(6)]
+        + [fit_result_row[f"cov_1{i}"] for i in range(6)]
+        + [fit_result_row[f"cov_2{i}"] for i in range(6)]
+        + [fit_result_row[f"cov_3{i}"] for i in range(6)]
+        + [fit_result_row[f"cov_4{i}"] for i in range(6)]
+        + [fit_result_row[f"cov_5{i}"] for i in range(6)]
     )
     # The number of iterations used during the fitting process.
     res.niter = fit_result_row["niter"]

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -102,36 +102,36 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
         "cov_03",
         "cov_04",
         "cov_05",
-        "cov_06",
-        "cov_07",
-        "cov_08",
-        "cov_09",
         "cov_10",
         "cov_11",
         "cov_12",
         "cov_13",
         "cov_14",
         "cov_15",
-        "cov_16",
-        "cov_17",
-        "cov_18",
-        "cov_19",
         "cov_20",
         "cov_21",
         "cov_22",
         "cov_23",
         "cov_24",
         "cov_25",
-        "cov_26",
-        "cov_27",
-        "cov_28",
-        "cov_29",
         "cov_30",
         "cov_31",
         "cov_32",
         "cov_33",
         "cov_34",
         "cov_35",
+        "cov_40",
+        "cov_41",
+        "cov_42",
+        "cov_43",
+        "cov_44",
+        "cov_45",
+        "cov_50",
+        "cov_51",
+        "cov_52",
+        "cov_53",
+        "cov_54",
+        "cov_55",
     ]
     assert set(output_data.dtype.names) == set(expected_cols)
 
@@ -145,7 +145,12 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
     for row in output_data:
         # Check that the covariance matrix is non-zero
         cov_matrix = np.array(
-            [row[f"cov_0{i}"] for i in range(10)] + [row[f"cov_{i}"] for i in range(10, 36)]
+            [row[f"cov_1{i}"] for i in range(6)]
+            + [row[f"cov_1{i}"] for i in range(6)]
+            + [row[f"cov_2{i}"] for i in range(6)]
+            + [row[f"cov_3{i}"] for i in range(6)]
+            + [row[f"cov_4{i}"] for i in range(6)]
+            + [row[f"cov_5{i}"] for i in range(6)]
         )
         # Check if the cov_matrix has any NaN values indicating a failed fit
         nan_mask = np.isnan(cov_matrix)
@@ -222,6 +227,15 @@ def test_orbitfit_result_parsing():
             assert fit_res.niter == row["niter"]
 
             # Check our flattened covariance matrix against each covariance matrix column in the results.
+
+            cov_matrix = np.array(
+                [(f"cov_0{i}") for i in range(6)]  # Flat covariance matrix (6x6)
+                + [(f"cov_1{i}") for i in range(6)]
+                + [(f"cov_2{i}") for i in range(6)]
+                + [(f"cov_3{i}") for i in range(6)]
+                + [(f"cov_4{i}") for i in range(6)]
+                + [(f"cov_5{i}") for i in range(6)]
+            )
             for i in range(36):
-                cov_col_name = f"cov_0{i}" if i < 10 else f"cov_{i}"
+                cov_col_name = cov_matrix[i]
                 assert fit_res.cov[i] == row[cov_col_name]


### PR DESCRIPTION
fixed cov output columns in orbitfit and unit tests.

Now instead of being cov{i} for range(36) it follows the matrix format ii

Fixes #208  .

Fixed cov output columns in orbitfit and unit tests.

Now, instead of being cov{i} for range(36), it follows the matrix format cov_ii

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
