### PR TITLE
convert: deduplicate _apply_convert output-format dispatch

### DIFF
--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -85,7 +85,24 @@ def _scale_degree_cov(arr, fmt, factor, mask=None):
 
 
 # Add this to MJD to convert to JD
-MJD_TO_JD_CONVERSTION = 2400000.5
+MJD_TO_JD = 2400000.5
+
+
+def _subtract_sun(coords, vels, sun):
+    """Shift a barycentric equatorial state to heliocentric by subtracting the Sun."""
+    return (
+        coords - np.array((sun.x, sun.y, sun.z)),
+        vels - np.array((sun.vx, sun.vy, sun.vz)),
+    )
+
+
+def _to_ecliptic(coords, vels):
+    """Rotate an equatorial (coords, vels) state pair into ecliptic coordinates."""
+    return (
+        np.array(equatorial_to_ecliptic(coords)),
+        np.array(equatorial_to_ecliptic(vels)),
+    )
+
 
 INPUT_READERS = {
     "csv": CSVDataReader,
@@ -161,7 +178,7 @@ def get_output_column_names_and_types(primary_id_column_name, has_covariance, ex
     return required_column_names, default_column_dtypes
 
 
-def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None, extra_cols_to_keep=[]):
+def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None, extra_cols_to_keep=None):
     """
     Apply the appropriate conversion function to the data
 
@@ -185,6 +202,9 @@ def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None
     """
     if len(data) == 0:
         return data
+
+    if extra_cols_to_keep is None:
+        extra_cols_to_keep = []
 
     expected_formats = ["BCART", "BCART_EQ", "BCOM", "BKEP", "CART", "COM", "KEP"]
     if convert_to not in expected_formats:
