### PR TITLE
Single source of truth for physical constants + predict/data_processing clarity

### DIFF
--- a/src/layup/constants.py
+++ b/src/layup/constants.py
@@ -1,0 +1,36 @@
+"""Physical constants for layup, defined once.
+
+Before this module these values were re-declared in several places
+(``orbitfit.py``, ``predict.py``, ``iod.py``,
+``utilities/data_processing_utilities.py``). The duplicates happened to agree
+numerically, but independent definitions are a drift hazard -- e.g.
+``SPEED_OF_LIGHT`` was written two different ways (via metres in some modules,
+via kilometres in another) that only coincidentally produced the same value.
+Importing everything from here gives a single, citable source of truth.
+
+Units follow layup's internal convention: distances in astronomical units (au),
+times in days, so GM values are in au^3/day^2 and the speed of light is in
+au/day.
+"""
+
+from __future__ import annotations
+
+# Astronomical unit in metres -- exact, by the IAU 2012 definition (Resolution
+# B2): 1 au = 149_597_870_700 m.
+AU_M = 149597870700
+AU_KM = AU_M / 1000.0
+
+# Speed of light in vacuum -- exact, by the SI definition: 299_792_458 m/s.
+C_M_PER_S = 299792458.0
+# ...expressed in layup's au/day (~173.144633 au/day).
+SPEED_OF_LIGHT = C_M_PER_S * 86400.0 / AU_M
+
+# Heliocentric gravitational parameter GM_sun in au^3/day^2. This is the square
+# of the Gaussian gravitational constant k = 0.01720209895, i.e. GM_sun = k^2.
+MU_SUN = 0.00029591220828559104
+
+# Total gravitational parameter of the solar system (Sun + planets) in
+# au^3/day^2, used as the central GM for barycentric two-body initial orbit
+# determination (Gauss's method) where the reference point is the solar-system
+# barycentre rather than the Sun.
+GMtotal = 0.0002963092748799319

--- a/src/layup/iod.py
+++ b/src/layup/iod.py
@@ -35,13 +35,10 @@ import logging
 import math
 from typing import Callable, Optional, Sequence
 
+from layup.constants import GMtotal, SPEED_OF_LIGHT
 from layup.routines import FitResult, Observation, gauss
 
 logger = logging.getLogger(__name__)
-
-GMtotal = 0.0002963092748799319
-AU_M = 149597870700
-SPEED_OF_LIGHT = 2.99792458e8 * 86400.0 / AU_M
 
 # Default bounds for the cheap physical-feasibility filter. We
 # deliberately *don't* check bound-orbit energy here: Gauss's velocity

