### PR TITLE
Include `ra` and `dec` in output of `predict` verb.

### DIFF
--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -25,8 +25,8 @@ def _get_result_dtypes(primary_id_column_name: str):
     return np.dtype(
         [
             (primary_id_column_name, "O"),  # Object ID
-            ("ra", "f8"),
-            ("dec", "f8"),
+            ("ra_deg", "f8"),
+            ("dec_deg", "f8"),
             ("rho_x", "f8"),  # The first of the 3 rho unit vector
             ("rho_y", "f8"),
             ("rho_z", "f8"),
@@ -95,7 +95,7 @@ def _predict(data, obs_pos_vel, times, cache_dir, primary_id_column_name):
             )
 
     results = np.array(predict_results, dtype=_get_result_dtypes(primary_id_column_name))
-    results["ra"], results["dec"] = vec2ra_dec([results["rho_x"], results["rho_y"], results["rho_z"]])
+    results["ra_deg"], results["dec_deg"] = vec2ra_dec([results["rho_x"], results["rho_y"], results["rho_z"]])
 
     return results
 

--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -6,6 +6,8 @@ import numpy as np
 import pooch
 import spiceypy as spice
 
+from sorcha.ephemeris.simulation_geometry import vec2ra_dec
+
 from layup.routines import Observation, get_ephem, numpy_to_eigen, predict_sequence
 from layup.utilities.data_processing_utilities import (
     LayupObservatory,
@@ -23,6 +25,8 @@ def _get_result_dtypes(primary_id_column_name: str):
     return np.dtype(
         [
             (primary_id_column_name, "O"),  # Object ID
+            ("ra", "f8"),
+            ("dec", "f8"),
             ("rho_x", "f8"),  # The first of the 3 rho unit vector
             ("rho_y", "f8"),
             ("rho_z", "f8"),
@@ -77,6 +81,8 @@ def _predict(data, obs_pos_vel, times, cache_dir, primary_id_column_name):
             predict_results.append(
                 (
                     row[primary_id_column_name],
+                    pred.rho[0],  # place holder
+                    pred.rho[0],  # place holder
                     pred.rho[0],
                     pred.rho[1],
                     pred.rho[2],
@@ -88,7 +94,10 @@ def _predict(data, obs_pos_vel, times, cache_dir, primary_id_column_name):
                 )
             )
 
-    return np.array(predict_results, dtype=_get_result_dtypes(primary_id_column_name))
+    results = np.array(predict_results, dtype=_get_result_dtypes(primary_id_column_name))
+    results["ra"], results["dec"] = vec2ra_dec([results["rho_x"], results["rho_y"], results["rho_z"]])
+
+    return results
 
 
 def predict(data, obscode, times, primary_id_column_name="provID", num_workers=-1, cache_dir=None):

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -67,5 +67,5 @@ def test_predict_cli(tmpdir, chunk_size, time_step):
     # ensure that have a prediction for each object at every time step
     assert_equal(len(output_data), n_uniq_ids * number_of_predictions_per)
 
-    assert np.all(output_data["ra"] <= 360.0) and np.all(output_data["ra"] >= 0.0)
-    assert np.all(output_data["dec"] <= 90.0) and np.all(output_data["dec"] >= -90.0)
+    assert np.all(output_data["ra_deg"] <= 360.0) and np.all(output_data["ra_deg"] >= 0.0)
+    assert np.all(output_data["dec_deg"] <= 90.0) and np.all(output_data["dec_deg"] >= -90.0)

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -66,3 +66,6 @@ def test_predict_cli(tmpdir, chunk_size, time_step):
 
     # ensure that have a prediction for each object at every time step
     assert_equal(len(output_data), n_uniq_ids * number_of_predictions_per)
+
+    assert np.all(output_data["ra"] <= 360.0) and np.all(output_data["ra"] >= 0.0)
+    assert np.all(output_data["dec"] <= 90.0) and np.all(output_data["dec"] >= -90.0)


### PR DESCRIPTION
Fixes #233

Describe your changes.
Calling Sorcha `vec2ra_dec` to include ra/dec values to the output of predict.

The output still includes the cartesian unit vector values. Those can be removed if they are truly not needed.

Additionally, the test input that I had available produced ra/dec values that were all very small. I believe all less than pi/2, while I was expecting degree values between 0-360 or -90-+90.

I assume that the Sorcha function has unit tests and has been verified, but if someone could cross check that, I would really appreciate it.


## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
