### PR TITLE
v1.0 clarity sweep: comet, orbit_conversion, readers, detection, bk_fit

### DIFF
--- a/src/layup/comet.py
+++ b/src/layup/comet.py
@@ -18,6 +18,14 @@ from layup.utilities.data_processing_utilities import (
 # These are the maximum and minimum dates that the ASSIST ephemeris file allows for
 ASSIST_TIMEFRAME_MAX_MJD = 236455
 ASSIST_TIMEFRAME_MIN_MJD = -163545
+
+# Heliocentric distance (au) at which a comet's "original"/"future" barycentric
+# orbit is evaluated. Far enough from the Sun that planetary perturbations are
+# negligible, so the osculating elements there represent the orbit before (or
+# after) its passage through the planetary region. The integration in this
+# module marches each comet out to this distance.
+REFERENCE_DISTANCE_AU = 250.0
+
 logger = logging.getLogger(__name__)
 
 INPUT_READERS = {
@@ -53,7 +61,7 @@ def _remove_spc(data):
     for i in range(len(data_BCOM)):
         if data_BCOM["e"][i] < 1:
             a = data_BCOM["q"][i] / (1 - data_BCOM["e"][i])
-            if np.isinf(a) or a < 250 or data_BCOM["q"][i] > 250:
+            if np.isinf(a) or a < REFERENCE_DISTANCE_AU or data_BCOM["q"][i] > REFERENCE_DISTANCE_AU:
                 to_delete.append(i)
     data = np.delete(data, to_delete)
 
@@ -87,20 +95,19 @@ def _assist_integrate(sim, ex, dt, ephem, include_assist=True):
         The simulation after integration.
     """
     sim.dt = dt
-    # print(sim.t, sim.dt)
-    if include_assist == True:
+    if include_assist:
         primary = ephem.get_particle("sun", sim.t)
     else:
         primary = sim.particles[0]
     oi = sim.particles[-1].orbit(primary=primary)
 
-    if include_assist == True:
+    if include_assist:
         ex.integrate_or_interpolate(sim.t + dt)
 
     else:
         sim.integrate(sim.t + dt)
 
-    if include_assist == True:
+    if include_assist:
         primary = ephem.get_particle("sun", sim.t)
     else:
         primary = sim.particles[0]
@@ -117,14 +124,12 @@ def _direction_of_integration(sim, ex, step, ephem, include_assist=True):
     ----------
     sim : REBOUND simulation
         The data to use comet function on.
+    ex : ASSIST Extras object
+        The ASSIST extras.
     step : int
         The timestep to integrate across.
     ephem : ASSIST Ephem Object
         The ASSIST Ephemeris.
-    ex : ASSIST Extras object
-        The ASSIST extras.
-    dt : int
-        The timestep to integrate across.
     include_assist : bool, optional
         If True, the simulation will run the integration through ASSIST, otherwise it will be a pure REBOUND integration. Default is True.
 
@@ -154,7 +159,7 @@ def _direction_of_integration(sim, ex, step, ephem, include_assist=True):
 
     else:
         # Moving inwards; if already passed 250au go back, otherwise go forward
-        if of.d > 250:
+        if of.d > REFERENCE_DISTANCE_AU:
             dt = abs(step)
 
         else:
@@ -214,17 +219,17 @@ def _apply_comet(data, args, aux=None, cache_dir=None, primary_id_column_name=No
         )  # Decide whether to go backwards in time or forwards
 
         if dt > 0:
-            while of.d > 250 and oi.d > of.d and sim.t < ASSIST_TIMEFRAME_MAX_MJD:
+            while of.d > REFERENCE_DISTANCE_AU and oi.d > of.d and sim.t < ASSIST_TIMEFRAME_MAX_MJD:
                 oi, of, sim = _assist_integrate(sim, ex, dt, ephem, include_assist=True)
 
         else:
-            while of.d < 250 and oi.d < of.d and sim.t > ASSIST_TIMEFRAME_MIN_MJD:
+            while of.d < REFERENCE_DISTANCE_AU and oi.d < of.d and sim.t > ASSIST_TIMEFRAME_MIN_MJD:
                 oi, of, sim = _assist_integrate(sim, ex, dt, ephem, include_assist=True)
 
         if sim.t >= ASSIST_TIMEFRAME_MAX_MJD or sim.t <= ASSIST_TIMEFRAME_MIN_MJD:
             # If comet goes outside assist timeframe, continue the simulation in pure rebound
             rebound_only.append(comet)
-            print(f"{comet} has exceeded the timeframe of the ASSIST Ephemeris")
+            logger.warning(f"{comet} has exceeded the timeframe of the ASSIST Ephemeris")
         else:
             output[comet] = (1 / of.a, of.a, of.d, of.e)
 
@@ -232,7 +237,7 @@ def _apply_comet(data, args, aux=None, cache_dir=None, primary_id_column_name=No
     sim_dict = generate_simulations(ephem, Msun, Mtot, orbit_df[orbit_df["ObjID"].isin(rebound_only)], args)
     step = 10
     for comet in rebound_only:
-        print(f"Running rebound only for {comet}")
+        logger.info(f"Running rebound only for {comet}")
         sim = sim_dict[comet]["sim"]
         ex = sim_dict[comet]["ex"]
 
@@ -246,11 +251,11 @@ def _apply_comet(data, args, aux=None, cache_dir=None, primary_id_column_name=No
         )  # Decide whether to go backwards in time or forwards
 
         if dt > 0:
-            while of.d > 250 and oi.d > of.d:
+            while of.d > REFERENCE_DISTANCE_AU and oi.d > of.d:
                 oi, of, sim = _assist_integrate(sim, ex, dt, ephem, include_assist=False)
 
         else:
-            while of.d < 250 and oi.d < of.d:
+            while of.d < REFERENCE_DISTANCE_AU and oi.d < of.d:
                 oi, of, sim = _assist_integrate(sim, ex, dt, ephem, include_assist=False)
         output[comet] = (1 / of.a, of.a, of.d, of.e)
 

--- a/src/layup/utilities/file_io/Obs80Reader.py
+++ b/src/layup/utilities/file_io/Obs80Reader.py
@@ -4,7 +4,13 @@ from layup.utilities.file_io.ObjectDataReader import ObjectDataReader
 
 
 def two_line_row_start(line):
-    """Checks if the MPC Obs80 line is the first line of a two-line row format."""
+    """Checks if the MPC Obs80 line is the first line of a two-line row format.
+
+    Column 15 (0-indexed 14) is the MPC "note 2" / observation-type code. The
+    codes S (satellite), R (radar) and V (roving observer) each emit a second
+    line carrying the observer position/data, so a line bearing one of them is
+    the first of a two-line record.
+    """
     note2 = line[14]
     return note2 == "S" or note2 == "R" or note2 == "V"
 

--- a/src/layup/utilities/orbit_conversion.py
+++ b/src/layup/utilities/orbit_conversion.py
@@ -290,8 +290,6 @@ def universal_cartesian(mu, q, e, incl, longnode, argperi, tp, epochMJD_TDB):
     v2 = mu * (1 + e) / q
     alpha = 2 * mu / r0 - v2
 
-    # print(alpha, np.sqrt(v2), mu/alpha)
-
     # bracket the root
     ds = (t - 0) / 4
     s_prev = 0
@@ -496,9 +494,7 @@ def universal_cometary(mu, x, y, z, vx, vy, vz, epochMJD_TDB):
 
     incl = jnp.arccos(h_vec[2] / h)
 
-    longnode = atan2_checkzero(
-        h_vec[0], -h_vec[1]
-    )  # jax.lax.cond(jnp.logical_and(h_vec[0] != 0.0, h_vec[1] != 0.0), lambda x : jnp.arctan2(h_vec[0], -h_vec[1]), lambda x : 0., 0)
+    longnode = atan2_checkzero(h_vec[0], -h_vec[1])
 
     ecostrueanom = p / r - 1.0
     esintrueanom = rdot * h / mu
@@ -506,9 +502,7 @@ def universal_cometary(mu, x, y, z, vx, vy, vz, epochMJD_TDB):
 
     q = p / (1 + e)
 
-    trueanom = atan2_checkzero(
-        esintrueanom, ecostrueanom
-    )  # jax.lax.cond(jnp.logical_and(esintrueanom != 0, ecostrueanom != 0), lambda x : jnp.arctan2(esintrueanom, ecostrueanom), lambda x : 0.0, 0)
+    trueanom = atan2_checkzero(esintrueanom, ecostrueanom)
 
     cosnode = jnp.cos(longnode)
     sinnode = jnp.sin(longnode)
@@ -517,9 +511,7 @@ def universal_cometary(mu, x, y, z, vx, vy, vz, epochMJD_TDB):
     rcosu = pos[0] * cosnode + pos[1] * sinnode
     rsinu = (pos[1] * cosnode - pos[0] * sinnode) / jnp.cos(incl)  # should check zero
 
-    u = atan2_checkzero(
-        rsinu, rcosu
-    )  # jax.lax.cond(jnp.logical_and(rsinu != 0.0, rcosu != 0.0), lambda x, y : jnp.arctan2(x, y), lambda x,y : 0., rsinu, rcosu)
+    u = atan2_checkzero(rsinu, rcosu)
 
     argperi = u - trueanom
 
@@ -539,28 +531,6 @@ def universal_cometary(mu, x, y, z, vx, vy, vz, epochMJD_TDB):
         alpha,
         p,
     )
-    """ 
-	if e < 1:
-		# elliptical
-		eccanom = 2.0 * jnp.arctan(jnp.sqrt((1.0 - e) / (1.0 + e)) * jnp.tan(trueanom / 2.0))
-		meananom = eccanom - e * jnp.sin(eccanom)
-		meananom = principal_value(meananom)
-		a = mu / alpha
-		mm = jnp.sqrt(mu / (a * a * a))
-		tp = epochMJD_TDB - meananom / mm
-	elif e == 1:
-		# parabolic
-		tf = jnp.tan(0.5 * trueanom)
-		B = 0.5 * (tf * tf * tf + 3 * tf)
-		mm = jnp.sqrt(mu / (p * p * p))
-		tp = epochMJD_TDB - B / (3 * mm)
-	else:
-		# hyperbolic
-		heccanom = 2.0 * jnp.arctanh(jnp.sqrt((e - 1.0) / (e + 1.0)) * jnp.tan(trueanom / 2.0))
-		N = e * jnp.sinh(heccanom) - heccanom
-		a = mu / alpha
-		mm = jnp.sqrt(-mu / (a * a * a))
-		tp = epochMJD_TDB - N / mm"""
 
     return q, e, incl, longnode, argperi, tp
 
@@ -629,7 +599,6 @@ jac_cometary_xyz = jax.jacobian(universal_cometary, argnums=(1, 2, 3, 4, 5, 6))
 jac_keplerian_xyz = jax.jacobian(universal_keplerian, argnums=(1, 2, 3, 4, 5, 6))
 
 
-# @jax.jit
 def covariance_ecl_to_eq(covariance):
     """
     Converts a covariance matrix from ecliptic to equatorial coordinates.

--- a/src/layup/utilities/orbit_conversion.py
+++ b/src/layup/utilities/orbit_conversion.py
@@ -115,9 +115,9 @@ def root_function(s, mu, alpha, r0, r0dot, t):
     Returns
     -------
     f : float
-        universal Kepler equation)
+        universal Kepler equation
     fp : float
-        (first derivative of f
+        first derivative of f
     fpp : float
         second derivative of f
     fppp : float
@@ -170,9 +170,8 @@ def halley_safe(x1, x2, mu, alpha, r0, r0dot, t, xacc=1e-14, maxit=100):
 
     """
     # verify the bracket
-    # Use these values later
-    fl, fpl, fppl = root_function(x1, mu, alpha, r0, r0dot, t)[0:3]
-    fh, fph, fpph = root_function(x2, mu, alpha, r0, r0dot, t)[0:3]
+    fl, fpl = root_function(x1, mu, alpha, r0, r0dot, t)[0:2]
+    fh, fph = root_function(x2, mu, alpha, r0, r0dot, t)[0:2]
     if (fl > 0.0 and fh > 0.0) or (fl < 0.0 and fh < 0.0):
         return False, np.nan, fl
     if fl == 0:
@@ -187,11 +186,6 @@ def halley_safe(x1, x2, mu, alpha, r0, r0dot, t, xacc=1e-14, maxit=100):
     else:
         xh = x1
         xl = x2
-
-    if np.abs(fl) < np.abs(fh):
-        rts, f, fp, fpp = xl, fl, fpl, fppl
-    else:
-        rts, f, fp, fpp = xh, fh, fph, fpph
 
     rts = 0.5 * (x1 + x2)  # Initialize the guess for root,
     dxold = np.abs(x2 - x1)  # the “stepsize before last,”
@@ -391,6 +385,11 @@ def principal_value(theta):
 
 @jax.jit
 def atan2_checkzero(x, y):
+    """Two-argument arctangent that returns 0 when both x and y are zero.
+
+    Guards the angle computations in universal_keplerian against the undefined
+    atan2(0, 0) (e.g. a node or argument of latitude that is exactly degenerate).
+    """
     return jax.lax.cond(
         jnp.logical_and(x != 0.0, y != 0), lambda x, y: jnp.arctan2(x, y), lambda x, y: 0.0, x, y
     )
@@ -398,6 +397,13 @@ def atan2_checkzero(x, y):
 
 @jax.jit
 def eccanom(e, trueanom, mu, alpha, p):
+    """Time from perihelion (days) for an elliptical orbit (e < 1).
+
+    Returns t_p relative to the state epoch (the caller adds the epoch). The
+    (e, trueanom, mu, alpha, p) signature is shared with paranom/hypanom so
+    jax.lax.cond can dispatch on eccentricity with identical arguments; this
+    branch uses e, trueanom, mu and alpha (= mu/a).
+    """
     eccanom = 2.0 * jnp.arctan(jnp.sqrt((1.0 - e) / (1.0 + e)) * jnp.tan(trueanom / 2.0))
     meananom = eccanom - e * jnp.sin(eccanom)
     meananom = principal_value(meananom)
@@ -409,6 +415,11 @@ def eccanom(e, trueanom, mu, alpha, p):
 
 @jax.jit
 def paranom(e, trueanom, mu, alpha, p):
+    """Time from perihelion (days) for a parabolic orbit (e == 1).
+
+    Returns t_p relative to the state epoch. Shares the anomaly-helper signature
+    (see eccanom); this branch uses trueanom, mu and p (the semi-latus rectum).
+    """
     tf = jnp.tan(0.5 * trueanom)
     B = 0.5 * (tf * tf * tf + 3 * tf)
     mm = jnp.sqrt(mu / (p * p * p))
@@ -418,6 +429,11 @@ def paranom(e, trueanom, mu, alpha, p):
 
 @jax.jit
 def hypanom(e, trueanom, mu, alpha, p):
+    """Time from perihelion (days) for a hyperbolic orbit (e > 1).
+
+    Returns t_p relative to the state epoch. Shares the anomaly-helper signature
+    (see eccanom); this branch uses e, trueanom, mu and alpha (= mu/a).
+    """
     heccanom = 2.0 * jnp.arctanh(jnp.sqrt((e - 1.0) / (e + 1.0)) * jnp.tan(trueanom / 2.0))
     N = e * jnp.sinh(heccanom) - heccanom
     a = mu / alpha

--- a/src/lib/detection.cpp
+++ b/src/lib/detection.cpp
@@ -102,6 +102,11 @@ namespace orbit_fit
 
     using ObservationType = std::variant<AstrometryObservation, StreakObservation, RadarObservation>;
 
+    // Default astrometric 1-sigma uncertainty: 1 arcsecond expressed in radians
+    // (206265 arcsec per radian). Used when a caller supplies no per-observation
+    // RA/Dec uncertainties.
+    constexpr double DEFAULT_ASTROMETRY_UNC_RAD = 1.0 / 206265.0;
+
     // --- Main Observation Structure ---
     // Now, Observation has private constructors and public static factory methods.
     struct Observation
@@ -151,6 +156,8 @@ namespace orbit_fit
         }
 
     public:
+        // Astrometry observation with the default RA/Dec uncertainties; delegates
+        // to the explicit-uncertainty constructor below.
         Observation(
             double ep,
             std::array<double, 3> obs_position,
@@ -158,26 +165,9 @@ namespace orbit_fit
             std::array<double, 3> rho,
             std::array<double, 3> avec,
             std::array<double, 3> dvec)
+            : Observation(ep, obs_position, obs_velocity, rho, avec, dvec,
+                          DEFAULT_ASTROMETRY_UNC_RAD, DEFAULT_ASTROMETRY_UNC_RAD)
         {
-            epoch = ep;
-            observer_position = obs_position;
-            observer_velocity = obs_velocity;
-            observation_type = AstrometryObservation();
-
-            rho_hat.x() = rho[0];
-            rho_hat.y() = rho[1];
-            rho_hat.z() = rho[2];
-
-            a_vec.x() = avec[0];
-            a_vec.y() = avec[1];
-            a_vec.z() = avec[2];
-
-            d_vec.x() = dvec[0];
-            d_vec.y() = dvec[1];
-            d_vec.z() = dvec[2];
-
-            ra_unc = 1.0 / 206265;
-            dec_unc = 1.0 / 206265;
         }
 
         Observation(
@@ -220,27 +210,21 @@ namespace orbit_fit
         {
             Observation obs(epoch_val, obs_position, obs_velocity);
             obs.observation_type = AstrometryObservation();
-            obs.ra_unc = 1.0 / 206265;
-            obs.dec_unc = 1.0 / 206265;
+            obs.ra_unc = DEFAULT_ASTROMETRY_UNC_RAD;
+            obs.dec_unc = DEFAULT_ASTROMETRY_UNC_RAD;
             obs.rho_hat = rho_hat_from_ra_dec(ra, dec);
             obs.a_vec = a_vec_from_rho_hat(obs.rho_hat);
             obs.d_vec = d_vec_from_rho_hat(obs.rho_hat);
             return obs;
         }
 
-        // Factory method for an Astrometry observation.
+        // Factory method for an Astrometry observation with an object ID.
         static Observation from_astrometry_with_id(std::string objID,
                                                    double ra, double dec, double epoch_val,
                                                    const std::array<double, 3> &obs_position,
                                                    const std::array<double, 3> &obs_velocity)
         {
-            Observation obs(epoch_val, obs_position, obs_velocity);
-            obs.observation_type = AstrometryObservation();
-            obs.ra_unc = 1.0 / 206265;
-            obs.dec_unc = 1.0 / 206265;
-            obs.rho_hat = rho_hat_from_ra_dec(ra, dec);
-            obs.a_vec = a_vec_from_rho_hat(obs.rho_hat);
-            obs.d_vec = d_vec_from_rho_hat(obs.rho_hat);
+            Observation obs = from_astrometry(ra, dec, epoch_val, obs_position, obs_velocity);
             obs.objID = objID;
             return obs;
         }

--- a/src/lib/orbit_fit/bk_fit.cpp
+++ b/src/lib/orbit_fit/bk_fit.cpp
@@ -31,6 +31,12 @@ FitResult run_bk_native_fit(
     result.epoch = initial_guess.epoch;
     result.csq = HUGE_VAL;
     result.niter = 0;
+    // NOTE: this fitter is astrometry-only. It builds exactly two residual rows
+    // (RA, Dec) per detection throughout (see the 2*N design matrix below), so
+    // ndof = 2 * n_obs - 6. Streak (rate) and radar (delay/Doppler) rows are NOT
+    // handled here -- such observations would be treated as plain astrometry and
+    // their extra information silently ignored. Use the Cartesian orbit_fit path
+    // for those until BK gains rate/radar residual support.
     result.ndof = (int)(2 * detections.size() - 6);
     result.state = initial_guess.state;
     result.cov.fill(0.0);


### PR DESCRIPTION
Part of #360 (clarity audit). Quality-only, behavior-preserving.

- `comet.py`: name the 250 au reference distance; `print()`->logger; drop
  `==True`/commented print; docstring fix.
- `orbit_conversion.py`: delete the dead pre-jax `tp` block + commented
  `jax.lax.cond`/`@jax.jit`/debug print; document the anomaly helpers; remove
  `halley_safe` dead init.
- `Obs80Reader.py`: document the MPC note-2 two-line record codes.
- `detection.cpp`: `DEFAULT_ASTROMETRY_UNC_RAD` constant; delegating Observation
  constructor + `from_astrometry_with_id` delegation.
- `bk_fit.cpp`: document the astrometry-only 2N row layout.

Remaining #360 items in `orbit_fit.cpp` are intentionally left until #356 lands
(it edits that file).
