### PR TITLE
Expose --engine flag on the layup orbitfit CLI

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -604,6 +604,7 @@ def _orbitfit(
     sort_array: bool = True,
     weight_data: bool = False,
     iod: str = "gauss",
+    engine: str = "cartesian",
 ):
     """This function will contain all of the calls to the c++ code that will
     calculate an orbit given a set of observations. Note that all observations
@@ -740,7 +741,13 @@ def _orbitfit(
         # Perform the orbit fitting
         if initial_guess is None or initial_guess["flag"] != 0:
             if iod.lower() in ["gauss"]:
-                res = do_fit(observations=observations, seq=sequence, cache_dir=kernels_loc, iod=iod.lower())
+                res = do_fit(
+                    observations=observations,
+                    seq=sequence,
+                    cache_dir=kernels_loc,
+                    iod=iod.lower(),
+                    engine=engine,
+                )
             else:
                 res = do_other_fit(iod=iod.lower())
         else:
@@ -781,6 +788,7 @@ def orbitfit(
     debias=False,
     weight_data=False,
     iod="gauss",
+    engine="cartesian",
 ):
     """This is the function that you would call interactively. i.e. from a notebook
 
@@ -830,6 +838,7 @@ def orbitfit(
         bias_dict=bias_dict,
         weight_data=weight_data,
         iod=iod,
+        engine=engine,
     )
 
 
@@ -869,6 +878,7 @@ def orbitfit_cli(
         weight_data = cli_args.weight_data
         output_orbit_format = cli_args.output_orbit_format
         iod = cli_args.iod
+        engine = getattr(cli_args, "engine", "cartesian")
     else:
         cache_dir = None
         debias = False
@@ -876,6 +886,7 @@ def orbitfit_cli(
         weight_data = False
         output_orbit_format = "COM"  # Default output orbit format.
         iod = "gauss"
+        engine = "cartesian"
 
     _primary_id_column_name = cli_args.primary_id_column_name
 
@@ -986,6 +997,7 @@ def orbitfit_cli(
             debias=debias,
             weight_data=weight_data,
             iod=iod,
+            engine=engine,
         )
 
         # Convert the fit_orbits to the preferred output format

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -79,6 +79,19 @@ def main():
         required=False,
     )
     optional.add_argument(
+        "--engine",
+        help=(
+            "LM fitter to use after IOD: 'cartesian' (default; classic "
+            "barycentric-Cartesian LM) or 'bk_native' (universal "
+            "Bernstein-Khushalani fit with energy prior, better-conditioned "
+            "for distant short-arc targets and at least as good elsewhere)."
+        ),
+        dest="engine",
+        choices=["cartesian", "bk_native"],
+        default="cartesian",
+        required=False,
+    )
+    optional.add_argument(
         "-o",
         "--output",
         help="output file stem. default path is current working directory",

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -250,6 +250,7 @@ def test_orbit_fit_cli_raises_with_unknown_iod(tmpdir):
             self.g = g  # Command line argument for initial guesses file
             self.output_orbit_format = ("BCART_EQ",)
             self.iod = "bad_iod"
+            self.engine = "cartesian"
 
     with pytest.raises(ValueError) as e:
         # Now run the orbit_fit cli with overwrite set to True
@@ -295,3 +296,38 @@ def test_orbitfit_does_not_report_success_with_nan_state():
             assert row["flag"] != 0, "fit reported success (flag == 0) with a NaN state"
         if row["flag"] == 0:
             assert not nan, "fit reported success (flag == 0) with a NaN state"
+
+
+def test_orbit_fit_cli_raises_with_unknown_engine(tmpdir):
+    """The CLI's --engine flag is validated by argparse choices, but the
+    Python-level orbitfit_cli also accepts a cli_args.engine attribute;
+    if a caller passes an unrecognized engine value, the dispatch in
+    _run_fit raises ValueError at fit time."""
+    os.chdir(tmpdir)
+    guess_file_stem = "test_guess"
+    test_input_filepath = get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv")
+
+    class FakeCliArgs:
+        def __init__(self, g=None):
+            self.ar_data_file_path = None
+            self.primary_id_column_name = "provID"
+            self.separate_flagged = False
+            self.force = False
+            self.debias = False
+            self.weight_data = False
+            self.g = g
+            self.output_orbit_format = ("BCART_EQ",)
+            self.iod = "gauss"
+            self.engine = "not_an_engine"
+
+    with pytest.raises(ValueError) as e:
+        orbitfit_cli(
+            input=test_input_filepath,
+            input_file_format="ADES_csv",
+            output_file_stem=guess_file_stem,
+            output_file_format="csv",
+            chunk_size=10_000,
+            num_workers=1,
+            cli_args=FakeCliArgs(),
+        )
+        assert "Unknown engine" in str(e.value)


### PR DESCRIPTION
This branch was developed with Claude Code, on top of an initial
implementation I had started.

Wires the `engine` choice end-to-end through `layup orbitfit`'s
command-line entry point.

## Why

PR #326 adds the universal Bernstein–Khushalani fitter as
`engine="bk_native"` on `do_fit`, but the layup-orbitfit CLI
entry point doesn't forward that argument — so even after #326
lands, running

```sh
layup orbitfit input.csv ADES_csv
```

always uses the Cartesian engine.  This PR closes that gap so the
new engine is actually reachable from the command line:

```sh
layup orbitfit input.csv ADES_csv --engine bk_native
```

## What changed

End-to-end plumbing:

```
CLI argparse --engine {cartesian, bk_native}, default 'cartesian'
  └─► orbitfit_cli reads cli_args.engine
       └─► orbitfit() takes engine= parameter
            └─► process_data_by_id forwards through **kwargs
                 └─► _orbitfit() receives engine and passes through
                      └─► do_fit(..., engine=...) (already engine-aware in #326)
                           └─► _run_fit() dispatches to the right LM
```

`argparse`'s `choices=["cartesian", "bk_native"]` gives users an
early error on a typo'd engine name; the existing `_run_fit`
dispatch also raises `ValueError` for unknown engines if a Python
caller bypasses argparse.

## Tests

- `test_orbit_fit_cli_raises_with_unknown_engine`: parallel to the
  existing unknown-iod test.  A `FakeCliArgs` with `engine="not_an_engine"`
  triggers `ValueError` from `_run_fit`'s dispatch.
- `test_orbit_fit_cli_raises_with_unknown_iod`: the existing test
  gets a `FakeCliArgs.engine = "cartesian"` field so it continues
  passing after `orbitfit_cli` starts reading that attribute.

Confirmed manually: `layup orbitfit --help` now shows

```
  --engine {cartesian,bk_native}
                        LM fitter to use after IOD: 'cartesian' (default;
                        classic barycentric-Cartesian LM) or 'bk_native'
                        (universal Bernstein-Khushalani fit with energy prior,
                        better-conditioned for distant short-arc targets and
                        at least as good elsewhere).
```

## Dependencies

Stacks on `feat/bk-everywhere` (PR #326 — adds the `engine` parameter to
`do_fit` and the `bk_native` engine itself).  This PR is purely the CLI-
plumbing follow-up.  Once #326 lands, this PR collapses to its one new
commit.

## Review Checklist for Source Code Changes
- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions? — `test_orbit_fit_cli_raises_with_unknown_engine`
- [x] Do all the units tests run successfully? — 43 BK + CLI validation tests pass locally
- [x] Does Layup run successfully on a test set of input files/databases? — `layup orbitfit --help` shows the new flag; the existing `test_orbit_fit_cli_raises_with_unknown_iod` continues to pass
- [x] Have you used black on the files you have updated?
