### PR TITLE
Fix A/D tangent basis vectors to canonical (RA, Dec) frame

### DIFF
--- a/src/lib/detection.cpp
+++ b/src/lib/detection.cpp
@@ -43,21 +43,26 @@ namespace orbit_fit
         return rho_hat;
     }
 
+    // Unit tangent vector in the direction of increasing RA: (-sin α, cos α, 0).
+    // The celestial pole is the z-axis. Singular only at ρ̂_z = ±1.
     Eigen::Vector3d a_vec_from_rho_hat(const Eigen::Vector3d &rho_hat)
     {
+        double cd = std::sqrt(rho_hat.x() * rho_hat.x() + rho_hat.y() * rho_hat.y());
         Eigen::Vector3d a_vec;
-        a_vec.x() = rho_hat.z();
-        a_vec.y() = 0.0;
-        a_vec.z() = -rho_hat.x();
+        a_vec.x() = -rho_hat.y() / cd;
+        a_vec.y() = rho_hat.x() / cd;
+        a_vec.z() = 0.0;
         return a_vec;
     }
 
+    // Unit tangent vector in the direction of increasing Dec.
     Eigen::Vector3d d_vec_from_rho_hat(const Eigen::Vector3d &rho_hat)
     {
+        double cd = std::sqrt(rho_hat.x() * rho_hat.x() + rho_hat.y() * rho_hat.y());
         Eigen::Vector3d d_vec;
-        d_vec.x() = -rho_hat.x() * rho_hat.y();
-        d_vec.y() = rho_hat.x() * rho_hat.x() + rho_hat.z() * rho_hat.z();
-        d_vec.z() = -rho_hat.z() * rho_hat.y();
+        d_vec.x() = -rho_hat.z() * rho_hat.x() / cd;
+        d_vec.y() = -rho_hat.z() * rho_hat.y() / cd;
+        d_vec.z() = cd;
         return d_vec;
     }
     struct AstrometryObservation

--- a/src/lib/detection.cpp
+++ b/src/lib/detection.cpp
@@ -5,6 +5,8 @@
 #include <cmath>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+#include <pybind11/stl.h>
 namespace py = pybind11;
 
 // --- Observation Variant Types ---

