### PR TITLE
Cache SPICE kernels + MPC obscodes in CI to survive upstream outages

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -29,6 +29,16 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+    # Cache the SPICE kernels + MPC obscodes that `layup bootstrap` and the
+    # tests download, so a transient outage of naif.jpl.nasa.gov or
+    # minorplanetcenter.net does not fail the run. See testing-and-coverage.yml.
+    - name: Cache layup ephemeris + obscodes data
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/layup
+          ~/Library/Caches/layup
+        key: layup-data-${{ runner.os }}-v1
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -24,6 +24,21 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+    # `layup bootstrap` and the observatory tests download the SPICE kernels
+    # and the MPC obscodes into pooch's os_cache ("layup"). Without a cache
+    # every leg of every run re-fetches these from naif.jpl.nasa.gov and
+    # minorplanetcenter.net, so a transient outage of either server fails the
+    # run (this has repeatedly taken down the ubuntu legs). Cache that data so
+    # it is fetched once per key and restored on subsequent runs. The data is
+    # Python-version independent, so the key is per-OS only -- the 3.13 and
+    # 3.14 legs share one cache. Bump the version suffix to force a refresh.
+    - name: Cache layup ephemeris + obscodes data
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/layup
+          ~/Library/Caches/layup
+        key: layup-data-${{ runner.os }}-v1
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
Every CI leg runs `layup bootstrap` (downloads SPICE kernels from `naif.jpl.nasa.gov`) and the observatory tests download the MPC obscodes from `minorplanetcenter.net` — both into pooch's `os_cache("layup")`. With **no caching**, every leg of every run re-fetches them, so a transient outage of either upstream server fails the run. This has repeatedly taken down the `ubuntu-latest 3.13` leg: `ConnectTimeout` to NAIF during `layup bootstrap`, and to the MPC during the tests.

## Changes
Add an `actions/cache@v4` step (in both `testing-and-coverage.yml` and `smoke-test.yml`), before *Install dependencies*, covering pooch's cache dir:

```yaml
- name: Cache layup ephemeris + obscodes data
  uses: actions/cache@v4
  with:
    path: |
      ~/.cache/layup           # Linux
      ~/Library/Caches/layup   # macOS
    key: layup-data-${{ runner.os }}-v1
```

One cache covers **both** the SPICE kernels and the obscodes (both land in `pooch.os_cache("layup")`). The data is Python-version independent, so the key is **per-OS only** — the 3.13 and 3.14 legs share one cache. Bump the `v1` suffix to force a refresh.

## Effect
After the first successful population, runs **restore** the kernels + obscodes instead of hitting NAIF/MPC, so transient upstream outages stop failing CI. Composes with #337 (bundled obscodes fallback) for defense in depth.

## Caveats
- Helps from the **2nd run onward**; the first population still downloads (and with `max-parallel: 4` the four legs cold-miss together once). The bundled fallbacks cover the first-population-during-outage case for obscodes (#337); the SPICE kernels could get a similar fallback later.
- A GitHub Actions cache can only be exercised on GitHub, so this PR's own CI is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)