### PR TITLE
Defined minimum required column names in `predict` and `orbit`

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -35,6 +35,20 @@ from layup.utilities.file_io.file_output import write_csv, write_hdf5
 
 logger = logging.getLogger(__name__)
 
+# The list of required input column names for the provided observations to be fit.
+# Note: This should not include the primary id column name.
+REQUIRED_INPUT_OBSERVATIONS_COLUMN_NAMES = [
+    "ra",
+    "dec",
+    "obstime",
+]
+
+# The list of required column names for the guessed orbits (if provided).
+# Note: This should now include the primary id column name.
+REQUIRED_INPUT_GUESS_COLUMN_NAMES = [
+    "epochMJD_TDB",
+]
+
 INPUT_FORMAT_READERS = {
     "MPC80col": (Obs80DataReader, None),
     "ADES_csv": (CSVDataReader, "csv"),
@@ -765,7 +779,12 @@ def orbitfit_cli(
     if reader_class is None:
         logger.error(f"File format {input_file_format} is not supported")
 
-    reader = reader_class(input_file, primary_id_column_name=_primary_id_column_name, sep=separator)
+    reader = reader_class(
+        input_file,
+        primary_id_column_name=_primary_id_column_name,
+        sep=separator,
+        required_columns=REQUIRED_INPUT_OBSERVATIONS_COLUMN_NAMES,
+    )
     if guess_file is not None:
         # Check that the guess file exists
         if not guess_file.exists():
@@ -777,7 +796,12 @@ def orbitfit_cli(
             raise ValueError("Guess file cannot be the same as the input file")
         # Set up our initial guess file reader. Assumes a matching file format and primary id column name
         # as the input file.
-        guess_reader = reader_class(guess_file, primary_id_column_name=_primary_id_column_name, sep=separator)
+        guess_reader = reader_class(
+            guess_file,
+            primary_id_column_name=_primary_id_column_name,
+            sep=separator,
+            required_columns=REQUIRED_INPUT_GUESS_COLUMN_NAMES,
+        )
 
     chunks = create_chunks(reader, chunk_size)
 

--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -20,6 +20,12 @@ from layup.utilities.data_processing_utilities import (
 from layup.utilities.file_io import CSVDataReader
 from layup.utilities.file_io.file_output import write_csv
 
+# The list of required input column names. Note: This should not include the
+# primary id column name.
+REQUIRED_INPUT_COLUMN_NAMES = [
+    "epochMJD_TDB",
+]
+
 
 def _get_result_dtypes(primary_id_column_name: str):
     """Helper function to create the result dtype with the correct primary ID column name."""
@@ -191,7 +197,12 @@ def predict_cli(
 
     times = np.arange(start_date, end_date + timestep_day, step=timestep_day)
 
-    reader = CSVDataReader(input_file, primary_id_column_name=cli_args.primary_id_column_name, sep="csv")
+    reader = CSVDataReader(
+        input_file,
+        primary_id_column_name=cli_args.primary_id_column_name,
+        sep="csv",
+        required_columns=REQUIRED_INPUT_COLUMN_NAMES,
+    )
 
     chunks = create_chunks(reader, chunk_size=cli_args.chunk)
 

--- a/src/layup/utilities/file_io/ObjectDataReader.py
+++ b/src/layup/utilities/file_io/ObjectDataReader.py
@@ -244,12 +244,12 @@ class ObjectDataReader(abc.ABC):
                 logger.error(outstr)
                 sys.exit(outstr)
 
-            # Check that the expected columns are present in this chunk
-            for col in self._required_columns:
-                if col not in input_table.dtype.names:
-                    outstr = f"ERROR: While reading table {self.filename}. Required column {col} not found."
-                    logger.error(outstr)
-                    sys.exit(outstr)
+        # Check that the expected columns are present in this chunk
+        for col in self._required_columns:
+            if col not in input_table.dtype.names:
+                outstr = f"ERROR: While reading table {self.filename}. Required column {col} not found."
+                logger.error(outstr)
+                sys.exit(outstr)
 
         # Check for NaNs or nulls.
         if kwargs.get("disallow_nan", False):  # pragma: no cover

--- a/tests/layup/test_file_readers.py
+++ b/tests/layup/test_file_readers.py
@@ -66,3 +66,44 @@ def test_file_readers_produce_identical_values_with_cache(orbit_format):
                 csv_data[column_name],
                 err_msg=f"Column {column_name} not equal with dtype {hdf5_data[column_name].dtype}",
             )
+
+
+def test_required_columns():
+    """Ensure that ObjectReader will accept required columns."""
+
+    required_columns = [
+        "ObjID",
+        "FORMAT",
+        "x",
+        "y",
+        "z",
+        "xdot",
+        "ydot",
+        "zdot",
+        "epochMJD_TDB",
+    ]
+
+    csv_reader = CSVDataReader(
+        get_test_filepath("CART.csv"),
+        required_columns=required_columns,
+    )
+
+    rows = csv_reader.read_rows()
+    assert len(rows) == 5
+    assert set(required_columns) == set(rows.dtype.names)
+
+
+def test_data_reader_raises_when_missing_columns():
+    """Ensure that ObjectReader will raise an error defined required columns are
+    missing."""
+
+    csv_reader = CSVDataReader(
+        get_test_filepath("CART.csv"),
+        required_columns=[
+            "ObjID",
+            "FORMAT",
+            "DOES_NOT_EXIST",
+        ],
+    )
+    with pytest.raises(SystemExit):
+        _ = csv_reader.read_rows()


### PR DESCRIPTION
Fixes #234 

Describe your changes.
- Adding required column lists to `predict` and `orbitfit`
- Fixed a bug in `ObjectReader`
- Added tests to prevent regression

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
