### PR TITLE
Support multiple IODs in `orbitfit`

### DIFF
--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -77,7 +77,7 @@ def main():
         "-i",
         "--iod",
         help="IOD choice",
-        dest="i",
+        dest="iod",
         default="gauss",
         required=False,
     )


### PR DESCRIPTION
Fixes #220 

Describe your changes.

- Pass the iod CLI around the orbit fit code. 
- Created a stub do_other_fit for potential future complicated IODs that require different data massaging
- Extracted gauss IOD from `do_fit`, and added the beginning of a if/else ladder there, again for future IODs that don't require as much data massaging as those that might end up in the `do_other_fit`-like functions.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
