### PR TITLE
Rename data_weight_Veres2017 -> astrometric_uncertainty_Veres2017

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -30,7 +30,7 @@ except ImportError:  # extension not rebuilt yet
 from layup.convert import convert
 from layup.iod import filter_candidates_by_residual, get_iod, iod_methods
 
-from layup.utilities.astrometric_uncertainty import data_weight_Veres2017
+from layup.utilities.astrometric_uncertainty import astrometric_uncertainty_Veres2017
 from layup.utilities.data_processing_utilities import (
     LayupObservatory,
     create_chunks,
@@ -712,19 +712,19 @@ def _orbitfit(
                 )
 
             if weight_data:
-                # data_weight_Veres2017 returns the astrometric uncertainty in
+                # astrometric_uncertainty_Veres2017 returns the astrometric uncertainty in
                 # ARCSECONDS (per its docstring), but Observation.ra_unc /
                 # dec_unc are stored in RADIANS.  Convert at the assignment.
-                data_weight_arcsec = data_weight_Veres2017(
+                sigma_arcsec = astrometric_uncertainty_Veres2017(
                     obsCode=d["stn"],
                     jd_tdb=convert_tdb_date_to_julian_date(d["obsTime"], cache_dir),
                     catalog=d["astCat"] if astcat_column_present else None,
                     program=d["program"] if program_column_present else None,
                 )
-                data_weight_rad = data_weight_arcsec * np.pi / (180.0 * 3600.0)
+                sigma_rad = sigma_arcsec * np.pi / (180.0 * 3600.0)
 
-                o.ra_unc = data_weight_rad
-                o.dec_unc = data_weight_rad
+                o.ra_unc = sigma_rad
+                o.dec_unc = sigma_rad
 
             observations.append(o)
 

--- a/src/layup/utilities/astrometric_uncertainty.py
+++ b/src/layup/utilities/astrometric_uncertainty.py
@@ -3,11 +3,13 @@ EARLY_691_JD = 2452640.5
 EARLY_644_JD = 2452883.5
 
 
-def data_weight_Veres2017(obsCode, jd_tdb, catalog=None, program=None):
-    """Return data weighting given an observatory, Julian date, and optionally
-    catalog and program. The weighting is based on the work of Veres et al.
+def astrometric_uncertainty_Veres2017(obsCode, jd_tdb, catalog=None, program=None):
+    """Return the astrometric uncertainty (sigma, in arcseconds) for an
+    observatory, Julian date, and optionally catalog and program, based on the
+    work of Veres et al. This is a one-sigma uncertainty, not a 1/sigma^2
+    weight -- the fit squares-and-inverts it into the weight matrix.
 
-    See: Veres et al. 20217 https://arxiv.org/pdf/1703.03479
+    See: Veres et al. 2017 https://arxiv.org/pdf/1703.03479
 
     Parameters
     ----------
@@ -26,109 +28,116 @@ def data_weight_Veres2017(obsCode, jd_tdb, catalog=None, program=None):
         Astrometric uncertainty in arcseconds
     """
 
-    dw = 1.5
+    sigma_arcsec = 1.5
     if obsCode == "703":
         if jd_tdb <= EARLY_703_JD:
-            dw = 1.0
+            sigma_arcsec = 1.0
         else:
-            dw = 0.8
+            sigma_arcsec = 0.8
     elif obsCode == "691":
         if jd_tdb <= EARLY_691_JD:
-            dw = 0.6
+            sigma_arcsec = 0.6
         else:
-            dw = 0.5
+            sigma_arcsec = 0.5
     elif obsCode == "644":
         if jd_tdb <= EARLY_644_JD:
-            dw = 0.6
+            sigma_arcsec = 0.6
         else:
-            dw = 0.4
+            sigma_arcsec = 0.4
     elif obsCode == "704":
-        dw = 1.0
+        sigma_arcsec = 1.0
     elif obsCode == "G96":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "F51":
-        dw = 0.2
+        sigma_arcsec = 0.2
     elif obsCode == "G45":
-        dw = 0.6
+        sigma_arcsec = 0.6
     elif obsCode == "699":
-        dw = 0.8
+        sigma_arcsec = 0.8
     elif obsCode == "D29":
-        dw = 0.75
+        sigma_arcsec = 0.75
     elif obsCode == "C51":
-        dw = 1.0
+        sigma_arcsec = 1.0
     elif obsCode == "E12":
-        dw = 0.75
+        sigma_arcsec = 0.75
     elif obsCode == "608":
-        dw = 0.6
+        sigma_arcsec = 0.6
     elif obsCode == "J75":
-        dw = 1.0
+        sigma_arcsec = 1.0
     elif obsCode == "645":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "673":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "689":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "950":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "H01":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "J04":
-        dw = 0.4
+        sigma_arcsec = 0.4
     elif obsCode == "W84":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "645":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "G83" and program == "2":
         if catalog:
             if catalog in ["UCAC4", "PPMXL"]:
-                dw = 0.3
+                sigma_arcsec = 0.3
             elif catalog in ["Gaia1", "Gaia2", "Gaia3", "Gaia3E"]:
-                dw = 0.2
+                sigma_arcsec = 0.2
             else:
-                dw = 0.3
+                sigma_arcsec = 0.3
         else:
-            dw = 1.0
+            sigma_arcsec = 1.0
     elif obsCode in ["K92", "K93", "Q63", "Q64", "V37", "W84", "W85", "W86", "W87", "K91", "E10", "F65"]:
-        dw = 0.4  # Careful with W84
+        sigma_arcsec = 0.4  # Careful with W84
     elif obsCode == "Y28":
         if catalog:
             if catalog in ["PPMXL", "Gaia1"]:
-                dw = 0.3
+                sigma_arcsec = 0.3
             else:
-                dw = 1.5
+                sigma_arcsec = 1.5
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif obsCode == "568":
         if catalog:
             if catalog in ["USNOB1", "USNOB2"]:  # TODO Unsure if "USNOB2" is correct abbreviation!!!
-                dw = 0.5
+                sigma_arcsec = 0.5
             elif catalog in ["Gaia1", "Gaia2", "Gaia3", "Gaia3E"]:
-                dw = 0.1
+                sigma_arcsec = 0.1
             elif catalog in ["PPMXL"]:
-                dw = 0.2
+                sigma_arcsec = 0.2
             else:
-                dw = 1.5
+                sigma_arcsec = 1.5
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif obsCode in ["T09", "T12", "T14"]:
         if catalog:
             if catalog in ["Gaia1", "Gaia2", "Gaia3", "Gaia3E"]:
-                dw = 0.1
+                sigma_arcsec = 0.1
             else:
-                dw = 1.5
+                sigma_arcsec = 1.5
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif obsCode == "309" and program == "&":  # Micheli
         if catalog:
             if catalog in ["UCAC4", "PPMXL"]:
-                dw = 0.3
+                sigma_arcsec = 0.3
             elif catalog in ["Gaia1", "Gaia2", "Gaia3", "Gaia3E"]:
-                dw = 0.2
+                sigma_arcsec = 0.2
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif catalog:
-        dw = 1.0
+        sigma_arcsec = 1.0
     else:
-        dw = 1.5
+        sigma_arcsec = 1.5
 
-    return dw
+    return sigma_arcsec
+
+
+# Backwards-compatible alias. Despite the historical "weight" name, this returns
+# an astrometric *uncertainty* (sigma, in arcseconds), not a 1/sigma^2 weight --
+# the fit forms the weight as 1/sigma^2 in get_weight_matrix. Prefer
+# astrometric_uncertainty_Veres2017 in new code.
+data_weight_Veres2017 = astrometric_uncertainty_Veres2017

--- a/src/lib/orbit_fit/process_obs80.py
+++ b/src/lib/orbit_fit/process_obs80.py
@@ -91,118 +91,123 @@ cat_codes = {
 }
 
 
-def data_weight_Veres2017(obsCode, jd_tdb, catalog=None):
+def astrometric_uncertainty_Veres2017(obsCode, jd_tdb, catalog=None):
     # Need to put in the photographic and other observation
     # types
 
     if not isinstance(obsCode, str):
         raise ValueError("obsCode must be a string")
 
-    dw = 1.5
+    sigma_arcsec = 1.5
     if obsCode == "703":
         if jd_tdb <= early_703:
-            dw = 1.0
+            sigma_arcsec = 1.0
         else:
-            dw = 0.8
+            sigma_arcsec = 0.8
     elif obsCode == "691":
         if jd_tdb <= early_691:
-            dw = 0.6
+            sigma_arcsec = 0.6
         else:
-            dw = 0.5
+            sigma_arcsec = 0.5
     elif obsCode == "644":
         if jd_tdb <= early_644:
-            dw = 0.6
+            sigma_arcsec = 0.6
         else:
-            dw = 0.4
+            sigma_arcsec = 0.4
     elif obsCode == "704":
-        dw = 1.0
+        sigma_arcsec = 1.0
     elif obsCode == "G96":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "F51":
-        dw = 0.2
+        sigma_arcsec = 0.2
     elif obsCode == "G45":
-        dw = 0.6
+        sigma_arcsec = 0.6
     elif obsCode == "699":
-        dw = 0.8
+        sigma_arcsec = 0.8
     elif obsCode == "D29":
-        dw = 0.75
+        sigma_arcsec = 0.75
     elif obsCode == "C51":
-        dw = 1.0
+        sigma_arcsec = 1.0
     elif obsCode == "E12":
-        dw = 0.75
+        sigma_arcsec = 0.75
     elif obsCode == "608":
-        dw = 0.6
+        sigma_arcsec = 0.6
     elif obsCode == "J75":
-        dw = 1.0
+        sigma_arcsec = 1.0
     elif obsCode == "645":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "673":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "689":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "950":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "H01":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "J04":
-        dw = 0.4
+        sigma_arcsec = 0.4
     elif obsCode == "W84":
-        dw = 0.5
+        sigma_arcsec = 0.5
     elif obsCode == "645":
-        dw = 0.3
+        sigma_arcsec = 0.3
     elif obsCode == "G83" and prg == "2":
         if catalog in cat_codes:
             if cat_codes[catalog] in ["UCAC-4", "PPMXL"]:
-                dw = 0.3
+                sigma_arcsec = 0.3
             elif cat_codes[catalog] in ["Gaia-DR1", "Gaia-DR2", "Gaia-DR3", "Gaia-EDR3"]:
-                dw = 0.2
+                sigma_arcsec = 0.2
             else:
-                dw = 0.3
+                sigma_arcsec = 0.3
         else:
-            dw = 1.0
+            sigma_arcsec = 1.0
     elif obsCode in ["K92", "K93", "Q63", "Q64", "V37", "W84", "W85", "W86", "W87", "K91", "E10", "F65"]:
-        dw = 0.4  # Careful with W84
+        sigma_arcsec = 0.4  # Careful with W84
     elif obsCode == "Y28":
         if catalog in cat_codes:
             if cat_codes[catalog] in ["PPMXL", "Gaia-DR1"]:
-                dw = 0.3
+                sigma_arcsec = 0.3
             else:
-                dw = 1.5
+                sigma_arcsec = 1.5
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif obsCode == "568":
         if catalog in cat_codes:
             if cat_codes[catalog] in ["USNO-B1.0", "USNO-B2.0"]:
-                dw = 0.5
+                sigma_arcsec = 0.5
             elif cat_codes[catalog] in ["Gaia-DR1", "Gaia-DR2", "Gaia-DR3", "Gaia-EDR3"]:
-                dw = 0.1
+                sigma_arcsec = 0.1
             elif cat_codes[catalog] in ["PPMXL"]:
-                dw = 0.2
+                sigma_arcsec = 0.2
             else:
-                dw = 1.5
+                sigma_arcsec = 1.5
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif obsCode in ["T09", "T12", "T14"]:
         if catalog in cat_codes:
             if cat_codes[catalog] in ["Gaia-DR1", "Gaia-DR2", "Gaia-DR3", "Gaia-EDR3"]:
-                dw = 0.1
+                sigma_arcsec = 0.1
             else:
-                dw = 1.5
+                sigma_arcsec = 1.5
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif obsCode == "309" and prg == "&":  # Micheli
         if cat_codes[catalog] in ["UCAC-4", "PPMXL"]:
-            dw = 0.3
+            sigma_arcsec = 0.3
         elif cat_codes[catalog] in ["Gaia-DR1", "Gaia-DR2", "Gaia-DR3", "Gaia-EDR3"]:
-            dw = 0.2
+            sigma_arcsec = 0.2
         else:
-            dw = 1.5
+            sigma_arcsec = 1.5
     elif catalog:
-        dw = 1.0
+        sigma_arcsec = 1.0
     else:
-        dw = 1.5
+        sigma_arcsec = 1.5
 
-    return dw
+    return sigma_arcsec
+
+
+# Backwards-compatible alias (returns an astrometric uncertainty in arcsec, not a
+# 1/sigma^2 weight, despite the historical name).
+data_weight_Veres2017 = astrometric_uncertainty_Veres2017
 
 
 # From Siegfried Eggl's code
@@ -354,12 +359,12 @@ def format_astrometry_line(line, readfunc=tr.convertObs80, ecliptic=False, jd_td
     if prg == " ":
         prg = None
 
-    dw = data_weight_Veres2017(obsCode, jd_tdb, cat)
+    sigma_arcsec = astrometric_uncertainty_Veres2017(obsCode, jd_tdb, cat)
     """
     if cat in cat_codes:
-        print(cat_codes[cat], obsCode, dw)
+        print(cat_codes[cat], obsCode, sigma_arcsec)
     else:
-        print('no catalog', obsCode, 'blah', dw)
+        print('no catalog', obsCode, 'blah', sigma_arcsec)
     """
 
     if jd_tdb < jd_tdb_min:
@@ -418,7 +423,7 @@ def format_astrometry_line(line, readfunc=tr.convertObs80, ecliptic=False, jd_td
         xo,
         yo,
         zo,
-        dw,
+        sigma_arcsec,
     )
 
     return outstring

--- a/tests/layup/test_weight_data.py
+++ b/tests/layup/test_weight_data.py
@@ -4,10 +4,10 @@ Guards two bugs that previously broke the `weight_data=True` code path:
 
   1. `g_column_present` was defined but `astcat_column_present` was
      referenced inside _orbitfit, raising NameError at the first
-     data_weight_Veres2017 call -- failure mode: hard crash before
+     astrometric_uncertainty_Veres2017 call -- failure mode: hard crash before
      any fitting happened.
 
-  2. `data_weight_Veres2017` returns astrometric uncertainty in
+  2. `astrometric_uncertainty_Veres2017` returns astrometric uncertainty in
      ARCSECONDS (per its docstring), but the call site assigned the
      return value directly to Observation.ra_unc / dec_unc which are
      stored in RADIANS -- failure mode: weights were ~206000x too


### PR DESCRIPTION
The function is named "weight" but returns a one-sigma astrometric **uncertainty** in arcseconds (0.2-1.5"), not a 1/σ² weight. The actual weight is formed only in `orbit_fit.cpp`'s `get_weight_matrix` as `1/σ²`. The misnomer (and the `dw` / `data_weight_*` locals) made the uncertainty-vs-weight distinction confusing — surfaced in the #345 review (kjnapier).

- Rename the function in both copies (`astrometric_uncertainty.py` and the standalone `process_obs80.py`) and all call sites.
- Rename the `dw` accumulator → `sigma_arcsec`; `orbitfit.py`'s `data_weight_arcsec`/`_rad` → `sigma_arcsec`/`sigma_rad`; clarify comments + docstring (one-sigma uncertainty, not a weight).
- Keep `data_weight_Veres2017` as a **back-compat alias** in both modules so no external caller breaks.

Behavior unchanged: `test_weight_data.py` passes; the alias resolves to the same object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)