### PR TITLE
Fix angle-covariance units in convert (degrees, not radians)

### DIFF
--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -45,6 +45,19 @@ degree_columns = {
     "KEP": ["inc", "node", "argPeri", "ma"],
 }
 
+# Ordered 6-element state for each format; the index of an element here is also
+# its row/column index in the 6x6 covariance. Used to scale the covariance of
+# the degree columns when their values are converted from radians to degrees.
+element_order = {
+    "BCART": ["x", "y", "z", "xdot", "ydot", "zdot"],
+    "BCART_EQ": ["x", "y", "z", "xdot", "ydot", "zdot"],
+    "CART": ["x", "y", "z", "xdot", "ydot", "zdot"],
+    "BCOM": ["q", "e", "inc", "node", "argPeri", "t_p_MJD_TDB"],
+    "COM": ["q", "e", "inc", "node", "argPeri", "t_p_MJD_TDB"],
+    "BKEP": ["a", "e", "inc", "node", "argPeri", "ma"],
+    "KEP": ["a", "e", "inc", "node", "argPeri", "ma"],
+}
+
 # Add this to MJD to convert to JD
 MJD_TO_JD_CONVERSTION = 2400000.5
 
@@ -175,6 +188,24 @@ def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None
         (col, dtype)
         for col, dtype in zip(required_colum_names[convert_to], default_column_dtypes, strict=False)
     ]
+
+    # A stored degree-format orbit carries its covariance in degrees (consistent
+    # with its degree-valued angles). The conversion math below works in radians
+    # (parse_covariance_row_to_CART and the element-value parsing use radians), so
+    # scale the angle rows/cols of the input covariance back to radians first.
+    # This mirrors the radians->degrees output scaling and keeps round-trips exact.
+    if has_covariance:
+        data = data.copy()
+        for fmt in degree_columns:
+            mask = data["FORMAT"] == fmt
+            if not mask.any():
+                continue
+            input_scale = np.ones(6)
+            for col in degree_columns[fmt]:
+                input_scale[element_order[fmt].index(col)] = np.pi / 180
+            for i in range(6):
+                for j in range(6):
+                    data[f"cov_{i}_{j}"][mask] *= input_scale[i] * input_scale[j]
 
     # For each row in the data, convert the orbit to the desired format
     results = []
@@ -342,6 +373,20 @@ def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None
     for col in degree_columns.get(convert_to, []):
         # Convert from radians to degrees and wrap to [0, 360)
         output[col] = (output[col] * 180 / np.pi) % 360
+
+    # The covariance is propagated in radians, so the rows/columns of any
+    # element whose value was just converted to degrees must be scaled by
+    # 180/pi to stay consistent with the (now degree-valued) state. Without
+    # this, the reported angular uncertainties are too small by 180/pi (their
+    # variances by (180/pi)^2). Round-trip conversions hide this because the
+    # inverse conversion undoes both the value and the covariance scaling.
+    if has_covariance and convert_to in degree_columns:
+        scale = np.ones(6)
+        for col in degree_columns[convert_to]:
+            scale[element_order[convert_to].index(col)] = 180 / np.pi
+        for i in range(6):
+            for j in range(6):
+                output[f"cov_{i}_{j}"] = output[f"cov_{i}_{j}"] * scale[i] * scale[j]
 
     return output
 

--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -46,8 +46,10 @@ degree_columns = {
 }
 
 # Ordered 6-element state for each format; the index of an element here is also
