### PR TITLE
Fix #286: handle observatories with zero-valued parallax constants

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -320,6 +320,44 @@ class LayupObservatory(SorchaObservatory):
         # A cache of barycentric positions for observatories of the form {obscode: {et: (x, y, z)}}
         self.cached_obs = {}
 
+    def convert_to_geocentric(self, obs_location: dict) -> tuple:
+        """Convert an observatory's parallax constants to geocentric coordinates.
+
+        This overrides Sorcha's ``Observatory.convert_to_geocentric``, which gates
+        on the truthiness of the parallax constants
+        (``obs_location.get("sin", False)``). A constant that is legitimately
+        ``0.0`` -- e.g. the geocenter (codes 500/244/248: Longitude=cos=sin=0),
+        Greenwich (code 000: Longitude=0), or an equatorial station such as Quito
+        (code 782: sin=0) -- is falsy, so the base class wrongly reports the
+        observatory as having no fixed position. Layup then routes it to the
+        moving-observatory path and raises "invalid coordinates" for plain MPC
+        input that carries no per-observation position (issue #286).
+
+        We instead test for the *presence* of the constants. Codes that have no
+        position keys at all (roving observer 247, space telescopes WISE/TESS/HST,
+        ...) still return ``(None, None, None)`` and are correctly routed to the
+        ADES per-observation position path. The geocenter resolves to a (0, 0, 0)
+        offset from Earth's center, which is exactly right.
+
+        Parameters
+        ----------
+        obs_location : dict
+            Dictionary with Longitude and the sin/cos of the observatory latitude.
+
+        Returns
+        -------
+        tuple
+            Geocentric position (x, y, z), or (None, None, None) when the
+            observatory has no fixed position.
+        """
+        longitude = obs_location.get("Longitude")
+        cos = obs_location.get("cos")
+        sin = obs_location.get("sin")
+        if longitude is not None and cos is not None and sin is not None:
+            longitude_rad = longitude * np.pi / 180.0
+            return (cos * np.cos(longitude_rad), cos * np.sin(longitude_rad), sin)
+        return (None, None, None)
+
     def create_obscode_cache_key(self, obscode, et):
         """
         Create a cache key for the observatory coordinates.

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -299,6 +299,41 @@ def test_moving_observatory_coordinate_cache():
             observatory.populate_observatory(obscode, et, row_inconsistent)
 
 
+def test_fixed_observatory_with_zero_parallax_constant():
+    """Regression test for issue #286.
+
+    Observatories whose parallax constants are legitimately 0.0 must still be
+    treated as fixed-position observatories. The previous truthiness check
+    treated a 0.0 Longitude/cos/sin as "no position", which routed these codes
+    to the moving-observatory path and raised "invalid coordinates" for plain
+    MPC input that carries no per-observation position.
+    """
+    observatory = LayupObservatory()
+
+    # Codes that have parallax-constant keys (possibly 0.0) must resolve to a
+    # finite fixed position. The geocenter codes resolve to (0, 0, 0).
+    fixed_with_zero = {
+        "000": None,  # Greenwich: Longitude == 0.0
+        "782": None,  # Quito (equatorial): sin == 0.0
+        "500": (0.0, 0.0, 0.0),  # Geocentric: Longitude == cos == sin == 0.0
+        "244": (0.0, 0.0, 0.0),  # Geocentric Occultation Observation
+        "248": (0.0, 0.0, 0.0),  # Hipparcos
+    }
+    for obscode, expected in fixed_with_zero.items():
+        coords = observatory.ObservatoryXYZ.get(obscode)
+        assert coords is not None
+        assert None not in coords, f"{obscode} wrongly treated as having no fixed position"
+        assert not np.isnan(np.asarray(coords, dtype=float)).any()
+        if expected is not None:
+            assert np.allclose(coords, expected)
+
+    # Codes with no parallax-constant keys (roving observer, space telescopes)
+    # must still report no fixed position so they take the ADES-position path.
+    for obscode in ("247", "C51", "C57", "250"):
+        coords = observatory.ObservatoryXYZ.get(obscode)
+        assert coords == (None, None, None)
+
+
 def test_get_format():
     """Test that the get_format function works for a small CSV file."""
     input_file = get_test_filepath("BCOM.csv")


### PR DESCRIPTION
## Summary

Fixes #286. `layup orbitfit` crashed with `ValueError: Observatory <code> has invalid coordinates` for several real observatory codes — most importantly the common **geocentric code 500**, plus **000 (Greenwich)**, **782 (Quito)**, and **244/248**.

## Root cause

The crash originates in Sorcha's `Observatory.convert_to_geocentric` (`simulation_parsing.py`), which gates on the **truthiness** of the parallax constants:

```python
if (obs_location.get("Longitude", False)
    and obs_location.get("cos", False)
    and obs_location.get("sin", False)):
```

A parallax constant that is legitimately `0.0` is falsy, so the observatory is wrongly reported as having no fixed position. Layup then routes it to the moving-observatory path, which demands per-observation `pos1/2/3` fields and raises for plain MPC input that carries none. The affected codes all have a constant that is exactly `0.0`:

| code | name | zero constant |
|------|------|---------------|
| 500 / 244 / 248 | Geocentric / Occultation / Hipparcos | Longitude = cos = sin = 0 |
| 000 | Greenwich | Longitude = 0 |
| 782 | Quito (equatorial) | sin = 0 |

## Fix

Override `convert_to_geocentric` in `LayupObservatory` to test for the **presence** of the constants (`is not None`) rather than their truthiness. Since `super().__init__` calls `self.convert_to_geocentric`, the override is used when the observatory table is built — no upstream release needed.

- Codes with no position keys at all (roving observer 247, space telescopes WISE/TESS/HST) still return `(None, None, None)` and correctly take the ADES per-observation position path.
- The geocenter resolves to a `(0, 0, 0)` offset from Earth's center, which is exactly right.

The same bug should also be fixed upstream in Sorcha (a separate one-line PR); this override makes layup correct immediately and is robust regardless of the installed Sorcha version.

## Verification

- New regression test `test_fixed_observatory_with_zero_parallax_constant` — passes with the fix, **fails without it**.
- Full `tests/layup/test_data_processing_utilities.py`: **40 passed**.
- End-to-end: a geocentric `500` observation now flows through `obscodes_to_barycentric` and resolves to Earth's barycentric position; Greenwich `000` lands exactly one Earth radius (4.25e-5 AU) from the geocenter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
