### PR TITLE
tests: fix ephem cache path so gated fit tests run on Linux CI (#359)

### DIFF
--- a/tests/layup/test_3i_atlas_validation.py
+++ b/tests/layup/test_3i_atlas_validation.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import pooch
 from pathlib import Path
 
 import numpy as np
@@ -30,7 +31,7 @@ from layup.orbitfit import orbitfit
 from layup.utilities.data_utilities_for_tests import get_test_filepath
 from layup.utilities.file_io.CSVReader import CSVDataReader
 
-CACHE = os.path.expanduser("~/Library/Caches/layup")
+CACHE = str(pooch.os_cache("layup"))
 EPHEM_PLANETS = os.path.join(CACHE, "linux_p1550p2650.440")
 EPHEM_SMALLBODIES = os.path.join(CACHE, "sb441-n16.bsp")
 EPHEM_AVAILABLE = os.path.exists(EPHEM_PLANETS) and os.path.exists(EPHEM_SMALLBODIES)

--- a/tests/layup/test_nongrav_a2.py
+++ b/tests/layup/test_nongrav_a2.py
@@ -20,6 +20,7 @@ A2 is only weakly constrained on short arcs, so the arc spans several years.
 from __future__ import annotations
 
 import os
+import pooch
 
 import numpy as np
 import pytest
@@ -27,7 +28,7 @@ import pytest
 from layup.orbitfit import orbitfit
 from layup.routines import FitResult, Observation, get_ephem, run_from_vector_with_initial_guess
 
-CACHE = os.path.expanduser("~/Library/Caches/layup")
+CACHE = str(pooch.os_cache("layup"))
 _EPHEM = ("linux_p1550p2650.440", "sb441-n16.bsp")
 _EPHEM_OK = all(os.path.exists(os.path.join(CACHE, f)) for f in _EPHEM)
 pytestmark = pytest.mark.skipif(

--- a/tests/layup/test_radar_realdata_validation.py
+++ b/tests/layup/test_radar_realdata_validation.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import pooch
 from pathlib import Path
 
 import numpy as np
@@ -34,7 +35,7 @@ import pytest
 from layup.orbitfit import _get_result_dtypes, orbitfit
 from layup.utilities.data_processing_utilities import get_cov_columns
 
-CACHE = os.path.expanduser("~/Library/Caches/layup")
+CACHE = str(pooch.os_cache("layup"))
 _EPHEM_OK = all(os.path.exists(os.path.join(CACHE, f)) for f in ("linux_p1550p2650.440", "sb441-n16.bsp"))
 pytestmark = pytest.mark.skipif(
     not _EPHEM_OK, reason="ASSIST ephemeris not in layup cache; run `layup bootstrap`"

--- a/tests/layup/test_real_data_validation.py
+++ b/tests/layup/test_real_data_validation.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import pooch
 from pathlib import Path
 
 import numpy as np
@@ -33,7 +34,7 @@ from layup.orbitfit import orbitfit
 from layup.utilities.data_utilities_for_tests import get_test_filepath
 from layup.utilities.file_io.CSVReader import CSVDataReader
 
-CACHE = os.path.expanduser("~/Library/Caches/layup")
+CACHE = str(pooch.os_cache("layup"))
 EPHEM_PLANETS = os.path.join(CACHE, "linux_p1550p2650.440")
 EPHEM_SMALLBODIES = os.path.join(CACHE, "sb441-n16.bsp")
 EPHEM_AVAILABLE = os.path.exists(EPHEM_PLANETS) and os.path.exists(EPHEM_SMALLBODIES)

--- a/tests/layup/test_tno_validation.py
+++ b/tests/layup/test_tno_validation.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import pooch
 from pathlib import Path
 
 import numpy as np
@@ -31,7 +32,7 @@ from layup.orbitfit import orbitfit
 from layup.utilities.data_utilities_for_tests import get_test_filepath
 from layup.utilities.file_io.CSVReader import CSVDataReader
 
-CACHE = os.path.expanduser("~/Library/Caches/layup")
+CACHE = str(pooch.os_cache("layup"))
 EPHEM_PLANETS = os.path.join(CACHE, "linux_p1550p2650.440")
 EPHEM_SMALLBODIES = os.path.join(CACHE, "sb441-n16.bsp")
 EPHEM_AVAILABLE = os.path.exists(EPHEM_PLANETS) and os.path.exists(EPHEM_SMALLBODIES)

--- a/tests/layup/test_weight_data.py
+++ b/tests/layup/test_weight_data.py
@@ -22,6 +22,7 @@ of regression.
 from __future__ import annotations
 
 import os
+import pooch
 
 import numpy as np
 import pytest
@@ -31,7 +32,7 @@ from layup.utilities.data_processing_utilities import parse_cov
 from layup.utilities.data_utilities_for_tests import get_test_filepath
 from layup.utilities.file_io.CSVReader import CSVDataReader
 
-CACHE = os.path.expanduser("~/Library/Caches/layup")
+CACHE = str(pooch.os_cache("layup"))
 EPHEM_PLANETS = os.path.join(CACHE, "linux_p1550p2650.440")
 EPHEM_SMALLBODIES = os.path.join(CACHE, "sb441-n16.bsp")
 EPHEM_AVAILABLE = os.path.exists(EPHEM_PLANETS) and os.path.exists(EPHEM_SMALLBODIES)


### PR DESCRIPTION
Closes #359. The de-gating fix that #373'''s `-rs` visibility pinpointed.

**Root cause:** six fit/validation suites hardcoded the **macOS** cache path (`~/Library/Caches/layup`) for both their ephem-presence guard and the runtime `cache_dir`. On Linux the ASSIST ephemeris is at `~/.cache/layup` (where `layup bootstrap` puts it), so these suites saw it as missing and **silently skipped on Linux CI**. (The shared `requires_ephem` guard uses `pooch.os_cache`, which is why `test_bk_fit`/`test_iod_picker`/`test_bk_everywhere` already ran.)

**Fix:** use `str(pooch.os_cache("layup"))` (platform-correct, matching the already-working `test_radar_validation`/`test_streak_validation`) in: `test_nongrav_a2`, `test_radar_realdata_validation`, `test_3i_atlas_validation`, `test_tno_validation`, `test_real_data_validation`, `test_weight_data`.

Re-enables ~17 non-grav / radar / JPL-validation tests on Linux CI — the skip count should drop from 19 to ~2. No-op on macOS (paths coincide); representative subset passes locally.

**Validation to watch:** this PR'''s own Linux CI `-rs` summary (once #373 merges, or visible here) should show only the `iod_auto` slow-test + one diagnostic skip remaining.