### PR TITLE
Add logic for occultation observations and debiasing.

### DIFF
--- a/src/layup/utilities/bootstrap_utilties/download_utilities.py
+++ b/src/layup/utilities/bootstrap_utilties/download_utilities.py
@@ -88,6 +88,11 @@ def _decompress(fname: str, action: str, pup: pooch.Pooch) -> None:  # pragma: n
     if os.path.splitext(fname)[-1] in known_extentions:
         pooch.Decompress(method="auto", name=os.path.splitext(fname)[0]).__call__(fname, action, pup)
 
+    tar_extentions = [".tar.gz", ".tgz"]
+    if os.path.splitext(fname)[-1] in tar_extentions:
+        print(f"Trying to decompress tar file: {fname}")
+        pooch.Untar(extract_dir=".").__call__(fname, action, pup)
+
 
 def _remove_files(aux_config: AuxiliaryConfigs, retriever: pooch.Pooch) -> None:
     """Utility to remove all the files tracked by the pooch retriever. This includes

--- a/src/layup/utilities/debiasing.py
+++ b/src/layup/utilities/debiasing.py
@@ -1,0 +1,146 @@
+from itertools import product
+from pathlib import Path
+
+import numpy as np
+import healpy as hp
+import pandas as pd
+import spiceypy as spice
+
+# From Siegfried Eggl's code
+mpc_catalogs = {
+    "a": "USNOA1",
+    "b": "USNOSA1",
+    "c": "USNOA2",
+    "d": "USNOSA2",
+    "e": "UCAC1",
+    "g": "Tyc2",
+    "i": "GSC1.1",
+    "j": "GSC1.2",
+    "l": "ACT",
+    "m": "GSCACT",
+    "n": "SDSS8",
+    "o": "USNOB1",
+    "p": "PPM",
+    "q": "UCAC4",
+    "r": "UCAC2",
+    "t": "PPMXL",
+    "u": "UCAC3",
+    "v": "NOMAD",
+    "w": "CMC14",
+    "L": "2MASS",
+    "N": "SDSS7",
+    "Q": "CMC15",
+    "R": "SSTRC4",
+    "S": "URAT1",
+    "U": "Gaia1",
+    "W": "Gaia3",
+}
+coords = ["ra", "dec", "pm_ra", "pm_dec"]
+
+columns = ["_".join(pair) for pair in product(mpc_catalogs.keys(), coords)]
+
+
+def generate_bias_dict(cache_dir=None):
+
+    #! We need to include this in the bootstrap files
+    #! curl ftp://ssd.jpl.nasa.gov/pub/ssd/debias/debias_hires2018.tgz --output debias_hires2018.tgz
+    #! tar -xvzf debias_hires2018.tgz
+    biasdf = pd.read_csv(Path(cache_dir) / "bias.dat", sep="\\s+", skiprows=23, names=columns)
+
+    # Turn this into a dictionary for speed
+    bias_dict = {}
+    for catalog in mpc_catalogs:
+        colnames = [f"{catalog}_ra", f"{catalog}_dec", f"{catalog}_pm_ra", f"{catalog}_pm_dec"]
+        bias_dict[catalog] = {}
+        for col in colnames:
+            short_col = col[2:]
+            bias_dict[catalog][short_col] = biasdf[col].values
+    return bias_dict
+
+
+def debias(ra, dec, epoch, catalog, bias_dict, nside=256):
+
+    if catalog not in bias_dict:
+        return ra, dec
+
+    # find pixel from RADEC
+    idx = hp.ang2pix(nside, ra, dec, nest=False, lonlat=True)
+
+    ra_off = bias_dict[catalog]["ra"][idx]
+    pm_ra = bias_dict[catalog]["pm_ra"][idx]
+    dec_off = bias_dict[catalog]["dec"][idx]
+    pm_dec = bias_dict[catalog]["pm_dec"][idx]
+
+    # time from epoch in Julian years
+    dt_jy = (epoch - spice.j2000()) / 365.25
+
+    # bias correction
+    ddec = dec_off + dt_jy * pm_dec / 1000
+    dec_deb = dec - ddec / 3600.0
+    dra = (ra_off + dt_jy * pm_ra / 1000) / np.cos(np.deg2rad(dec))
+    ra_deb = ra - dra / 3600.0
+
+    # Quadrant correction
+    xyz = radec2icrf(ra_deb, dec_deb, deg=True)
+    ra_deb, dec_deb = icrf2radec(xyz[0], xyz[1], xyz[2], deg=True)
+
+    return ra_deb, dec_deb
+
+
+# From Siegfried Eggl's code
+def radec2icrf(ra, dec, deg=True):
+    """Convert Right Ascension and Declination to ICRF xyz unit vector.
+    Geometric states on unit sphere, no light travel time/aberration correction.
+    Parameters:
+    -----------
+    ra ... Right Ascension [deg]
+    dec ... Declination [deg]
+    deg ... True: angles in degrees, False: angles in radians
+    Returns:
+    --------
+    x,y,z ... 3D vector of unit length (ICRF)
+    """
+
+    if deg:
+        a = np.deg2rad(ra)
+        d = np.deg2rad(dec)
+    else:
+        a = np.array(ra)
+        d = np.array(dec)
+
+    cosd = np.cos(d)
+    x = cosd * np.cos(a)
+    y = cosd * np.sin(a)
+    z = np.sin(d)
+
+    return np.array([x, y, z])
+
+
+# From Siegfried Eggl's code
+def icrf2radec(x, y, z, deg=True):
+    """Convert ICRF xyz to Right Ascension and Declination.
+    Geometric states on unit sphere, no light travel time/aberration correction.
+    Parameters:
+    -----------
+    x,y,z ... 3D vector of unit length (ICRF)
+    deg ... True: angles in degrees, False: angles in radians
+    Returns:
+    --------
+    ra ... Right Ascension [deg]
+    dec ... Declination [deg]
+    """
+
+    pos = np.array([x, y, z])
+    r = np.linalg.norm(pos, axis=0) if (pos.ndim > 1) else np.linalg.norm(pos)
+    xu = x / r
+    yu = y / r
+    zu = z / r
+    phi = np.arctan2(yu, xu)
+    delta = np.arcsin(zu)
+    if deg:
+        ra = np.mod(np.rad2deg(phi) + 360, 360)
+        dec = np.rad2deg(delta)
+    else:
+        ra = np.mod(phi + 2 * np.pi, 2 * np.pi)
+        dec = delta
+    return ra, dec

--- a/src/layup/utilities/layup_configs.py
+++ b/src/layup/utilities/layup_configs.py
@@ -63,6 +63,14 @@ class AuxiliaryConfigs:
     orientation_constants_url: str = f"{naif_base_url}/pck/pck00010.tpc"
     """url of observatory_constants"""
 
+    debiasing_data: str = "bias.dat"
+    """filename of debiasing data (uncompressed)"""
+
+    debiasing_data_compressed: str = "debias_hires2018.tgz"
+    """filename of compressed debiasing_data"""
+    debiasing_data_compressed_url: str = "ftp://ssd.jpl.nasa.gov/pub/ssd/debias/debias_hires2018.tgz"
+    """url of compressed debiasing_data"""
+
     data_file_list: list[str] = field(default_factory=list)
     """convenience list of all the file names"""
 
@@ -91,6 +99,7 @@ class AuxiliaryConfigs:
             "leap_seconds": self.__class__.leap_seconds_url,
             "observatory_codes_compressed": self.__class__.observatory_codes_compressed_url,
             "orientation_constants": self.__class__.orientation_constants_url,
+            "debiasing_data_compressed": self.__class__.debiasing_data_compressed_url,
         }
 
     @property
@@ -107,6 +116,7 @@ class AuxiliaryConfigs:
             "meta_kernel": self.__class__.meta_kernel,
             "observatory_codes_compressed": self.__class__.observatory_codes_compressed,
             "orientation_constants": self.__class__.orientation_constants,
+            "debiasing_data_compressed": self.__class__.debiasing_data_compressed,
         }
 
     def __post_init__(self):
@@ -151,6 +161,7 @@ class AuxiliaryConfigs:
             self.leap_seconds: self.leap_seconds_url,
             self.observatory_codes_compressed: self.observatory_codes_compressed_url,
             self.orientation_constants: self.orientation_constants_url,
+            self.debiasing_data_compressed: self.debiasing_data_compressed_url,
         }
 
         self.data_file_list = [
@@ -165,6 +176,8 @@ class AuxiliaryConfigs:
             self.observatory_codes_compressed,
             self.observatory_codes,
             self.orientation_constants,
+            self.debiasing_data_compressed,
+            self.debiasing_data,
         ]
 
         self.data_files_to_download = [
@@ -177,6 +190,7 @@ class AuxiliaryConfigs:
             self.leap_seconds,
             self.observatory_codes_compressed,
             self.orientation_constants,
+            self.debiasing_data_compressed,
         ]
 
         self.ordered_kernel_files = [

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -52,6 +52,14 @@ def main():
         default=10000,
         required=False,
     )
+    optional.add_argument(
+        "-d",
+        "--debias",
+        action="store_true",
+        help="Perform dibiasing of the input astrometry based on catalog and epoch.",
+        required=False,
+        dest="debias",
+    )
 
     optional.add_argument(
         "-f",

--- a/tests/layup/test_debias.py
+++ b/tests/layup/test_debias.py
@@ -1,0 +1,72 @@
+import pytest
+import pooch
+import numpy as np
+
+
+from layup.utilities.debiasing import debias, generate_bias_dict, mpc_catalogs
+
+
+def test_generate_bias_dict():
+    """Test the generate_bias_dict function to ensure it returns a dictionary with the correct structure."""
+
+    cache_dir = pooch.os_cache("layup")
+    # Call the function to generate the bias dictionary
+    bias_dict = generate_bias_dict(cache_dir=cache_dir)
+
+    # Check that the returned object is a dictionary
+    assert isinstance(bias_dict, dict), "The returned object should be a dictionary."
+
+    # Check that the dictionary contains expected keys
+    bias_keys = mpc_catalogs.values()
+    for key in bias_keys:
+        assert key in bias_dict, f"The key '{key}' is missing from the bias dictionary."
+
+    # Check that each key has a list as its value
+    for key in bias_keys:
+        assert isinstance(bias_dict[key], dict), f"The value for key '{key}' should be a list."
+
+    # Optionally, check that lists are not empty (if applicable)
+    for key in bias_keys:
+        assert len(bias_dict[key].keys()) == 4, f"The list for key '{key}' should not be empty."
+        columns = ["ra", "dec", "pm_ra", "pm_dec"]
+        assert all(
+            col in bias_dict[key] for col in columns
+        ), f"Missing expected columns in bias dictionary for key '{key}'."
+        assert all(
+            isinstance(bias_dict[key][col], np.ndarray) for col in columns
+        ), f"Values for key '{key}' should be lists."
+
+
+def test_generate_bias_dict_file_not_found():
+    """Test the generate_bias_dict function raises FileNotFoundError when bias.dat is not found."""
+
+    # Create a temporary directory that does not contain the bias.dat file
+    cache_dir = "/tmp/non_existent_cache_dir"
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        _ = generate_bias_dict(cache_dir=cache_dir)
+        assert str(exc_info) == f"The bias.dat file was not found in the cache directory: {cache_dir}"
+
+
+def test_debias():
+    """Test the debias function to ensure it correctly debiases RA and Dec coordinates."""
+
+    # Generate a bias dictionary for testing
+    cache_dir = pooch.os_cache("layup")
+    bias_dict = generate_bias_dict(cache_dir=cache_dir)
+
+    # Test data
+    ra = 10.0  # Right Ascension in degrees
+    dec = 20.0  # Declination in degrees
+    epoch = 2451545.0  # Julian date for J2000.0
+    catalog = "PPM"  # Example catalog name
+
+    # Call the debias function
+    debiased_ra, debiased_dec = debias(ra, dec, epoch, catalog, bias_dict)
+
+    # Check that the returned values are not None
+    assert debiased_ra is not None, "Debiased RA should not be None."
+    assert debiased_dec is not None, "Debiased Dec should not be None."
+
+    # Check that the returned values are different from the input values (indicating debiasing occurred)
+    assert debiased_ra != ra or debiased_dec != dec, "Debiased values should differ from input values."

--- a/tests/layup/test_layup_configs.py
+++ b/tests/layup/test_layup_configs.py
@@ -16,6 +16,7 @@ correct_auxciliary_URLs = {
     "naif0012.tls": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/naif0012.tls",
     "ObsCodes.json.gz": "https://minorplanetcenter.net/Extended_Files/obscodes_extended.json.gz",
     "pck00010.pck": "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/pck00010.tpc",
+    "debias_hires2018.tgz": "ftp://ssd.jpl.nasa.gov/pub/ssd/debias/debias_hires2018.tgz",
 }
 correct_auxciliary_filenames = [
     "de440s.bsp",
@@ -29,6 +30,8 @@ correct_auxciliary_filenames = [
     "ObsCodes.json.gz",
     "ObsCodes.json",
     "pck00010.pck",
+    "debias_hires2018.tgz",
+    "bias.dat",
 ]
 
 ##################################################################################################################################

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -36,6 +36,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers):
             self.primary_id_column_name = "provID"
             self.separate_flagged = False
             self.force = force
+            self.debias = False
 
     with pytest.raises(FileExistsError):
         orbitfit_cli(


### PR DESCRIPTION
Fixes a portion of #204 .

Describe your changes.
- Update layup bootstrap to download bias file to the cache directory
- Add a new `orbitfit` cli flag, `--debias` that defaults to false. 
- When `--debias` is passed, we will use the bias file to attempt to debias the input data based on observatory, ra, dec and epoch. 
- When ra and dec are not in the input file passed to orbitfit, we assume an occultation observation, and will use starra, stardec to calculate the object's true ra/dec.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
