### PR TITLE
Fix Linux fork+JAX worker deadlock by using the 'spawn' start method (#256)

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -1,4 +1,5 @@
 import logging
+import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
@@ -10,6 +11,23 @@ from layup.routines import FitResult
 from layup.utilities.layup_configs import LayupConfigs
 
 """ A module for utilities useful for processing data in structured numpy arrays """
+
+# Start worker processes with "spawn" rather than the platform default.
+#
+# On Linux the default start method is "fork", which clones the whole parent
+# process -- including any mutexes other threads hold at the instant of the
+# fork, in their *locked* state.  layup imports JAX (via layup.convert ->
+# orbit_conversion) at module load, and JAX/XLA runs background threads, so a
+# forked worker can inherit a permanently-locked JAX mutex and deadlock the
+# first time it touches it.  This is the cause of the ubuntu CI hangs in
+# orbit-fit/convert workflows with num_workers > 1 (see issues #256 and #302).
+#
+# "spawn" launches a fresh interpreter per worker, inheriting none of the
+# parent's locks or threads, so the deadlock cannot occur.  macOS already
+# defaults to "spawn" (which is why the hang was Linux-only); pinning it here
+# makes every platform behave the same.  ("forkserver" would also work and is
+# cheaper, but "spawn" is the most portable and matches the macOS default.)
+_MP_CONTEXT = multiprocessing.get_context("spawn")
 
 AU_M = 149597870700
 AU_KM = AU_M / 1000.0
@@ -49,7 +67,7 @@ def process_data(data, n_workers, func, **kwargs):
     # and end is the last index of the block + 1.
     blocks = [(i, min(i + block_size, len(data))) for i in range(0, len(data), block_size)]
 
-    with ProcessPoolExecutor(max_workers=n_workers) as executor:
+    with ProcessPoolExecutor(max_workers=n_workers, mp_context=_MP_CONTEXT) as executor:
         # Create a future applying the function to each block of data
         futures = [executor.submit(func, data[start:end], **kwargs) for start, end in blocks]
         # Concatenate all processed blocks together as our final result
@@ -90,7 +108,7 @@ def process_data_by_id(data, n_workers, func, primary_id_column_name, **kwargs):
         return data
 
     kwargs["primary_id_column_name"] = primary_id_column_name
-    with ProcessPoolExecutor(max_workers=n_workers) as executor:
+    with ProcessPoolExecutor(max_workers=n_workers, mp_context=_MP_CONTEXT) as executor:
         # Create a future applying the function to each block of data for a given object id
         futures = [
             executor.submit(func, data[data[primary_id_column_name] == id], **kwargs)

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -30,9 +30,7 @@ SPEED_OF_LIGHT = 2.99792458e8 * 86400.0 / AU_M
     [
         (100_000, 1, "BCART_EQ"),
         (100_000, 1, "COM"),
-        # num_workers=2 exercises the multi-worker fit->convert path that used
-        # to hang the ubuntu runner (#256).  #255 dropped this to 1 as a
-        # bandaid; restored now that the spawn start method fixes the deadlock.
+        # num_workers=2 exercises the multi-worker fit->convert path
         (100_000, 2, "KEP"),
     ],
 )

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -30,7 +30,10 @@ SPEED_OF_LIGHT = 2.99792458e8 * 86400.0 / AU_M
     [
         (100_000, 1, "BCART_EQ"),
         (100_000, 1, "COM"),
-        (100_000, 1, "KEP"),
+        # num_workers=2 exercises the multi-worker fit->convert path that used
+        # to hang the ubuntu runner (#256).  #255 dropped this to 1 as a
+        # bandaid; restored now that the spawn start method fixes the deadlock.
+        (100_000, 2, "KEP"),
     ],
 )
 def test_orbit_fit_cli(tmpdir, chunk_size, num_workers, output_orbit_format):


### PR DESCRIPTION
## Summary
The ubuntu CI runner intermittently **hangs** in orbit-fit / convert workflows with `num_workers > 1` (issue #256). This is the classic *fork-in-a-multithreaded-process* deadlock.

`ProcessPoolExecutor` was created with the platform-default start method, which on **Linux is `fork`**. `fork()` clones the whole parent process — including any mutex another thread holds at the instant of the fork, in its **locked** state. `orbitfit` imports JAX (via `layup.convert` → `orbit_conversion`) at module load, and JAX/XLA runs background threads, so a forked worker can inherit a permanently-locked JAX mutex and deadlock the first time it touches it. CPython's *"os.fork() … JAX is multithreaded … will likely lead to a deadlock"* `RuntimeWarning` (#302) is the same root cause.

macOS already defaults to **`spawn`**, which is exactly why the hang was Linux-only.

## Changes
- Pin both `ProcessPoolExecutor` sites in `data_processing_utilities.py` to a **`spawn`** context, so every platform launches a fresh interpreter per worker — inheriting none of the parent's locks or threads, so the deadlock cannot occur. (`forkserver` would also work and is cheaper, since it forks workers from a clean single-threaded helper; `spawn` is the most portable and matches the macOS default. Easy to switch if the team prefers `forkserver`.)
- Revert #255's test-only bandaid (`num_workers` `1 → 2` in `test_orbit_fit_cli`) so the multi-worker fit→convert path is exercised again.

## Verification
On a fresh build:
- `test_orbit_fit_cli[num_workers=2]` (the reverted #255 case, i.e. the exact #256 scenario) — passes.
- `test_data_processing_utilities` with `n_workers ∈ {1,2,4,8}` — 39 passed.
- In-process predict tests — pass.

Note: macOS already used `spawn`, so local macOS runs confirm the explicit context doesn't break the multi-worker paths; the Linux deadlock resolution itself is validated by the ubuntu CI legs on this PR. (Corroborating data point: on a recent PR the same commit hung on `ubuntu-3.14` once and passed on re-run — the nondeterministic race this change eliminates.)

Closes #256. Related: #302 (same root cause), #255 (bandaid reverted here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)