### PR TITLE
CI: surface skipped tests with pytest -rs (#359 step 1)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -51,4 +51,5 @@ jobs:
         pip list
     - name: Run unit tests with pytest
       run: |
-        python -m pytest -n auto
+        # -rs surfaces skipped tests + reasons in the CI log (issue #359).
+        python -m pytest -n auto -rs

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -49,7 +49,10 @@ jobs:
         layup bootstrap
     - name: Run unit tests with pytest
       run: |
-        python -m pytest -n auto --cov=layup --cov-report=xml
+        # -rs prints a summary of skipped tests and their reasons, so silently
+        # skipped suites (e.g. ephem-gated fit/validation tests) are visible in
+        # the CI log (issue #359).
+        python -m pytest -n auto -rs --cov=layup --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v6
       with:


### PR DESCRIPTION
First step toward #359 (visibility before the de-gating fix).

Adds `-rs` to the pytest invocations (testing-and-coverage + smoke-test) so skipped tests + reasons appear in the CI log.

**Why:** a green CI run shows 283 passed / **19 skipped**, but the default `pytest -n auto` output only prints a count. Locally (ASSIST ephem present) the same invocation gives 298 passed / 1 skipped, so ~18 ephem-gated suites (BK engine, radar, non-grav, JPL validation) silently skip on CI. `-rs` will show exactly which suites skip and why on the next run, so the real de-gating fix (ensure the ASSIST ephem is at the guard'''s cache path on CI / fail loudly if absent) can be targeted.