### PR TITLE
For test_orbit_fit_cli set num_workers to 1

### DIFF
--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -27,7 +27,7 @@ OUTPUT_COL_PER_ORBIT_TYPE = {
     [
         (100_000, 1, "BCART_EQ"),
         (100_000, 1, "COM"),
-        (100_000, 2, "KEP"),
+        (100_000, 1, "KEP"),
     ],
 )
 def test_orbit_fit_cli(tmpdir, chunk_size, num_workers, output_orbit_format):


### PR DESCRIPTION
Fixes a test error observed since https://github.com/Smithsonian/layup/pull/241 where the ubuntu github runner hangs on test_orbit_fit_cli

https://github.com/Smithsonian/layup/issues/256 is filed to follow-up on debugging and fixing the underlying issue. However here we simply make the tests usable again by setting num_workers=1

Describe your changes.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
