### PR TITLE
Automatically download files if they are missing

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -299,7 +299,7 @@ def orbitfit(
         and program. Default is False.
     """
 
-    layup_observatory = LayupObservatory()
+    layup_observatory = LayupObservatory(cache_dir=cache_dir)
 
     # The units of et are seconds (from J2000). This new column is used by
     # data_processing_utilities.obscodes_to_barycentric.

--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -116,7 +116,7 @@ def predict(data, obscode, times, primary_id_column_name="provID", num_workers=-
     if num_workers < 0:
         num_workers = os.cpu_count()
 
-    Layup_observatory = LayupObservatory()
+    Layup_observatory = LayupObservatory(cache_dir=cache_dir)
 
     times_et = np.array([spice.str2et(f"jd {t} tdb") for t in times], dtype="<f8")
 

--- a/src/layup/utilities/bootstrap_utilties/download_utilities.py
+++ b/src/layup/utilities/bootstrap_utilties/download_utilities.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 import concurrent.futures
 import os
 import pooch
@@ -33,7 +34,7 @@ def make_retriever(aux_config: AuxiliaryConfigs, directory_path: Optional[str] =
     )
 
 
-def download_files_if_missing(configs, args) -> None:
+def download_files_if_missing(aux_config: AuxiliaryConfigs, args: Namespace) -> None:
     """This function partially encapsulates the functionality of the
     `layup.bootstrap` command line tool. While `layup.bootstrap` allows for forced
     re-downloading of files, this function will only download files that are not
@@ -41,7 +42,7 @@ def download_files_if_missing(configs, args) -> None:
 
     Parameters
     ----------
-    configs : LayupConfigs
+    aux_configs : AuxiliaryConfigs
         Dataclass of configuration file arguments.
         This includes the AuxiliaryConfigs dataclass that contains the
         configuration for the bootstrap files.
@@ -50,10 +51,8 @@ def download_files_if_missing(configs, args) -> None:
         that specifies the directory to store the downloaded files.
     """
 
-    aux_config = configs.auxiliary
-
     # create the Pooch retriever that tracks and retrieves the requested files
-    retriever = make_retriever(aux_config, args.cache)
+    retriever = make_retriever(aux_config, args.ar_data_file_path)
 
     print("Checking cache for existing files.")
     found_all_files = _check_for_existing_files(aux_config, retriever)

--- a/src/layup/utilities/bootstrap_utilties/download_utilities.py
+++ b/src/layup/utilities/bootstrap_utilties/download_utilities.py
@@ -1,7 +1,10 @@
+import concurrent.futures
 import os
 import pooch
+from functools import partial
 from typing import Optional
 from layup.utilities.layup_configs import AuxiliaryConfigs
+from layup.utilities.bootstrap_utilties.create_meta_kernel import build_meta_kernel_file
 
 
 def make_retriever(aux_config: AuxiliaryConfigs, directory_path: Optional[str] = None) -> pooch.Pooch:
@@ -28,6 +31,46 @@ def make_retriever(aux_config: AuxiliaryConfigs, directory_path: Optional[str] =
         registry=aux_config.registry,
         retry_if_failed=25,
     )
+
+
+def download_files_if_missing(configs, args) -> None:
+    """This function partially encapsulates the functionality of the
+    `layup.bootstrap` command line tool. While `layup.bootstrap` allows for forced
+    re-downloading of files, this function will only download files that are not
+    already present in the local cache.
+
+    Parameters
+    ----------
+    configs : LayupConfigs
+        Dataclass of configuration file arguments.
+        This includes the AuxiliaryConfigs dataclass that contains the
+        configuration for the bootstrap files.
+    args : Namespace
+        The command line arguments. This includes the `--cache` argument
+        that specifies the directory to store the downloaded files.
+    """
+
+    aux_config = configs.auxiliary
+
+    # create the Pooch retriever that tracks and retrieves the requested files
+    retriever = make_retriever(aux_config, args.cache)
+
+    print("Checking cache for existing files.")
+    found_all_files = _check_for_existing_files(aux_config, retriever)
+
+    if not found_all_files:
+        # create a partial function of `Pooch.fetch` including the `_decompress` method
+        fetch_partial = partial(retriever.fetch, processor=_decompress, progressbar=True)
+
+        # download the data files in parallel
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            executor.map(fetch_partial, aux_config.data_files_to_download)
+
+        # build the meta_kernel.txt file
+        build_meta_kernel_file(aux_config, retriever)
+
+        print("Checking cache after attempting to download and create files.")
+        _check_for_existing_files(aux_config, retriever)
 
 
 def _check_for_existing_files(aux_config: AuxiliaryConfigs, retriever: pooch.Pooch) -> bool:

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -259,19 +259,30 @@ class LayupObservatory(SorchaObservatory):
     A wrapper around Sorcha's Observatory class to provide additional functionality for Layup.
     """
 
-    def __init__(self):
+    def __init__(self, cache_dir=None):
+        """Create an instance of the LayupObservatory class.
+
+        Parameters
+        ----------
+        cache_dir : str, optional
+            The location of the cache directory containing the bootstrapped files.
+            If the files or cache is not present, the files will be downloaded, by default None
+        """
+
         # Get Layup configs
         config = LayupConfigs()
+        self.cache_dir = cache_dir
 
         # A simple class to mimic the arguments processed by Sorcha's observatory class
         class FakeSorchaArgs:
-            def __init__(self):
+            def __init__(self, cache_dir=None):
                 # Sorcha allows this argument to be None, so simply use that here
-                self.ar_data_file_path = None
+                self.ar_data_file_path = cache_dir
 
         # Furnish spiceypy kernels used for calculating barycentric positions
-        furnish_spiceypy(FakeSorchaArgs(), config.auxiliary)
-        super().__init__(FakeSorchaArgs(), config.auxiliary)
+        fake_args = FakeSorchaArgs(self.cache_dir)
+        furnish_spiceypy(fake_args, config.auxiliary)
+        super().__init__(fake_args, config.auxiliary)
 
         # A cache of barycentric positions for observatories of the form {obscode: {et: (x, y, z)}}
         self.cached_obs = {}

--- a/src/layup_cmdline/bootstrap.py
+++ b/src/layup_cmdline/bootstrap.py
@@ -21,7 +21,7 @@ def main():
         "--config",
         help="Input configuration file name",
         type=str,
-        dest="c",
+        dest="config",
         required=False,
     )
 
