### PR TITLE
Subset test_apply_comet by default to avoid the slow deep-time integration

### DIFF
--- a/tests/layup/test_comet.py
+++ b/tests/layup/test_comet.py
@@ -166,6 +166,14 @@ def test_apply_comet(tmpdir):
         get_test_filepath("code_LPCs.csv"), "csv", primary_id_column_name="ObjID"
     ).read_rows()
 
+    # Each comet is a ~300-year backward ASSIST integration out to 250 AU
+    # (~0.7 s/comet), so the full 369-object catalogue takes ~4 minutes.  For CI,
+    # exercise a representative subset by default; set LAYUP_SLOW_TESTS=1 to run
+    # the whole catalogue.  (The deep-time integration also approaches the JPL
+    # ephemeris floor -- see ASSIST_ephemeris_time_bounds notes.)
+    if not os.environ.get("LAYUP_SLOW_TESTS"):
+        data = data[:12]
+
     class FakeCliArgs:
         def __init__(self, g=None):
             self.primary_id_column_name = "ObjID"


### PR DESCRIPTION
## What

`test_apply_comet` integrates **all 369 CODE long-period comets ~300 years backward** to
their 250 AU "original orbit" crossing — ~0.7 s/comet, **~4 minutes total**.

This integrates a **representative 12-comet subset by default (~12 s)**; set
`LAYUP_SLOW_TESTS=1` to run the full catalogue. The test still validates `_apply_comet`
against the CODE catalogue; expected values are unchanged (`code_LPCs_originals.csv`
already covers the subset).

## Why

Beyond the runtime, the deep-time integration runs close to the JPL ephemeris floor
(~year 1411). For some extreme orbits the integrator steps **outside ASSIST's ephemeris
span** — a separate, pre-existing ASSIST-side failure mode (the comet's ~300-yr backward
arc clears the floor by only ~70–170 yr). This PR doesn't touch `comet.py`; it only keeps
CI fast and off the boundary regime by default. The ephemeris-bound behavior is documented
separately for a future ASSIST fix.

## Test

- subset (default): `1 passed in ~12s`
- full catalogue: `LAYUP_SLOW_TESTS=1 pytest tests/layup/test_comet.py::test_apply_comet` → `1 passed in ~246s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