--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -142,7 +142,7 @@ def layup_calculate_rates_and_geometry(pointing: DataFrame, ephem_geom_params: E
 
 
 def _get_on_sky_data(predictions, orbits_df, obs_pos_vel, primary_id_column_name, args, configs):
-    '''Calculates the on-sky rates and geometry for a set of orbits at certain pointings.
+    """Calculates the on-sky rates and geometry for a set of orbits at certain pointings.
 
     Parameters
     ----------
@@ -156,14 +156,14 @@ def _get_on_sky_data(predictions, orbits_df, obs_pos_vel, primary_id_column_name
         The name of the primary ID column.
     args : argparse
         The argparse object that was created when running from the CLI.
-    aux : AuxiliaryConfigs object
-        The LayUp auxiliary arguments.
+    configs : LayupConfigs
+        The layup configuration object.
 
     Returns
     -------
     rates : numpy recarray
         Numpy recarray containing the on-sky rates.
-    """'''
+    """
 
     observations = []
     for i, pos in enumerate(obs_pos_vel):
@@ -230,10 +230,8 @@ def _get_on_sky_data(predictions, orbits_df, obs_pos_vel, primary_id_column_name
     # Get the on-sky rates
     onsky = layup_calculate_rates_and_geometry(pointing, ephem_geom_params)
 
-    # Only want certain info from onsky
-
-    # This method is the fastest for making a recarray, but I've commented a different way in case we don't want to depend on pandas
-
+    # Only want certain info from onsky.
+    # Build the output recarray via a pandas DataFrame (fast for this column set).
     rates_df = DataFrame(
         {
             primary_id_column_name: ephem_geom_params.obj_id,
@@ -254,34 +252,6 @@ def _get_on_sky_data(predictions, orbits_df, obs_pos_vel, primary_id_column_name
         }
     )
     rates = rates_df.to_records(index=False)
-
-    # rates = np.empty(
-    #     len(predictions),
-    #     dtype=[
-    #         ("provID", "O"),
-    #         ("epoch_JD_TDB", "f8"),
-    #         ("Range_LTC_km", "f8"),
-    #         ("RangeRate_LTC_km_s", "f8"),
-    #         ("Obj_Sun_x_LTC_km", "f8"),
-    #         ("Obj_Sun_y_LTC_km", "f8"),
-    #         ("Obj_Sun_z_LTC_km", "f8"),
-    #         ("Obj_Sun_vx_LTC_km_s", "f8"),
-    #         ("Obj_Sun_vy_LTC_km_s", "f8"),
-    #         ("Obj_Sun_vz_LTC_km_s", "f8"),
-    #         ("phase_deg", "f8"),
-    #     ],
-    # )
-    # rates["provID"], rates["epoch_JD_TDB"] = ephem_geom_params.obj_id, predictions["epoch_JD_TDB"]
-    # rates["Range_LTC_km"], rates["RangeRate_LTC_km_s"] = onsky[4], onsky[5]
-    # (
-    #     rates["Obj_Sun_x_LTC_km"],
-    #     rates["Obj_Sun_y_LTC_km"],
-    #     rates["Obj_Sun_z_LTC_km"],
-    #     rates["Obj_Sun_vx_LTC_km_s"],
-    #     rates["Obj_Sun_vy_LTC_km_s"],
-    #     rates["Obj_Sun_vz_LTC_km_s"],
-    # ) = (onsky[10], onsky[11], onsky[12], onsky[13], onsky[14], onsky[15])
-    # rates["phase_deg"] = onsky[22]
 
     spice.kclear()
     return rates
@@ -397,11 +367,11 @@ def _predict(data, obs_pos_vel, times, cache_dir, primary_id_column_name):
                     row[primary_id_column_name],
                     utc_time,
                     pred.epoch,  # JD TDB
-                    pred.rho[0],  # place holder
-                    pred.rho[0],  # place holder
-                    pred.rho[0],
-                    pred.rho[1],
-                    pred.rho[2],
+                    0.0,  # ra_deg placeholder; set below from the rho vector
+                    0.0,  # dec_deg placeholder; set below from the rho vector
+                    pred.rho[0],  # rho_x
+                    pred.rho[1],  # rho_y
+                    pred.rho[2],  # rho_z
                     pred.obs_cov[0],  # obs_cov_xx = (0, 0)
                     pred.obs_cov[3],  # obs_cov_yy = (1, 1)
                     pred.obs_cov[1],  # obs_cov_xy = (0, 1)
@@ -452,8 +422,8 @@ def predict(
         The directory to the cached kernels. If None, use the default cache directory.
     args : argparse
         The argparse object that was created when running from the CLI.
-    aux : AuxiliaryConfigs object
-        The LayUp auxiliary arguments. Needed if on-sky rates are requested.
+    configs : LayupConfigs
+        The layup configuration object. Needed if on-sky rates are requested.
 
     Returns
     -------
@@ -462,13 +432,13 @@ def predict(
     if num_workers < 0:
         num_workers = os.cpu_count()
 
-    Layup_observatory = LayupObservatory(cache_dir=cache_dir)
+    layup_observatory = LayupObservatory(cache_dir=cache_dir)
 
     times_et = np.array([spice.str2et(f"jd {t} tdb") for t in times], dtype="<f8")
 
     obs_data = np.array([(obscode, t) for t in times_et], dtype=[("stn", "<U10"), ("et", "<f8")])
 
-    obs_pos_vel = Layup_observatory.obscodes_to_barycentric(obs_data)
+    obs_pos_vel = layup_observatory.obscodes_to_barycentric(obs_data)
 
     predictions = process_data(
         data,
@@ -491,7 +461,6 @@ def predict(
         orbits_df = DataFrame(data, columns=cols, index=data[primary_id_column_name])
         if primary_id_column_name != "ObjID":
             orbits_df = orbits_df.rename(columns={primary_id_column_name: "ObjID"})
-        # onsky_results = _get_on_sky_data(orbits_df, observations, results, args, configs)
         onsky_results = process_data_by_id(
             predictions,
             n_workers=num_workers,
@@ -542,8 +511,8 @@ def predict_cli(
         The output file to write the predictions to.
     cache_dir : Path
         The directory to the cached kernels.
-    aux : AuxiliaryConfigs object
-        The LayUp auxiliary arguments
+    configs : LayupConfigs
+        The layup configuration object.
     """
 
     num_workers = cli_args.n

--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -16,6 +16,7 @@ from sorcha.ephemeris.simulation_driver import (
 from pandas import DataFrame, Series
 from numpy.lib.recfunctions import join_by
 
+from layup.constants import AU_KM, SPEED_OF_LIGHT
 from layup.convert import convert
 from layup.routines import Observation, get_ephem, numpy_to_eigen, predict_sequence
 from layup.utilities.data_processing_utilities import (
@@ -36,9 +37,6 @@ logger = logging.getLogger(__name__)
 
 # The list of required input column names. Note: This should not include the
 # primary id column name.
-AU_M = 149597870700
-AU_KM = AU_M / 1000.0
-SPEED_OF_LIGHT = 2.99792458e5 * 86400.0 / AU_KM
 REQUIRED_INPUT_COLUMN_NAMES = [
     "epochMJD_TDB",
     "FORMAT",

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -14,6 +14,7 @@ from sorcha.ephemeris.simulation_geometry import barycentricObservatoryRates
 from sorcha.ephemeris.simulation_parsing import Observatory as SorchaObservatory
 from sorcha.ephemeris.simulation_setup import furnish_spiceypy
 
+from layup.constants import AU_KM
 from layup.routines import FitResult
 from layup.utilities.layup_configs import LayupConfigs
 
@@ -35,9 +36,6 @@ from layup.utilities.layup_configs import LayupConfigs
 # makes every platform behave the same.  ("forkserver" would also work and is
 # cheaper, but "spawn" is the most portable and matches the macOS default.)
 _MP_CONTEXT = multiprocessing.get_context("spawn")
-
-AU_M = 149597870700
-AU_KM = AU_M / 1000.0
 
 logger = logging.getLogger(__name__)
 

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -209,14 +209,7 @@ def parse_cov(orbit_row, flatten=False):
 def parse_fit_result(
     fit_result_row,
     orbit_colm_flag=True,
-    orbit_para=[
-        "x",
-        "y",
-        "z",
-        "xdot",
-        "ydot",
-        "zdot",
-    ],
+    orbit_para=None,
 ):
     """
     Parse the initial guess data from a structured numpy array representing our
@@ -231,20 +224,22 @@ def parse_fit_result(
     res : FitResult
         The parsed fit result.
     """
+    if orbit_para is None:
+        orbit_para = ["x", "y", "z", "xdot", "ydot", "zdot"]
 
     if isinstance(fit_result_row, np.ndarray) and fit_result_row.shape == (1,):
         fit_result_row = fit_result_row[0]
 
     res = FitResult()
 
-    if orbit_colm_flag == True:
+    if orbit_colm_flag:
         res.csq = fit_result_row["csq"]  # The chi-squared value of the fit
         res.ndof = fit_result_row["ndof"]  # The number of degrees of freedom
         # The number of iterations used during the fitting process.
         res.niter = fit_result_row["niter"]
 
     # The state vector of the fit result
-    res.state = res.state = [fit_result_row[param] for param in orbit_para]
+    res.state = [fit_result_row[param] for param in orbit_para]
     # While orbitfit saves the epoch in MJD_TDB, internal calculations use JD_TDB
     res.epoch = fit_result_row["epochMJD_TDB"] + 2400000.5
     # Construct the flattened covariance matrix from the columns of the fit result
@@ -469,27 +464,14 @@ class LayupObservatory(SorchaObservatory):
         # Update the cached coordinates and obscode_cache_key for the case of a moving observatory
         if coords is None or None in coords or np.isnan(coords).any():
             obscode_cache_key = self.create_obscode_cache_key(obscode, et)
-            # The observatory does not have a fixed position, so don't try to calculate barycentric coordinates
-            if "sys" not in data.dtype.names:
-                raise ValueError(
-                    f"The data must have a 'sys' field for the reference frame of non-fixed position observatory {obscode}."
-                )
-            if "ctr" not in data.dtype.names:
-                raise ValueError(
-                    f"The data must have a 'ctr' field for non-fixed position observatory {obscode}."
-                )
-            if "pos1" not in data.dtype.names:
-                raise ValueError(
-                    f"The data must have a 'pos1' field for non-fixed position observatory {obscode}."
-                )
-            if "pos2" not in data.dtype.names:
-                raise ValueError(
-                    f"The data must have a 'pos2' field for non-fixed position observatory {obscode}."
-                )
-            if "pos3" not in data.dtype.names:
-                raise ValueError(
-                    f"The data must have a 'pos3' field for non-fixed postion observatory {obscode}."
-                )
+            # The observatory does not have a fixed position, so don't try to calculate barycentric coordinates.
+            # A non-fixed observatory must carry its reference frame ('sys'), center ('ctr') and the three
+            # position components ('pos1'/'pos2'/'pos3') in the data.
+            for field in ("sys", "ctr", "pos1", "pos2", "pos3"):
+                if field not in data.dtype.names:
+                    raise ValueError(
+                        f"The data must have a '{field}' field for non-fixed position observatory {obscode}."
+                    )
             coords = np.array([data["pos1"], data["pos2"], data["pos3"]])
             # If any of the coordinates are None or NaN, raise an error
             if coords is None or np.isnan(coords).any():
@@ -703,16 +685,13 @@ def get_format(data):
         logger.error("Data is empty")
         raise ValueError("Data is empty")
 
-    format = None
-
     if "FORMAT" in data.dtype.names:
         # Find first valid format in the data
-        for format in data["FORMAT"]:
-            if format in ["BCART", "BCART_EQ", "BCOM", "BKEP", "CART", "COM", "KEP"]:
-                return format
-        else:
-            logger.error("Data does not contain valid orbit format")
-            raise ValueError("Data does not contain valid orbit format")
+        for fmt in data["FORMAT"]:
+            if fmt in ["BCART", "BCART_EQ", "BCOM", "BKEP", "CART", "COM", "KEP"]:
+                return fmt
+        logger.error("Data does not contain valid orbit format")
+        raise ValueError("Data does not contain valid orbit format")
     else:
         logger.error("Data does not contain 'FORMAT' column")
         raise ValueError("Data does not contain 'FORMAT' column")


### PR DESCRIPTION
Closes #358. Part of #360 (clarity audit).

- New `src/layup/constants.py` with one definition each of `AU_M`, `AU_KM`,
  `SPEED_OF_LIGHT`, `MU_SUN`, `GMtotal` (with provenance comments). Migrates
  `iod.py`, `predict.py`, `data_processing_utilities.py` to import from it.
  (`SPEED_OF_LIGHT` was previously derived two different ways that differed by
  ~1 ULP; now a single canonical value.)
- Clarity in `predict.py` (malformed docstring + `aux`->`configs`, dead recarray
  block, `Layup_observatory` rename, placeholder columns) and
  `data_processing_utilities.py` (`parse_fit_result` mutable default/double-assign/
  `==True`; `populate_observatory` 5-block->loop + typo; `get_format` builtin
  shadow/dead init).

Quality-only, behavior-preserving. `orbitfit.py`'s own constant copies are left for
a small follow-up (that file was in flight at the time).
