### PR TITLE
Fall back to bundled obscodes on empty/corrupt MPC file, not just network errors

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -1,4 +1,5 @@
 import gzip
+import json
 import logging
 import multiprocessing
 import os
@@ -360,12 +361,15 @@ class LayupObservatory(SorchaObservatory):
 
         try:
             super().__init__(FakeSorchaArgs(cache_dir), config.auxiliary)
-        except requests.exceptions.RequestException as exc:
-            # The observatory-codes download from the MPC failed (server
-            # unreachable, timeout, etc.).  Fall back to the copy bundled with
-            # layup so we don't fail the run over a transient network outage.
+        except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
+            # Loading the MPC observatory-codes file failed. Either the download
+            # itself errored (server unreachable, timeout, etc.), or it
+            # "succeeded" but produced an empty/corrupt file that does not parse
+            # as JSON -- both have been seen as transient CI failures. Either
+            # way, fall back to the copy bundled with layup rather than failing
+            # the run over a transient outage.
             logger.warning(
-                "Could not fetch observatory codes from the MPC (%s); "
+                "Could not load observatory codes from the MPC (%s); "
                 "falling back to the copy bundled with layup.",
                 exc,
             )

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -717,3 +717,34 @@ def test_layup_observatory_falls_back_on_mpc_failure(monkeypatch):
     assert calls[0] is None and calls[1] is not None
     assert "X05" in observatory.ObservatoryXYZ
     assert len(observatory.ObservatoryXYZ) > 2000
+
+
+def test_layup_observatory_falls_back_on_corrupt_obscodes(monkeypatch):
+    """If the MPC obscodes download "succeeds" but yields an empty/corrupt file
+    that fails to parse as JSON, the LayupObservatory should still fall back to
+    the bundled copy instead of raising (the download error is a
+    json.JSONDecodeError, not a network exception)."""
+    import json
+
+    import layup.utilities.data_processing_utilities as dpu
+
+    orig_init = dpu.SorchaObservatory.__init__
+    calls = []
+
+    def fake_init(self, args, auxconfigs, oc_file=None):
+        calls.append(oc_file)
+        if oc_file is None:
+            # Simulate sorcha decompressing an empty obscodes file and json.load
+            # choking on the empty string -- the failure observed on CI.
+            raise json.JSONDecodeError("Expecting value", "", 0)
+        # The fallback path supplies a local oc_file; let the real init read it.
+        orig_init(self, args, auxconfigs, oc_file=oc_file)
+
+    monkeypatch.setattr(dpu.SorchaObservatory, "__init__", fake_init)
+
+    observatory = LayupObservatory()
+
+    # First attempt (corrupt download) raised; the second used the bundled fallback.
+    assert calls[0] is None and calls[1] is not None
+    assert "X05" in observatory.ObservatoryXYZ
+    assert len(observatory.ObservatoryXYZ) > 2000


### PR DESCRIPTION
Hardens the bundled-obscodes fallback from #337.

#337's fallback only catches `requests.exceptions.RequestException` (a network failure). But a download that *succeeds* yet yields an **empty/corrupt** file slips past it: sorcha's obscodes loader then raises `json.JSONDecodeError` from `json.load`, crashing `LayupObservatory()` inside `super().__init__()`.

This was just observed as a transient CI failure on #349 — the runner downloaded `ObsCodes.json.gz`, decompressed it to an **empty** `ObsCodes.json`, and `json.load('')` raised `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

### Change
Broaden the `except` to `(requests.exceptions.RequestException, json.JSONDecodeError)` and fall back to the bundled copy in both cases. Adds a regression test mirroring the existing network-failure test but raising `JSONDecodeError` on the download path.

No behavior change on the happy path; this only adds a second class of transient failure to the existing fallback.
