### PR TITLE
issue/242/predict_epoch

### DIFF
--- a/src/lib/orbit_fit/predict.cpp
+++ b/src/lib/orbit_fit/predict.cpp
@@ -197,7 +197,7 @@ namespace orbit_fit
         result.obs_cov[1] = obs_cov(0, 1);
         result.obs_cov[2] = obs_cov(1, 0);
         result.obs_cov[3] = obs_cov(1, 1);
-        result.epoch = epoch;
+        result.epoch = jd_tdb;
 
         return result;
     }


### PR DESCRIPTION
Fixes #244 

This changes the epoch in the returned predict_result struct to the time of the prediction.

## Review Checklist for Source Code Changes

- [x ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