@@ -243,142 +263,70 @@ def _apply_convert(data, convert_to, cache_dir=None, primary_id_column_name=None
         row = (np.nan,) * 6
         cov = np.full((6, 6), np.nan)
         if d["FORMAT"] != "NONE":
-            # First we convert our data into equatorial barycentric cartesian coordinates,
-            # regardless of the input format. That allows us to simplify the conversion
-            # process below by only having the logic to convert from BCART_EQ to the other formats.
-            sun = ephem.get_particle("Sun", d["epochMJD_TDB"] + MJD_TO_JD_CONVERSTION - ephem.jd_ref)
-
             if not isinstance(d["FORMAT"], str):
                 raise ValueError(f"FORMAT column must be a string {d['FORMAT']}.")
 
+            epoch = d["epochMJD_TDB"]
+            sun = ephem.get_particle("Sun", epoch + MJD_TO_JD - ephem.jd_ref)
+
+            # First convert the input into equatorial barycentric Cartesian
+            # coordinates regardless of input format, so the per-output-format
+            # logic below only has to convert *out* of BCART_EQ.
             if d["FORMAT"] == "BCART_EQ":
-                # We don't use parse_orbit_row here because we already have the BCART_EQ coordinates
+                # Already BCART_EQ; parse_orbit_row not needed.
                 x, y, z, xdot, ydot, zdot = d["x"], d["y"], d["z"], d["xdot"], d["ydot"], d["zdot"]
             else:
-                x, y, z, xdot, ydot, zdot = parse_orbit_row(
-                    d, d["epochMJD_TDB"] + MJD_TO_JD_CONVERSTION, ephem, {}, gm_sun, gm_total
-                )
-            # Parse our 6x6 cartesian covariance matrix if it exists regardless of the input format.
-            # Note that this does not differentiate between BCART, BCART_EQ, and CART covariance matrices, and
-            # we handle whether or not it will be barycentric further below.
+                x, y, z, xdot, ydot, zdot = parse_orbit_row(d, epoch + MJD_TO_JD, ephem, {}, gm_sun, gm_total)
+            # Parse the 6x6 equatorial Cartesian covariance (basis-independent of
+            # the eventual output format; handled per-format below).
             if has_covariance:
                 cov = parse_covariance_row_to_CART(d, gm_total, gm_sun)
 
-            # For each possible output format, covert our BCART_EQ coordinates to the requested format.
+            eq_coords = np.array((x, y, z))
+            eq_vels = np.array((xdot, ydot, zdot))
+
             if convert_to == "BCART_EQ":
-                # Already in equatorial BCART so simply use the parsed coordinates
+                # Already equatorial barycentric Cartesian.
                 row = x, y, z, xdot, ydot, zdot
-            elif convert_to == "BCART":
-                # Convert our covariance matrix from equatorial to ecliptic.
+            elif convert_to in ("BCART", "CART"):
+                # Both are ecliptic Cartesian; CART is additionally heliocentric.
                 cov = covariance_eq_to_ecl(cov)
-
-                # Convert to BCART by converting to ecliptic coordinates
-                equatorial_coords = np.array((x, y, z))
-                equatorial_velocities = np.array((xdot, ydot, zdot))
-
-                ecliptic_coords = np.array(equatorial_to_ecliptic(equatorial_coords))
-                ecliptic_velocities = np.array(equatorial_to_ecliptic(equatorial_velocities))
-                row = tuple(np.concatenate([ecliptic_coords, ecliptic_velocities]))
-
-            elif convert_to == "CART":
-                # Convert our covariance matrix from equatorial to ecliptic.
-                cov = covariance_eq_to_ecl(cov)
-
-                # Convert to CART by subtracting the Sun's position and velocity from the Barycentric Cartesian equatorial coordinates
-                sun = ephem.get_particle("Sun", d["epochMJD_TDB"] + MJD_TO_JD_CONVERSTION - ephem.jd_ref)
-                equatorial_coords = np.array((x, y, z)) - np.array((sun.x, sun.y, sun.z))
-                equatorial_velocities = np.array((xdot, ydot, zdot)) - np.array((sun.vx, sun.vy, sun.vz))
-
-                # Convert to ecliptic coordinates
-                ecliptic_coords = np.array(equatorial_to_ecliptic(equatorial_coords))
-                ecliptic_velocities = np.array(equatorial_to_ecliptic(equatorial_velocities))
-
-                row = tuple(np.concatenate([ecliptic_coords, ecliptic_velocities]))
-
-            elif convert_to == "BCOM":
-                if has_covariance:
-                    # Our covariance matrix is already in equatorial cartesian so no tranformation
-                    # and we can use the BCART_EQ coordinates to convert our covariance matrix to the cometary format.
-                    cov = covariance_cometary_xyz(gm_total, x, y, z, xdot, ydot, zdot, d["epochMJD_TDB"], cov)
-                # Convert back to ecliptic from parse_orbit_row's equatorial output.
-                ecliptic_coords = np.array(equatorial_to_ecliptic([x, y, z]))
-                ecliptic_velocities = np.array(equatorial_to_ecliptic([xdot, ydot, zdot]))
-                x, y, z, xdot, ydot, zdot = tuple(np.concatenate([ecliptic_coords, ecliptic_velocities]))
-
-                # Use universal_cometary to convert to BCOM with mu = gm_total (used for barycentric)
-                row = universal_cometary(gm_total, x, y, z, xdot, ydot, zdot, d["epochMJD_TDB"])
-            elif convert_to == "COM":
-                # Convert out of barycentric by subtracting the Sun's position and velocity from the BCART coordinates
-                equatorial_coords = np.array((x, y, z)) - np.array((sun.x, sun.y, sun.z))
-                equatorial_velocities = np.array((xdot, ydot, zdot)) - np.array((sun.vx, sun.vy, sun.vz))
-                if has_covariance:
-                    # We now use our cartesian equatorial coordinates, which have been adjusted to
-                    # no longer be barycentric, to convert our covariance matrix to the cometary format.
-                    cov = covariance_cometary_xyz(
-                        gm_sun,
-                        equatorial_coords[0],
-                        equatorial_coords[1],
-                        equatorial_coords[2],
-                        equatorial_velocities[0],
-                        equatorial_velocities[1],
-                        equatorial_velocities[2],
-                        d["epochMJD_TDB"],
-                        cov,
-                    )
-
-                # Convert back to ecliptic from parse_orbit_row's equatorial output.
-                ecliptic_coords = np.array(equatorial_to_ecliptic(equatorial_coords))
-                ecliptic_velocities = np.array(equatorial_to_ecliptic(equatorial_velocities))
-                x, y, z, xdot, ydot, zdot = tuple(np.concatenate([ecliptic_coords, ecliptic_velocities]))
-
-                # Use universal_cometary to convert to COM with mu = gm_sun
-                row = universal_cometary(gm_sun, x, y, z, xdot, ydot, zdot, d["epochMJD_TDB"])
-
-            elif convert_to == "BKEP":
-                if has_covariance:
-                    # Our covariance matrix is already in equatorial cartesian so using the BCART coordinates
-                    # we can convert our covariance matrix to barycentric keplerian.
-                    cov = covariance_keplerian_xyz(
-                        gm_total, x, y, z, xdot, ydot, zdot, d["epochMJD_TDB"], cov
-                    )
-
-                # Convert back to ecliptic from parse_orbit_row's equatorial output.
-                ecliptic_coords = np.array(equatorial_to_ecliptic([x, y, z]))
-                ecliptic_velocities = np.array(equatorial_to_ecliptic([xdot, ydot, zdot]))
-                x, y, z, xdot, ydot, zdot = tuple(np.concatenate([ecliptic_coords, ecliptic_velocities]))
-
-                # Use universal_keplerian to convert to BKEP with mu = gm_total
-                row = universal_keplerian(gm_total, x, y, z, xdot, ydot, zdot, d["epochMJD_TDB"])
-            elif convert_to == "KEP":
-                # Convert out of barycentric by subtracting the Sun's position and velocity from the Barycentric Cartesian coordinates
-                sun = ephem.get_particle("Sun", d["epochMJD_TDB"] + MJD_TO_JD_CONVERSTION - ephem.jd_ref)
-                equatorial_coords = np.array((x, y, z)) - np.array((sun.x, sun.y, sun.z))
-                equatorial_velocities = np.array((xdot, ydot, zdot)) - np.array((sun.vx, sun.vy, sun.vz))
-
-                if has_covariance:
-                    # We now use our cartesian equatorial coordinates, which have been adjusted to
-                    # no longer be barycentric, to convert our covariance matrix to the keplerian format.
-                    cov = covariance_keplerian_xyz(
-                        gm_sun,
-                        equatorial_coords[0],
-                        equatorial_coords[1],
-                        equatorial_coords[2],
-                        equatorial_velocities[0],
-                        equatorial_velocities[1],
-                        equatorial_velocities[2],
-                        d["epochMJD_TDB"],
-                        cov,
-                    )
-
-                # Convert back to ecliptic from parse_orbit_row's equatorial output.
-                ecliptic_coords = np.array(equatorial_to_ecliptic(equatorial_coords))
-                ecliptic_velocities = np.array(equatorial_to_ecliptic(equatorial_velocities))
-
-                # Use universal_keplerian to convert to KEP with mu = gm_sun
-                x, y, z, xdot, ydot, zdot = tuple(np.concatenate([ecliptic_coords, ecliptic_velocities]))
-                row = universal_keplerian(gm_sun, x, y, z, xdot, ydot, zdot, d["epochMJD_TDB"])
+                coords, vels = eq_coords, eq_vels
+                if convert_to == "CART":
+                    coords, vels = _subtract_sun(coords, vels, sun)
+                ecl_coords, ecl_vels = _to_ecliptic(coords, vels)
+                row = tuple(np.concatenate([ecl_coords, ecl_vels]))
             else:
-                raise ValueError(f"Invalid conversion type {convert_to}. Must be one of: {expected_formats}")
+                # Cometary (BCOM/COM) and Keplerian (BKEP/KEP). These differ only
+                # in: central mass (barycentric gm_total vs heliocentric gm_sun),
+                # whether the Sun is subtracted, and which element/covariance
+                # routine is used. The covariance is built from the *equatorial*
+                # state (the basis those routines expect); the element conversion
+                # uses the *ecliptic* state.
+                barycentric = convert_to in ("BCOM", "BKEP")
+                cometary = convert_to in ("BCOM", "COM")
+                mu = gm_total if barycentric else gm_sun
+
+                coords, vels = eq_coords, eq_vels
+                if not barycentric:
+                    coords, vels = _subtract_sun(coords, vels, sun)
+
+                if has_covariance:
+                    cov_fn = covariance_cometary_xyz if cometary else covariance_keplerian_xyz
+                    cov = cov_fn(mu, coords[0], coords[1], coords[2], vels[0], vels[1], vels[2], epoch, cov)
+
+                ecl_coords, ecl_vels = _to_ecliptic(coords, vels)
+                transform = universal_cometary if cometary else universal_keplerian
+                row = transform(
+                    mu,
+                    ecl_coords[0],
+                    ecl_coords[1],
+                    ecl_coords[2],
+                    ecl_vels[0],
+                    ecl_vels[1],
+                    ecl_vels[2],
+                    epoch,
+                )
 
         row += (d["epochMJD_TDB"],)
         row += tuple(d[col] for col, _ in cols_to_keep)
@@ -423,7 +371,7 @@ def convert(
     num_workers=1,
     cache_dir=None,
     primary_id_column_name="ObjID",
-    extra_cols_to_keep=[],
+    extra_cols_to_keep=None,
 ):
     """
     Convert a structured numpy array to a different orbital format with support for parallel processing.


### PR DESCRIPTION
Part of #360 (clarity audit). (Perf optimization of `convert` is tracked
separately in #93 and deferred past v1.0 -- see profiling notes there.)

- Collapse the four near-identical cometary/Keplerian output branches into one
  block keyed on (barycentric?, cometary?); extract `_subtract_sun`/`_to_ecliptic`.
- Drop two redundant Sun-particle re-fetches; fix the `MJD_TO_JD_CONVERSTION` typo;
  replace mutable default args with `None`.

Behavior-preserving: all `test_convert.py` tests pass.