@@ -63,9 +63,9 @@ def execute(args):
     # layup.AuxiliaryConfigs) for the current version of layup. A user can
     # download new files by running layup and specifying in the config file
     # under the section [AUXILIARY] a new filename and url.
-    if args.c:
+    if args.config:
         find_file_or_exit(args.c, "-c, --config")
-        configs = LayupConfigs(args.c)
+        configs = LayupConfigs(args.config)
     else:
         configs = LayupConfigs()
 

--- a/src/layup_cmdline/comet.py
+++ b/src/layup_cmdline/comet.py
@@ -33,7 +33,7 @@ def main():
         "--conf",
         help="optional configuration file",
         type=str,
-        dest="c",
+        dest="config",
         required=False,
     )
     optional.add_argument(
@@ -76,6 +76,18 @@ def main():
 
 
 def execute(args):
+    from layup.utilities.bootstrap_utilties.download_utilities import download_files_if_missing
+    from layup.utilities.file_access_utils import find_file_or_exit
+    from layup.utilities.layup_configs import LayupConfigs
+
+    configs = LayupConfigs()
+    if args.config:
+        find_file_or_exit(args.config, "-c, --config")
+        configs = LayupConfigs(args.config)
+
+    # check if bootstrap files are missing, and download if necessary
+    download_files_if_missing(configs.auxiliary, args)
+
     print("Hello world this would start comet")
 
 

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -44,7 +44,7 @@ def main():
         "--conf",
         help="optional configuration file",
         type=str,
-        dest="c",
+        dest="config",
         required=False,
     )
     optional.add_argument(
@@ -146,10 +146,10 @@ def execute(args):
     configs = LayupConfigs()
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
-        configs = LayupConfigs(args.c)
+        configs = LayupConfigs(args.config)
 
     # check if bootstrap files are missing, and download if necessary
-    download_files_if_missing(configs, args)
+    download_files_if_missing(configs.auxiliary, args)
 
     convert_cli(
         input=args.input,

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -108,8 +108,10 @@ def main():
 
 def execute(args):
     from layup.convert import convert_cli
+    from layup.utilities.bootstrap_utilties.download_utilities import download_files_if_missing
     from layup.utilities.cli_utilities import warn_or_remove_file
     from layup.utilities.file_access_utils import find_directory_or_exit, find_file_or_exit
+    from layup.utilities.layup_configs import LayupConfigs
 
     # check ar directory exists if specified
     if args.ar_data_file_path:
@@ -140,6 +142,15 @@ def execute(args):
     # Check that chunk size is a positive integer
     if not isinstance(args.chunk, int) or args.chunk <= 0:
         logger.error("ERROR: Chunk size must be a positive integer")
+
+    configs = LayupConfigs()
+    if args.config:
+        find_file_or_exit(args.config, "-c, --config")
+        configs = LayupConfigs(args.c)
+
+    # check if bootstrap files are missing, and download if necessary
+    download_files_if_missing(configs, args)
+
     convert_cli(
         input=args.input,
         output_file_stem=args.o,

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -191,10 +191,10 @@ def execute(args):
     configs = LayupConfigs()
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
-        configs = LayupConfigs(args.c)
+        configs = LayupConfigs(args.config)
 
     # check if bootstrap files are missing, and download if necessary
-    download_files_if_missing(configs, args)
+    download_files_if_missing(configs.auxiliary, args)
 
     orbitfit_cli(
         input=args.input,

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -153,6 +153,7 @@ def main():
 
 def execute(args):
     from layup.orbitfit import orbitfit_cli
+    from layup.utilities.bootstrap_utilties.download_utilities import download_files_if_missing
 
     print("Starting orbitfit...")
 
@@ -191,6 +192,9 @@ def execute(args):
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
         configs = LayupConfigs(args.c)
+
+    # check if bootstrap files are missing, and download if necessary
+    download_files_if_missing(configs, args)
 
     orbitfit_cli(
         input=args.input,

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -2,10 +2,8 @@
 # The `layup predict` subcommand implementation
 #
 import argparse
-import os
 from pathlib import Path
 from layup_cmdline.layupargumentparser import LayupArgumentParser
-from astropy.time import Time
 import astropy.units as u
 from datetime import datetime, timezone
 import logging
@@ -229,8 +227,10 @@ def execute(args):
     import astropy.units as u
     import re
     from layup.predict import predict_cli
+    from layup.utilities.bootstrap_utilties.download_utilities import download_files_if_missing
     from layup.utilities.cli_utilities import warn_or_remove_file
     from layup.utilities.file_access_utils import find_file_or_exit, find_directory_or_exit
+    from layup.utilities.layup_configs import LayupConfigs
     import sys
     import pooch
 
@@ -283,6 +283,14 @@ def execute(args):
         sys.exit(f"Unsupported unit, {unit_str}, for timestep: {timestep_str}.")
 
     timestep_day = (value * UNIT_DICT[unit_str]).to(u.day).value  # converting value into day units
+
+    configs = LayupConfigs()
+    if args.config:
+        find_file_or_exit(args.config, "-c, --config")
+        configs = LayupConfigs(args.c)
+
+    # check if bootstrap files are missing, and download if necessary
+    download_files_if_missing(configs, args)
 
     predict_cli(
         cli_args=args,

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -63,7 +63,7 @@ def main():
         "--conf",
         help="Optional configuration file",
         type=str,
-        dest="c",
+        dest="config",
         required=False,
     )
 
@@ -287,10 +287,10 @@ def execute(args):
     configs = LayupConfigs()
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
-        configs = LayupConfigs(args.c)
+        configs = LayupConfigs(args.config)
 
     # check if bootstrap files are missing, and download if necessary
-    download_files_if_missing(configs, args)
+    download_files_if_missing(configs.auxiliary, args)
 
     predict_cli(
         cli_args=args,


### PR DESCRIPTION
Automatically download files if they are missing when running verbs from the command line. When creating `SorchaObservatory` object, request that the layup cache files are used.

Fixes #126 #108 .

Describe your changes.
Two big changes here

1. We check to see if all the expected bootstrap files are present when running `convert`, `predict`, or `orbitfit` from the commandline. If anything is missing, we download it (and decompress if needed). This should fix issue #126.
2. When creating a `LayupObservatory` object, we instantiate a `SorchaObservatory` object under the hood. The SorchaObservatory can take a cache directory as input, which we were not passing. Now we will, so the SorchaObservatory object will look in the `layup` cache directory for the files it needs. This should fix issue #108. 

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
