### PR TITLE
Add pybind11 eigen/stl includes so Observation.rho_hat is usable from…

### DIFF
--- a/src/lib/detection.cpp
+++ b/src/lib/detection.cpp
@@ -5,6 +5,8 @@
 #include <cmath>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
 namespace py = pybind11;
 
 // --- Observation Variant Types ---


### PR DESCRIPTION


This was developed with Claude code.  It goes with another two PRs.

PR 1 — feat/pybind11-eigen-includes
  
  Title: Add pybind11 eigen/stl includes so Observation.rho_hat is usable from Python
  
  Adds `pybind11/eigen.h` and `pybind11/stl.h` to `src/lib/detection.cpp`.
  Without these, accessing `Observation.rho_hat`, `a_vec`, or `d_vec`
  from Python raises *"Unable to convert function return value to a
  Python type"* because the binding can't see the Eigen and `std::array`
  conversion machinery. 
  
  Mechanical enabler with no behavior change. Required by downstream
  Python code in two follow-up PRs:
  - `feat/bk-engine-dispatch` — reads `obs.rho_hat` in `bk_orbitfit.py`
  - `feat/iod-picker-pipeline` — reads `obs.rho_hat` in the IOD prefilter
  
  This is the same include change carried by the unmerged
  `fix/tangent-basis-vectors` branch, factored out so it can land
  independently of the A/D formula correctness fix.
  
  ## Review Checklist for Source Code Changes
  - [x] Does pip install still work?
  - [x] Have you written a unit test for any new functions? *(N/A — header-include change only)*
  - [x] Do all the units tests run successfully? 
  - [x] Does Layup run successfully on a test set of input files/databases?
  - [x] Have you used black on the files you have updated *(N/A — C++)*