-# its row/column index in the 6x6 covariance. Used to scale the covariance of
-# the degree columns when their values are converted from radians to degrees.
+# its row/column index in the 6x6 covariance. This ordering MUST match the basis
+# of the covariance produced by the conversion routines (covariance_*_xyz /
+# parse_covariance_row_to_CART); _scale_degree_cov relies on it, and
+# test_element_order_matches_degree_columns guards the dict from drifting.
 element_order = {
     "BCART": ["x", "y", "z", "xdot", "ydot", "zdot"],
     "BCART_EQ": ["x", "y", "z", "xdot", "ydot", "zdot"],
@@ -57,6 +59,30 @@ element_order = {
     "BKEP": ["a", "e", "inc", "node", "argPeri", "ma"],
     "KEP": ["a", "e", "inc", "node", "argPeri", "ma"],
 }
+
+
+def _scale_degree_cov(arr, fmt, factor, mask=None):
+    """Congruence-scale the flattened 6x6 covariance of a structured array.
+
+    Applies ``diag(s) C diag(s)`` where ``s`` is ``factor`` on each of
+    ``fmt``'s degree columns and 1 elsewhere -- i.e. the covariance transform
+    for rescaling those state elements by ``factor``. Pass ``factor = 180/pi``
+    when the matching state values were just converted radians->degrees, or
+    ``pi/180`` for the inverse. Restricted to rows in ``mask`` when given,
+    else applied to the whole column.
+
+    Relies on the invariant that ``element_order[fmt]`` indexes the ``cov_i_j``
+    rows/cols (see element_order; guarded by
+    test_element_order_matches_degree_columns).
+    """
+    s = np.ones(6)
+    for col in degree_columns[fmt]:
+        s[element_order[fmt].index(col)] = factor
+    sel = slice(None) if mask is None else mask
+    for i in range(6):
+        for j in range(6):
+            arr[f"cov_{i}_{j}"][sel] *= s[i] * s[j]
+
 
 # Add this to MJD to convert to JD
 MJD_TO_JD_CONVERSTION = 2400000.5
@@ -204,12 +230,10 @@ def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None
             mask = data["FORMAT"] == fmt
             if not mask.any():
                 continue
-            input_scale = np.ones(6)
-            for col in degree_columns[fmt]:
-                input_scale[element_order[fmt].index(col)] = np.pi / 180
-            for i in range(6):
-                for j in range(6):
-                    data[f"cov_{i}_{j}"][mask] *= input_scale[i] * input_scale[j]
+            # Input values for this format are in degrees; rescale the
+            # covariance of those elements back to radians (pi/180) for the
+            # rows of this format before conversion.
+            _scale_degree_cov(data, fmt, np.pi / 180, mask=mask)
 
     # For each row in the data, convert the orbit to the desired format
     results = []
@@ -385,12 +409,10 @@ def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None
     # variances by (180/pi)^2). Round-trip conversions hide this because the
     # inverse conversion undoes both the value and the covariance scaling.
     if has_covariance and convert_to in degree_columns:
-        scale = np.ones(6)
-        for col in degree_columns[convert_to]:
-            scale[element_order[convert_to].index(col)] = 180 / np.pi
-        for i in range(6):
-            for j in range(6):
-                output[f"cov_{i}_{j}"] = output[f"cov_{i}_{j}"] * scale[i] * scale[j]
+        # Mirror the value conversion directly above (radians->degrees), which
+        # operates on the whole column, so scale the covariance whole-column
+        # too (no row mask) to keep values and covariance consistent.
+        _scale_degree_cov(output, convert_to, 180 / np.pi)
 
     return output
 

--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -195,7 +195,11 @@ def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None
     # scale the angle rows/cols of the input covariance back to radians first.
     # This mirrors the radians->degrees output scaling and keeps round-trips exact.
     if has_covariance:
-        data = data.copy()
+        # Copy, and ensure the covariance columns are float: a CSV of all-zero
+        # placeholder covariances may be read as int, which an in-place float
+        # multiply cannot cast into under numpy's same-kind rule.
+        cov_cols = set(get_cov_columns())
+        data = data.astype([(n, "f8" if n in cov_cols else data.dtype[n]) for n in data.dtype.names])
         for fmt in degree_columns:
             mask = data["FORMAT"] == fmt
             if not mask.any():

--- a/tests/layup/test_convert.py
+++ b/tests/layup/test_convert.py
@@ -367,3 +367,26 @@ def test_convert_covariance_angle_units():
             f"{fmt} covariance is inconsistent with the finite-difference Jacobian "
             f"(rel.err {rel_err:.2e}) -- angle covariance likely in the wrong units"
         )
+
+
+def test_element_order_matches_degree_columns():
+    """Guard the hand-synced invariant _scale_degree_cov relies on.
+
+    `_scale_degree_cov` maps each degree column to a covariance row/col via
+    `element_order[fmt].index(col)`. If `degree_columns` and `element_order`
+    drift apart the lookup either raises or silently scales the wrong row, so
+    pin: every degree format is in element_order, each of its degree columns is
+    present there, and every element_order entry is a unique 6-vector (so the
+    index is a valid 0..5 covariance position). The *numerical* basis match is
+    covered by test_convert_covariance_angle_units.
+    """
+    from layup.convert import degree_columns, element_order
+
+    for fmt, cols in degree_columns.items():
+        assert fmt in element_order, f"{fmt} in degree_columns but not element_order"
+        order = element_order[fmt]
+        assert len(order) == 6, f"element_order[{fmt}] is not a 6-vector: {order}"
+        assert len(set(order)) == 6, f"element_order[{fmt}] has duplicates: {order}"
+        for col in cols:
+            assert col in order, f"degree column {col!r} missing from element_order[{fmt}]"
+            assert 0 <= order.index(col) <= 5

--- a/tests/layup/test_convert.py
+++ b/tests/layup/test_convert.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
 
