### PR TITLE
Use user-supplied observer velocities (ADES vel1/vel2/vel3) in orbit fit (#147)

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -378,6 +378,13 @@ class LayupObservatory(SorchaObservatory):
         # A cache of barycentric positions for observatories of the form {obscode: {et: (x, y, z)}}
         self.cached_obs = {}
 
+        # Optional user-supplied geocentric observer velocities (km/s, ICRF),
+        # keyed by the same per-epoch cache key as ObservatoryXYZ (issue #147).
+        # Empty unless ADES vel1/vel2/vel3 columns are provided for a moving
+        # observer; _barycentric_moving_observatory falls back to Earth's
+        # velocity for keys that are absent here.
+        self.ObservatoryVel = {}
+
     def convert_to_geocentric(self, obs_location: dict) -> tuple:
         """Convert an observatory's parallax constants to geocentric coordinates.
 
@@ -512,7 +519,68 @@ class LayupObservatory(SorchaObservatory):
                     )
             # Save the coordinates in the cache for the given obscode and epoch
             self.ObservatoryXYZ[obscode_cache_key] = coords
+
+            # Optionally cache a user-supplied observer velocity. ADES permits the
+            # velocity columns (vel1/vel2/vel3) only for space-based observers, so
+            # we read them here, inside the moving-observer branch, reusing the
+            # sys/ctr already validated for the position (issue #147).
+            self._populate_observatory_velocity(obscode_cache_key, data)
         return obscode_cache_key
+
+    def _populate_observatory_velocity(self, obscode_cache_key, data):
+        """Cache an optional user-supplied geocentric observer velocity (km/s).
+
+        ADES allows optional velocity columns (vel1/vel2/vel3) alongside the
+        position of a space-based observer (issue #147). They share the
+        position's reference frame (``sys``) and center (``ctr``), both already
+        validated for the position in :meth:`populate_observatory`. We convert to
+        km/s and store under the same per-epoch cache key as the position;
+        :meth:`_barycentric_moving_observatory` then adds Earth's barycentric
+        velocity to it. Velocity is optional: if the columns are absent or NaN we
+        leave the cache untouched and fall back to Earth's velocity.
+
+        Parameters
+        ----------
+        obscode_cache_key : str
+            The per-epoch cache key the position was stored under.
+        data : numpy structured array
+            The observation row (already known to be a moving observer).
+        """
+        vel_fields = ("vel1", "vel2", "vel3")
+        if not all(field in data.dtype.names for field in vel_fields):
+            return
+        vel = np.array([data["vel1"], data["vel2"], data["vel3"]], dtype=float)
+        # Velocity is optional even when the columns exist (e.g. blank/NaN rows).
+        if np.isnan(vel).any():
+            return
+
+        vel_km_s = self._obs_vel_to_km_s(vel, data["sys"])
+        if obscode_cache_key in self.ObservatoryVel and not np.allclose(
+            self.ObservatoryVel[obscode_cache_key], vel_km_s
+        ):
+            raise ValueError(
+                f"Observatory velocity reported inconsistently at the same epoch for "
+                f"cache key {obscode_cache_key}: previously "
+                f"{self.ObservatoryVel[obscode_cache_key]}, now {vel_km_s} (km/s)."
+            )
+        self.ObservatoryVel[obscode_cache_key] = vel_km_s
+
+    @staticmethod
+    def _obs_vel_to_km_s(vel, sys):
+        """Convert an ADES OBS_VEL observer velocity to km/s.
+
+        Unit convention (matches the SPICE km/s state that
+        :meth:`_barycentric_moving_observatory` uses for Earth):
+
+        * ``ICRF_KM`` -> km/s (no conversion; SPICE-native)
+        * ``ICRF_AU`` -> au/day -> km/s
+
+        ``sys`` has already been validated to one of these two values in
+        :meth:`populate_observatory`.
+        """
+        if sys == "ICRF_AU":
+            return vel * AU_KM / (24 * 60 * 60)
+        return vel
 
     def _barycentric_moving_observatory(self, et, obscode_cache_key):
         """Barycentric position and velocity (km, km/s) of a moving observatory.
@@ -529,16 +597,24 @@ class LayupObservatory(SorchaObservatory):
         barycentricObservatoryRates would apply and which would misplace the
         observatory by a factor of the Earth radius (~6378x).
 
-        The observatory's own geocentric velocity is not provided per
-        observation, so Earth's barycentric velocity is used; the satellite's
-        orbital velocity (~km/s) is a small correction that only enters through
-        aberration.
+        The observatory's own geocentric velocity is used when the user supplies
+        it via the ADES vel1/vel2/vel3 columns (cached in ObservatoryVel, km/s,
+        issue #147): the barycentric velocity is then Earth's velocity plus the
+        geocentric observer velocity, mirroring the position. When no velocity is
+        supplied we fall back to Earth's barycentric velocity alone; the
+        satellite's orbital velocity (~km/s) is then a small correction that only
+        enters through aberration.
         """
         posvel, _ = spice.spkezr("EARTH", et, "J2000", "NONE", "SSB")
         earth_pos = np.array(posvel[0:3])  # km, J2000
         earth_vel = np.array(posvel[3:6])  # km/s, J2000
         obs_geocentric = np.array(self.ObservatoryXYZ[obscode_cache_key])  # km, J2000
-        return earth_pos + obs_geocentric, earth_vel
+
+        bary_pos = earth_pos + obs_geocentric
+        obs_geocentric_vel = self.ObservatoryVel.get(obscode_cache_key)  # km/s or None
+        if obs_geocentric_vel is not None:
+            return bary_pos, earth_vel + obs_geocentric_vel
+        return bary_pos, earth_vel
 
     def obscodes_to_barycentric(self, data):
         """

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -640,6 +640,136 @@ def test_moving_observatory_barycentric_position():
     np.testing.assert_allclose(offset_km, geocentric_km, atol=1.0)
 
 
+def test_obs_vel_to_km_s_units():
+    """Pin the ADES OBS_VEL unit convention used by issue #147: ICRF_KM is km/s
+    (unchanged) and ICRF_AU is au/day -> km/s."""
+    vel = np.array([1.0, -2.0, 0.5])
+    assert_array_equal(LayupObservatory._obs_vel_to_km_s(vel, "ICRF_KM"), vel)
+    np.testing.assert_allclose(
+        LayupObservatory._obs_vel_to_km_s(vel, "ICRF_AU"), vel * AU_KM / (24 * 60 * 60)
+    )
+
+
+def test_moving_observatory_velocity_uses_user_value():
+    """When ADES vel1/vel2/vel3 are supplied for a moving observer, the barycentric
+    velocity is Earth's barycentric velocity plus the geocentric observer velocity
+    (issue #147), not Earth's velocity alone."""
+    observatory = LayupObservatory()
+    et = spice.str2et("2003-01-26T00:24:24.480Z")
+    geocentric_km = np.array([-6905.9, -673.9, -353.1])
+    # An LEO-like geocentric velocity (km/s, ICRF), |v| ~ 7.6 km/s.
+    geocentric_vel_km_s = np.array([0.73, -5.41, -5.30])
+    row = np.array(
+        [("250", et, "ICRF_KM", 399, *geocentric_km, *geocentric_vel_km_s)],
+        dtype=[
+            ("stn", "U4"),
+            ("et", "<f8"),
+            ("sys", "U7"),
+            ("ctr", "i4"),
+            ("pos1", "<f8"),
+            ("pos2", "<f8"),
+            ("pos3", "<f8"),
+            ("vel1", "<f8"),
+            ("vel2", "<f8"),
+            ("vel3", "<f8"),
+        ],
+    )
+
+    bary = np.atleast_1d(observatory.obscodes_to_barycentric(row))
+    # obscodes_to_barycentric returns velocity in AU/day; convert back to km/s.
+    obs_vel_km_s = np.array([bary["vx"][0], bary["vy"][0], bary["vz"][0]]) * AU_KM / (24 * 60 * 60)
+
+    earth_state, _ = spice.spkezr("EARTH", et, "J2000", "NONE", "SSB")
+    earth_vel_km_s = np.array(earth_state[3:6])
+
+    np.testing.assert_allclose(obs_vel_km_s - earth_vel_km_s, geocentric_vel_km_s, atol=1e-6)
+
+
+def test_moving_observatory_velocity_icrf_au_units():
+    """An ICRF_AU observer velocity (au/day) yields the same barycentric velocity
+    as the equivalent ICRF_KM (km/s) input -- guards the #147 unit conversion
+    end-to-end."""
+    observatory = LayupObservatory()
+    et = spice.str2et("2003-01-26T00:24:24.480Z")
+    geocentric_km = np.array([-6905.9, -673.9, -353.1])
+    geocentric_vel_km_s = np.array([0.73, -5.41, -5.30])
+    # Same physical state expressed in AU and AU/day.
+    pos_au = geocentric_km / AU_KM
+    vel_au_day = geocentric_vel_km_s * (24 * 60 * 60) / AU_KM
+    row = np.array(
+        [("250", et, "ICRF_AU", 399, *pos_au, *vel_au_day)],
+        dtype=[
+            ("stn", "U4"),
+            ("et", "<f8"),
+            ("sys", "U7"),
+            ("ctr", "i4"),
+            ("pos1", "<f8"),
+            ("pos2", "<f8"),
+            ("pos3", "<f8"),
+            ("vel1", "<f8"),
+            ("vel2", "<f8"),
+            ("vel3", "<f8"),
+        ],
+    )
+
+    bary = np.atleast_1d(observatory.obscodes_to_barycentric(row))
+    obs_vel_km_s = np.array([bary["vx"][0], bary["vy"][0], bary["vz"][0]]) * AU_KM / (24 * 60 * 60)
+
+    earth_state, _ = spice.spkezr("EARTH", et, "J2000", "NONE", "SSB")
+    np.testing.assert_allclose(obs_vel_km_s - np.array(earth_state[3:6]), geocentric_vel_km_s, atol=1e-6)
+
+
+def test_moving_observatory_velocity_absent_falls_back_to_earth():
+    """Without ADES velocity columns, a moving observer's barycentric velocity
+    falls back to Earth's barycentric velocity (the pre-#147 behavior)."""
+    observatory = LayupObservatory()
+    et = spice.str2et("2003-01-26T00:24:24.480Z")
+    geocentric_km = np.array([-6905.9, -673.9, -353.1])
+    row = np.array(
+        [("250", et, "ICRF_KM", 399, *geocentric_km)],
+        dtype=[
+            ("stn", "U4"),
+            ("et", "<f8"),
+            ("sys", "U7"),
+            ("ctr", "i4"),
+            ("pos1", "<f8"),
+            ("pos2", "<f8"),
+            ("pos3", "<f8"),
+        ],
+    )
+
+    bary = np.atleast_1d(observatory.obscodes_to_barycentric(row))
+    obs_vel_km_s = np.array([bary["vx"][0], bary["vy"][0], bary["vz"][0]]) * AU_KM / (24 * 60 * 60)
+
+    earth_state, _ = spice.spkezr("EARTH", et, "J2000", "NONE", "SSB")
+    np.testing.assert_allclose(obs_vel_km_s, np.array(earth_state[3:6]), atol=1e-6)
+
+
+def test_observatory_velocity_inconsistent_at_same_epoch_raises():
+    """Two different velocities for the same moving observer at the same epoch is
+    an error, mirroring the existing position-consistency check."""
+    observatory = LayupObservatory()
+    et = spice.str2et("2003-01-26T00:24:24.480Z")
+    dtype = [
+        ("stn", "U4"),
+        ("et", "<f8"),
+        ("sys", "U7"),
+        ("ctr", "i4"),
+        ("pos1", "<f8"),
+        ("pos2", "<f8"),
+        ("pos3", "<f8"),
+        ("vel1", "<f8"),
+        ("vel2", "<f8"),
+        ("vel3", "<f8"),
+    ]
+    row1 = np.array([("250", et, "ICRF_KM", 399, 1000.0, 0.0, 0.0, 1.0, 0.0, 0.0)], dtype=dtype)[0]
+    row2 = np.array([("250", et, "ICRF_KM", 399, 1000.0, 0.0, 0.0, 2.0, 0.0, 0.0)], dtype=dtype)[0]
+
+    observatory.populate_observatory("250", et, row1)
+    with pytest.raises(ValueError):
+        observatory.populate_observatory("250", et, row2)
+
+
 def test_skyplane_cov_to_radec_cov():
     """The sky-plane covariance is already an on-sky (great-circle) covariance,
     so the error ellipse is the eigen-decomposition of the 2x2 matrix with no


### PR DESCRIPTION
Closes #147.

ADES allows optional observer **velocity** columns (`vel1/vel2/vel3`) for space-based observers. The fit already consumes an observer velocity end-to-end — C++ `Observation.observer_velocity` (fed from the `vx/vy/vz` columns, used for aberration and the streak-rate residual from #345) — but until now that velocity was always the *computed* value, and for a moving observatory #341 approximated it with **Earth's** velocity. This wires the user-supplied velocity through.

### Changes (all in `data_processing_utilities.py`; no C++ changes)
- `populate_observatory` caches an optional geocentric velocity (`vel1/vel2/vel3`) under the same per-epoch key as the position, reusing the `sys`/`ctr` already validated for the position. Absent/NaN → cache untouched (back-compatible).
- `_obs_vel_to_km_s` converts to km/s. **Unit convention: `ICRF_KM` → km/s, `ICRF_AU` → au/day** (confirmed against the ADES OBS_VEL spec).
- `_barycentric_moving_observatory` returns `earth_vel + obs_vel` when supplied, else falls back to Earth's velocity (the prior #341 behavior).
- Readers need no change — `vel1/vel2/vel3` pass through by header name (Obs80 has no velocity; ADES-only, per spec).

### Why
Removes the Earth-velocity approximation #341 noted for space-based observatories (the satellite's ~km/s orbital velocity is not negligible for precise astrometry), tightens streak-rate fits for moving observers, and is the prerequisite for radar/Doppler (#146), where the observer's true velocity is mandatory.

A natural follow-up (#55) can populate the same `ObservatoryVel` cache from a JPL/SPICE query for known spacecraft.

### Tests
Static unit conversion, ICRF_KM + ICRF_AU end-to-end (vs Earth's velocity), absent→Earth-velocity fallback, and a same-epoch inconsistency guard. Full `test_data_processing_utilities.py` passes (49); black/isort clean.
