### PR TITLE
Fix orbit_fit reporting success (flag=0) on a NaN solution

### DIFF
--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -499,14 +499,22 @@ namespace orbit_fit
 
     int converged(Eigen::MatrixXd dX, double eps, double chi2, size_t ndof, double thresh)
     {
-
+        // A NaN chi-square or step means the fit has diverged, not converged.
+        // Without this guard the loop below reports convergence on a NaN step,
+        // because abs(NaN) > eps is false for every element, so the function
+        // falls through to "return 1" -- making orbit_fit report flag = 0
+        // (success) for a NaN solution.
+        if (std::isnan(chi2))
+        {
+            return 0;
+        }
         if ((chi2 > ndof) > thresh)
         {
             return 2;
         }
         for (size_t i = 0; i < dX.size(); i++)
         {
-            if (abs(dX(i)) > eps)
+            if (std::isnan(dX(i)) || abs(dX(i)) > eps)
             {
                 return 0;
             }
@@ -623,6 +631,16 @@ namespace orbit_fit
             compute_dX(resid_vec, partials_vec, W, dX, C, chi2, grad, lambda);
 
             double chi2_d = chi2(0, 0);
+
+            // A NaN chi-square means the fit has diverged (e.g. from a
+            // degenerate IOD seed on a too-short tracklet). Stop immediately,
+            // leaving flag != 0, so the result is reported as a failure rather
+            // than grinding through every remaining iteration on NaNs.
+            if (std::isnan(chi2_d))
+            {
+                chi2_final = chi2_d;
+                break;
+            }
 
             double rho = (chi2_prev - chi2_d) / (dX.transpose() * (lambda * dX - grad)).norm();
 

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -263,3 +263,34 @@ def test_orbit_fit_cli_raises_with_unknown_iod(tmpdir):
         )
 
         assert "The IOD, bad_iod is not supported" in str(e.value)
+
+
+def test_orbitfit_does_not_report_success_with_nan_state():
+    """A fit that cannot be solved must report failure, never success with NaN.
+
+    Regression test for converged(): a NaN Levenberg-Marquardt step was treated
+    as convergence (abs(NaN) > eps is false for every component, so the function
+    fell through to "converged"), which made orbit_fit return flag == 0 on a NaN
+    solution. The short single-night tracklets in this fixture have a degenerate
+    IOD seed and cannot be solved, so they exercise that path.
+    """
+    pid = "orbitID"
+    data = CSVDataReader(
+        get_test_filepath("streak_observations_complete.csv"), "csv", primary_id_column_name=pid
+    ).read_rows()
+    fitted = orbitfit(data, cache_dir=None, primary_id_column_name=pid)
+
+    state_cols = ["x", "y", "z", "xdot", "ydot", "zdot"]
+    has_nan = [not np.all(np.isfinite([row[c] for c in state_cols])) for row in fitted]
+
+    # The fixture must still exercise a degenerate (NaN-producing) fit, otherwise
+    # this test isn't checking anything.
+    assert any(has_nan), "fixture no longer produces a degenerate fit"
+
+    # Any fit with a NaN state MUST be reported as a failure (flag != 0); and
+    # equivalently, a successful fit (flag == 0) must have a finite state.
+    for row, nan in zip(fitted, has_nan):
+        if nan:
+            assert row["flag"] != 0, "fit reported success (flag == 0) with a NaN state"
+        if row["flag"] == 0:
+            assert not nan, "fit reported success (flag == 0) with a NaN state"


### PR DESCRIPTION
## Summary

`orbit_fit` could report **`flag = 0` (success) with a NaN state**. When the Levenberg–Marquardt step `dX` (or the chi-square) is NaN — e.g. from a degenerate Gauss IOD seed on a too-short single tracklet — the fit returned `flag = 0` after `niter = 0` iterations, with a NaN state vector.

**Root cause** — `converged()`:
```cpp
for (size_t i = 0; i < dX.size(); i++)
    if (abs(dX(i)) > eps) { return 0; }   // abs(NaN) > eps is FALSE for every i
return 1;                                  // ...so it falls through to "converged"
```
A NaN step never trips `abs(dX(i)) > eps`, so the function returns `1` (converged) on the first iteration; the loop sets `flag = 0` and breaks.

This is **not streak-specific** (a degenerate astrometry tracklet does it too) and it's **silent**: any consumer that trusts `flag == 0` (predict, the JPL-validation tests, even the sub-24h-arc warning which only fires on `flag != 0`) treats the NaN orbit as a valid fit. It was found while auditing the streak path, where the existing test only checks the *count* of returned orbits and so never caught it.

## Fix

- `converged()` returns *not*-converged (`0`) when `chi2` or any `dX` component is NaN.
- The LM loop **breaks immediately on a NaN chi-square**, leaving `flag != 0`, so a diverged fit fails **fast (~0.05s)** instead of grinding every iteration on NaNs (~1.2s) — and never reports success.

A degenerate tracklet now returns `flag = 3` (failure) with a NaN state instead of `flag = 0`. **Normal fits are unaffected** — the guards only trigger on NaN (verified: a normal MBA fit still converges to `flag = 0`, and `test_orbit_fit`/`test_convert` pass unchanged).

## Test

`test_orbitfit_does_not_report_success_with_nan_state` — any fit with a NaN state must have `flag != 0`. Fails against the previous behavior, passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