@@ -318,3 +319,51 @@ def test_convert_round_trip_hdf5(tmpdir, chunk_size, num_workers):
                 output_data_BCOM[column_name],
                 err_msg=f"Column {column_name} not equal with dtype {input_data_BCOM[column_name].dtype}",
             )
+
+
+def test_convert_covariance_angle_units():
+    """Covariance of degree-valued angle elements must be in degrees^2.
+
+    convert() reports the angular elements (inc, node, argPeri, ma) in degrees.
+    Their covariance must be in degrees^2 to match. Regression test for a bug
+    where the angle *values* were converted radians->degrees but their
+    covariance was left in radians^2, making the reported angular uncertainties
+    too small by 180/pi (their variances by (180/pi)^2 ~ 3283x). The existing
+    round-trip tests miss this because the inverse conversion undoes both the
+    value and the covariance scaling; here we check the forward covariance
+    against a finite-difference Jacobian of the conversion.
+    """
+    data = CSVDataReader(
+        get_test_filepath("test_convert_BCART_EQ.csv"), "csv", primary_id_column_name="provID"
+    ).read_rows()
+    data = np.atleast_1d(data)
+    state_cols = ["x", "y", "z", "xdot", "ydot", "zdot"]
+    s0 = np.array([data[c][0] for c in state_cols])
+    cov_bcart = np.array([[data[f"cov_{i}_{j}"][0] for j in range(6)] for i in range(6)])
+
+    for fmt, elem_cols in [
+        ("KEP", ["a", "e", "inc", "node", "argPeri", "ma"]),
+        ("COM", ["q", "e", "inc", "node", "argPeri", "t_p_MJD_TDB"]),
+    ]:
+        conv = convert(data, fmt, num_workers=1, primary_id_column_name="provID")
+        cov_analytic = np.array([[conv[f"cov_{i}_{j}"][0] for j in range(6)] for i in range(6)])
+
+        # Finite-difference Jacobian d(format element)/d(BCART_EQ state).
+        jac = np.zeros((6, 6))
+        for k in range(6):
+            h = 1e-7 * max(abs(s0[k]), 1e-3 if k < 3 else 1e-5)
+            dp = data.copy()
+            dp[state_cols[k]][0] = s0[k] + h
+            dm = data.copy()
+            dm[state_cols[k]][0] = s0[k] - h
+            cp = convert(dp, fmt, num_workers=1, primary_id_column_name="provID")
+            cm = convert(dm, fmt, num_workers=1, primary_id_column_name="provID")
+            for r in range(6):
+                jac[r, k] = (cp[elem_cols[r]][0] - cm[elem_cols[r]][0]) / (2 * h)
+
+        cov_fd = jac @ cov_bcart @ jac.T
+        rel_err = np.linalg.norm(cov_analytic - cov_fd) / np.linalg.norm(cov_fd)
+        assert rel_err < 1e-3, (
+            f"{fmt} covariance is inconsistent with the finite-difference Jacobian "
+            f"(rel.err {rel_err:.2e}) -- angle covariance likely in the wrong units"
+        )


### PR DESCRIPTION
## Summary

`convert()` reports the angular orbital elements (`inc`, `node`, `argPeri`, and `ma` for KEP/BKEP) in **degrees**, but left their **covariance in radians²** — the angle *values* were scaled radians→degrees while the covariance was not. So the reported angular uncertainties were too small by **180/π** (variances by **(180/π)² ≈ 3283×**) and inconsistent with the state they accompany. This affects every degree-bearing output format: **COM, BCOM, KEP, BKEP** — i.e. the human-readable orbit outputs.

## Why it wasn't caught

The existing round-trip tests (`BCART → format → BCART`) miss it: the inverse conversion reads the covariance back assuming radians, so the inconsistency cancels and the Cartesian covariance returns unchanged (`~6e-14`). The bug only shows up if you look at the *reported* covariance of a degree-format orbit, which no test did.

Found via a finite-difference audit of convert's covariance across formats and regimes:

| format | analytic-vs-FD rel.err (before) | (after) |
|--------|---------------------------------|---------|
| BCART / CART | ~1e-9 ✓ | ~1e-9 |
| COM / BCOM | ~8e-3 ✗ | ~4e-10 |
| **KEP / BKEP** | **~1.0 (100%)** ✗ | ~1e-9 |

## Fix

Scale the covariance rows/columns of each degree element symmetrically: by **180/π on output**, and by **π/180 when reading a degree-format orbit back in**, so the covariance is always in the same units as the state while the conversion math stays in radians. Round-trips remain exact (`~6e-14`).

## Test

`test_convert_covariance_angle_units` — a **forward** finite-difference check of the reported covariance against the conversion Jacobian (the round-trip tests structurally cannot catch this). Fails by ~100% without the fix; passes at ~1e-9 with it. Full convert suite: 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