--- a/tests/layup/test_tangent_basis.py
+++ b/tests/layup/test_tangent_basis.py
@@ -1,0 +1,89 @@
+"""Tests for the (A, D) tangent-plane basis vectors attached to each
+astrometric observation.
+
+These vectors must point along the canonical equatorial-tangent
+directions:
+
+    A = ∂ρ̂/∂α  (unit-normalized, direction of increasing RA)
+      = (-sin α,  cos α,  0)
+    D = ∂ρ̂/∂δ  (direction of increasing Dec, already unit length)
+      = (-sin δ cos α,  -sin δ sin α,  cos δ)
+
+A previous implementation used a different (and unnormalized) basis
+that was rotated about ρ̂ by an object-position-dependent angle. That
+silently biased fits whenever per-observation RA/Dec uncertainties
+were not equal. This test pins the basis to the canonical convention.
+"""
+
+import numpy as np
+import pytest
+
+from layup.routines import Observation
+
+
+def _canonical_basis(ra_rad, dec_rad):
+    rho = np.array(
+        [
+            np.cos(dec_rad) * np.cos(ra_rad),
+            np.cos(dec_rad) * np.sin(ra_rad),
+            np.sin(dec_rad),
+        ]
+    )
+    a = np.array([-np.sin(ra_rad), np.cos(ra_rad), 0.0])
+    d = np.array(
+        [
+            -np.sin(dec_rad) * np.cos(ra_rad),
+            -np.sin(dec_rad) * np.sin(ra_rad),
+            np.cos(dec_rad),
+        ]
+    )
+    return rho, a, d
+
+
+@pytest.mark.parametrize(
+    "ra_deg,dec_deg",
+    [
+        (0.0, 0.0),
+        (45.0, 30.0),
+        (135.0, -20.0),
+        (10.0, 60.0),
+        (270.0, -45.0),
+        (180.0, 5.0),
+    ],
+)
+def test_a_d_vectors_are_canonical(ra_deg, dec_deg):
+    """Observation.from_astrometry must populate a_vec/d_vec with the
+    canonical equatorial-tangent vectors at ρ̂."""
+    ra = np.deg2rad(ra_deg)
+    dec = np.deg2rad(dec_deg)
+    obs = Observation.from_astrometry(ra, dec, 0.0, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+    rho_canon, a_canon, d_canon = _canonical_basis(ra, dec)
+
+    np.testing.assert_allclose(np.asarray(obs.rho_hat), rho_canon, atol=1e-12)
+    np.testing.assert_allclose(np.asarray(obs.a_vec), a_canon, atol=1e-12)
+    np.testing.assert_allclose(np.asarray(obs.d_vec), d_canon, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "ra_deg,dec_deg",
+    [
+        (45.0, 30.0),
+        (135.0, -20.0),
+        (270.0, -45.0),
+    ],
+)
+def test_a_d_vectors_form_orthonormal_tangent_frame(ra_deg, dec_deg):
+    """{a_vec, d_vec} must be unit vectors, mutually orthogonal, and
+    perpendicular to ρ̂."""
+    ra = np.deg2rad(ra_deg)
+    dec = np.deg2rad(dec_deg)
+    obs = Observation.from_astrometry(ra, dec, 0.0, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+    rho = np.asarray(obs.rho_hat)
+    a = np.asarray(obs.a_vec)
+    d = np.asarray(obs.d_vec)
+
+    assert abs(np.linalg.norm(a) - 1.0) < 1e-12
+    assert abs(np.linalg.norm(d) - 1.0) < 1e-12
+    assert abs(np.dot(a, d)) < 1e-12
+    assert abs(np.dot(rho, a)) < 1e-12
+    assert abs(np.dot(rho, d)) < 1e-12


### PR DESCRIPTION
  
This fixes an error in the A/D vectors that Adam spotted before I could fix it.
  
  `a_vec_from_rho_hat` and `d_vec_from_rho_hat` in `src/lib/detection.cpp`
  were producing **unnormalized tangent vectors of a y-pole
  parameterization** (rotated ~70-120° about ρ̂ from the canonical
  RA/Dec basis):
  
  A_old = (ρ̂_z, 0, -ρ̂_x)                     (not unit length)
  D_old = (-ρ̂_x ρ̂_y, ρ̂_x²+ρ̂_z², -ρ̂_z ρ̂_y)  (not unit length)

  These are **silent under symmetric `σ_RA = σ_Dec`** — rotation
  invariance of the diagonal weight matrix in the LM normal equations
  hides the mistake — but bias the fit whenever per-observation RA/Dec
  uncertainties differ. The basis is also degenerate at ρ̂_y = ±1
  (arbitrary point on the celestial equator) rather than the much less
  common ρ̂_z = ±1 (the actual celestial poles).

  Replaced with the canonical equatorial-tangent basis:

  A = ∂ρ̂/∂α  =  (-sin α,  cos α,  0)
  D = ∂ρ̂/∂δ  =  (-sin δ cos α,  -sin δ sin α,  cos δ)

  Both unit length, mutually orthogonal, orthogonal to ρ̂ everywhere
  except at the celestial poles.

  Adds `tests/layup/test_tangent_basis.py` (9 tests) that pin the basis
  to the canonical formulas and verify the (ρ̂, A, D) frame is
  orthonormal at representative points across the sky.

  ## Dependencies
  Stacks on `feat/pybind11-eigen-includes` (#322), which provides the
  `pybind11/eigen.h` / `pybind11/stl.h` headers required for the
  Python-side tests to access `obs.a_vec` and `obs.d_vec`.

  ## Review Checklist for Source Code Changes
  - [x] Does pip install still work?
  - [x] Have you written a unit test for any new functions? — `tests/layup/test_tangent_basis.py`
  - [x] Do all the units tests run successfully?
  - [x] Does Layup run successfully on a test set of input files/databases?
  - [x] Have you used black on the files you have updated? — C++ change; N/A
