### PR TITLE
Drop os.chdir import hack in layup.routines (RPATH resolves the libs) (#75)

### DIFF
--- a/src/layup/routines/__init__.py
+++ b/src/layup/routines/__init__.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
-import os
-from pathlib import Path
 
-# temporarily change the working directory to help MacOS find
-# the library objects, if running in a different directory.
-cwd = os.getcwd()
-os.chdir(Path(__file__).parent.parent.parent.parent)
+# The compiled extension is linked with an RPATH (``$ORIGIN/..`` on Linux,
+# ``@loader_path/..`` on macOS, set in CMakeLists.txt) so the dynamic loader
+# finds librebound/libassist in site-packages regardless of the working
+# directory. The previous os.chdir() dance is therefore no longer needed (#75).
 from _layup_cpp._core import *
-
-os.chdir(cwd)


### PR DESCRIPTION
Small follow-up cleanup to the RPATH fix from #320 that resolved #75.

`src/layup/routines/__init__.py` used to `os.chdir()` to the repo root before
importing `_layup_cpp._core`, "to help MacOS find the library objects." Since
#320 the extension is linked with an RPATH (`$ORIGIN/..` on Linux,
`@loader_path/..` on macOS — see `CMakeLists.txt`), so the dynamic loader finds
`librebound`/`libassist` in site-packages regardless of the working directory.
The chdir is therefore no longer needed, and it had a side effect: it mutated
the process-global cwd at import time.

Verified the extension now imports from an unrelated working directory with no
`chdir` and no `LD_LIBRARY_PATH`:
- `otool` on the built `_core` shows `LC_RPATH @loader_path/..` and
  `@rpath/lib{assist,rebound}` install names;
- `import layup.routines` succeeds from `/tmp` with cwd unchanged afterward;
- `tests/layup/test_cpp_import.py` passes.

No functional change beyond removing the import-time chdir.
