### PR TITLE
Enforce ingesting "stn" column as a str in CSVReader.read_objects

### DIFF
--- a/src/layup/utilities/file_io/CSVReader.py
+++ b/src/layup/utilities/file_io/CSVReader.py
@@ -192,6 +192,20 @@ class CSVDataReader(ObjectDataReader):
 
         self._primary_id_col_index = column_names.index(self._primary_id_column_name)
 
+    def _get_fixed_dtypes(self):
+        """Get a dictionary of the fixed dtypes for the columns in the CSV file.
+
+        Returns
+        -------
+        fixed_dtypes : dict
+            A dictionary of the fixed dtypes for the columns in the CSV file.
+            The keys are the column names and the values are assigned dtype.
+        """
+        fixed_dtypes = {self._primary_id_column_name: str}
+        if self._station_column_name is not None:
+            fixed_dtypes[self._station_column_name] = str
+        return fixed_dtypes
+
     def _read_rows_internal(self, block_start=0, block_size=None, **kwargs):
         """Reads in a set number of rows from the input.
 
@@ -225,10 +239,6 @@ class CSVDataReader(ObjectDataReader):
                 [i for i in range(self.header_row_index + 1, self.header_row_index + 1 + block_start)]
             )
 
-        fixed_dtypes = {self._primary_id_column_name: str}
-        if self._station_column_name is not None:
-            fixed_dtypes[self._station_column_name] = str
-
         # Read in the data from self.filename, extracting the header row, reading
         # in `block_size` rows, and skipping the `skip_rows`.
         res_df = pd.read_csv(
@@ -236,7 +246,7 @@ class CSVDataReader(ObjectDataReader):
             sep=self.data_separator,
             skiprows=skip_rows,
             nrows=block_size,
-            dtype=fixed_dtypes,
+            dtype=self._get_fixed_dtypes(),
         )
 
         res_df.columns = [col.strip() for col in res_df.columns]
@@ -293,7 +303,7 @@ class CSVDataReader(ObjectDataReader):
             self.filename,
             sep=self.data_separator,
             skiprows=(lambda x: skipped_row[x]),
-            dtype={self._primary_id_column_name: str},
+            dtype=self._get_fixed_dtypes(),
         )
 
         res_df.columns = [col.strip() for col in res_df.columns]

--- a/tests/data/bernstein_2004_kbos_data_with_sats_occ.csv
+++ b/tests/data/bernstein_2004_kbos_data_with_sats_occ.csv
@@ -1,4 +1,4 @@
-provid,ra,dec,obstime,stn,sys,ctr,pos1,pos2,pos3,astcat,rmsra,rmsdec,rmstime,rmscorr,deltadec,deltara,rastar,decstar,unctime,mag,rmsmag,band
+provID,ra,dec,obstime,stn,sys,ctr,pos1,pos2,pos3,astcat,rmsra,rmsdec,rmstime,rmscorr,deltadec,deltara,rastar,decstar,unctime,mag,rmsmag,band
 2000 FV53,204.89583,-10.70975,2000-03-31T13:21:25.056Z,568,,,,,,UNK,,,,,,,,,,22.9,,R
 2000 FV53,204.89529,-10.70947,2000-03-31T13:55:41.376Z,568,,,,,,UNK,,,,,,,,,,22.9,,R
 2000 FV53,204.85167,-10.68936,2000-04-02T12:46:33.312Z,568,,,,,,UNK,,,,,,,,,,22.8,,R

--- a/tests/layup/test_CSVReader.py
+++ b/tests/layup/test_CSVReader.py
@@ -475,8 +475,18 @@ def test_CSVReader_stn_as_string():
     )
     all_data = csv_reader.read_rows()
     assert all(isinstance(stn, str) for stn in all_data["stn"])
+    expected_stations = {
+        "568",
+        "950",
+        "304",
+        "695",
+        "705",
+        "250",
+    }
+    assert set(all_data["stn"]) == expected_stations
 
     objs = ["2000 FV53", "2003 BG91", "2003 BF91", "2003 BH91"]
     obj_data = csv_reader.read_objects(objs)
     assert len(obj_data) == (len(all_data))
-    assert all(isinstance(stn, str) for stn in all_data["stn"])
+    assert all(isinstance(stn, str) for stn in obj_data["stn"])
+    assert set(obj_data["stn"]) == expected_stations

--- a/tests/layup/test_CSVReader.py
+++ b/tests/layup/test_CSVReader.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
-from layup.utilities.file_io.CSVReader import CSVDataReader
 from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.utilities.file_io.CSVReader import CSVDataReader
 
 
 @pytest.mark.parametrize("use_cache", [True, False])
@@ -464,3 +464,19 @@ def test_CSVDataReader_primary_col_is_string():
     all_data = csv_reader.read_rows()
     assert all(isinstance(i, str) for i in all_data["ObjID"])
     assert all(all_data["ObjID"] == expected_objids)
+
+
+def test_CSVReader_stn_as_string():
+    """Tests that the station column is read in as a string."""
+    csv_reader = CSVDataReader(
+        get_test_filepath("bernstein_2004_kbos_data_with_sats_occ.csv"),
+        "csv",
+        primary_id_column_name="provID",
+    )
+    all_data = csv_reader.read_rows()
+    assert all(isinstance(stn, str) for stn in all_data["stn"])
+
+    objs = ["2000 FV53", "2003 BG91", "2003 BF91", "2003 BH91"]
+    obj_data = csv_reader.read_objects(objs)
+    assert len(obj_data) == (len(all_data))
+    assert all(isinstance(stn, str) for stn in all_data["stn"])


### PR DESCRIPTION
The previous fix to enforce reading the `stn` column as a string for the CSV reader was only being applied for read_rows and not read_objs. This is important since other unit tests used read_rows rather than read_objs (which is actually what is used by orbitfit).

Here we fix that and add a test file which has only MPC obscodes that are numeric (which is the case that triggers this bug).

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Layup run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
