### PR TITLE
Reducing pre-commit unit test run time.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
       - id: pytest-check
         name: Run unit tests
         description: Run unit tests with pytest.
-        entry: bash -c "if python -m pytest --co -qq; then python -m pytest --cov=./src --cov-report=html; fi"
+        entry: bash -c "if python -m pytest --co -qq; then python -m pytest; fi"
         language: system
         pass_filenames: false
         always_run: true

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -42,8 +42,8 @@ def test_empty(n_workers):
     assert len(processed_data) == 0
 
 
-@pytest.mark.parametrize("n_workers", [1, 4, 5, 8])
-@pytest.mark.parametrize("n_rows", [1, 413, 1000])
+@pytest.mark.parametrize("n_workers", [1, 5, 8])
+@pytest.mark.parametrize("n_rows", [1, 413])
 def test_no_op(n_rows, n_workers):
     """Test that we can apply simple functions on datasets of various sizes and numbers of workers."""
     dtypes = [
@@ -65,8 +65,8 @@ def test_no_op(n_rows, n_workers):
     assert_equal(processed_data.dtype, data.dtype)
 
 
-@pytest.mark.parametrize("n_workers", [1, 4, 5, 8])
-@pytest.mark.parametrize("n_rows", [1, 413, 1000])
+@pytest.mark.parametrize("n_workers", [1, 5, 8])
+@pytest.mark.parametrize("n_rows", [1, 413])
 def test_data_modify(n_rows, n_workers):
     """Test that we can apply simple functions on datasets of various sizes and numbers of workers."""
     dtypes = [
@@ -132,8 +132,8 @@ def test_get_cov_columns():
     ]
 
 
-@pytest.mark.parametrize("n_workers", [1, 4, 5, 8])
-@pytest.mark.parametrize("n_rows", [1, 413, 1000])
+@pytest.mark.parametrize("n_workers", [1, 5, 8])
+@pytest.mark.parametrize("n_rows", [1, 413])
 def test_parallelization(n_rows, n_workers):
     """Test that we can apply simple functions on datasets of various sizes and numbers of workers."""
     dtypes = [


### PR DESCRIPTION
Still need to audit the rest of the unit tests. A couple of long running test suites stand out: 
test_orbit_fit:test_orbitfit_result_parsing - probably doesn't need to run orbitfit, we could just test the parsing
test_predict - Takes about 10-20 seconds to run, might be able to reduce the test matrix

Consider adding pytest.mark.slow, and segmenting the unit tests between per-commit unit tests and nightly smoke tests that can run for longer without bothering anyone. 

Fixes #226.

Describe your changes.
- Removed code coverage reporting from pre-commit
- Reduced the testing matrix for one of the unit tests.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
