### PR TITLE
Clarity leftovers: remove debug printf, name magic numbers (#360)

### DIFF
--- a/src/lib/detection.cpp
+++ b/src/lib/detection.cpp
@@ -107,6 +107,11 @@ namespace orbit_fit
     // RA/Dec uncertainties.
     constexpr double DEFAULT_ASTROMETRY_UNC_RAD = 1.0 / 206265.0;
 
+    // Default streak (sky-motion-rate) 1-sigma uncertainty: 24 arcseconds in
+    // radians (206265 arcsec per radian), used when a caller supplies no
+    // per-observation RA-rate/Dec-rate uncertainties.
+    constexpr double DEFAULT_RATE_UNC_RAD = 24.0 / 206265.0;
+
     // --- Main Observation Structure ---
     // Now, Observation has private constructors and public static factory methods.
     struct Observation
@@ -236,8 +241,8 @@ namespace orbit_fit
                                        double epoch_val,
                                        const std::array<double, 3> &obs_position,
                                        const std::array<double, 3> &obs_velocity,
-                                       double ra_rate_uncy = 24.0 / 206265.0,
-                                       double dec_rate_uncy = 24.0 / 206265.0)
+                                       double ra_rate_uncy = DEFAULT_RATE_UNC_RAD,
+                                       double dec_rate_uncy = DEFAULT_RATE_UNC_RAD)
         {
             Observation obs(epoch_val, obs_position, obs_velocity);
             obs.observation_type = StreakObservation(ra_rate, dec_rate);
@@ -256,8 +261,8 @@ namespace orbit_fit
                                                double epoch_val,
                                                const std::array<double, 3> &obs_position,
                                                const std::array<double, 3> &obs_velocity,
-                                               double ra_rate_uncy = 24.0 / 206265.0,
-                                               double dec_rate_uncy = 24.0 / 206265.0)
+                                               double ra_rate_uncy = DEFAULT_RATE_UNC_RAD,
+                                               double dec_rate_uncy = DEFAULT_RATE_UNC_RAD)
         {
             Observation obs = from_streak(ra, dec, ra_rate, dec_rate, epoch_val, obs_position, obs_velocity,
                                           ra_rate_uncy, dec_rate_uncy);
@@ -350,13 +355,13 @@ namespace orbit_fit
             .def_static("from_streak", &Observation::from_streak,
                         py::arg("ra"), py::arg("dec"), py::arg("ra_rate"), py::arg("dec_rate"),
                         py::arg("epoch"), py::arg("observer_position"), py::arg("observer_velocity"),
-                        py::arg("ra_rate_unc") = 24.0 / 206265.0, py::arg("dec_rate_unc") = 24.0 / 206265.0,
+                        py::arg("ra_rate_unc") = DEFAULT_RATE_UNC_RAD, py::arg("dec_rate_unc") = DEFAULT_RATE_UNC_RAD,
                         "Construct a Streak observation")
             .def_static("from_streak_with_id", &Observation::from_streak_with_id,
                         py::arg("objID"),
                         py::arg("ra"), py::arg("dec"), py::arg("ra_rate"), py::arg("dec_rate"),
                         py::arg("epoch"), py::arg("observer_position"), py::arg("observer_velocity"),
-                        py::arg("ra_rate_unc") = 24.0 / 206265.0, py::arg("dec_rate_unc") = 24.0 / 206265.0,
+                        py::arg("ra_rate_unc") = DEFAULT_RATE_UNC_RAD, py::arg("dec_rate_unc") = DEFAULT_RATE_UNC_RAD,
                         "Construct a Streak observation")
             // Constructor for a Radar (delay/Doppler) observation.
             .def_static("from_radar", &Observation::from_radar,

--- a/src/lib/gauss/gauss.cpp
+++ b/src/lib/gauss/gauss.cpp
@@ -144,7 +144,10 @@ namespace orbit_fit
             return std::nullopt;
         }
 
-        // Filter eigenvalues: select those with (nearly) zero imaginary part and real part > min_distance
+        // Keep the companion-matrix eigenvalues that are physical ranges: real
+        // (imaginary part below a 1e-10 tolerance -- the eigensolver leaves tiny
+        // numerical imaginary parts on genuinely real roots) and beyond
+        // min_distance.
         std::vector<double> roots;
         for (int i = 0; i < ces.eigenvalues().size(); ++i)
         {

--- a/src/lib/orbit_fit/bk_fit.cpp
+++ b/src/lib/orbit_fit/bk_fit.cpp
@@ -89,11 +89,11 @@ FitResult run_bk_native_fit(
     // Initial Marquardt damping and accept threshold are copied verbatim
     // from the Cartesian fitter (orbit_fit at orbit_fit.cpp L553) so the two
     // engines ramp damping identically.  Both numbers are empirical: the
-    // 206265^2 factor is (arcsec-per-radian)^2, which puts lambda on the
+    // ARCSEC_PER_RAD^2 factor is (arcsec-per-radian)^2, which puts lambda on the
     // scale of the chi^2 curvature when residuals are measured in radians,
     // and the /1000 starting offset and the 0.1 gain-ratio accept threshold
     // were tuned for the Cartesian fit's convergence and reused as-is.
-    double lambda = (206265.0 * 206265.0) / 1000.0;
+    double lambda = (ARCSEC_PER_RAD * ARCSEC_PER_RAD) / 1000.0;
     const double rho_accept = 0.1;
     double chi2_prev = HUGE_VAL;
     double chi2_cur = HUGE_VAL;

--- a/src/lib/orbit_fit/predict.cpp
+++ b/src/lib/orbit_fit/predict.cpp
@@ -38,7 +38,7 @@ namespace orbit_fit
             double rho_mag = sqrt(dx * dx + dy * dy + dz * dz);
             if (r->status == REB_STATUS_GENERIC_ERROR)
             {
-                printf("barf %lf %le %lf\n", t, lt, rho_mag);
+                // Integrator failed during the light-time iteration; signal failure.
                 return 1;
             }
 


### PR DESCRIPTION
Small, low-risk readability fixes from the v1.0 clarity audit (#360). **No behavior change.**

- **predict.cpp** — drop the leftover `printf("barf ...")` debug line in the light-time integrator error path (the `return 1` is kept).
- **gauss.cpp** — explain the `1e-10` imaginary-part tolerance used to treat a companion-matrix eigenvalue as a real (physical) range.
- **detection.cpp** — replace the six `24.0 / 206265.0` literals (streak RA/Dec-rate default uncertainty) with a named `DEFAULT_RATE_UNC_RAD` constant alongside `DEFAULT_ASTROMETRY_UNC_RAD`.
- **bk_fit.cpp** — use the in-scope `ARCSEC_PER_RAD` constant for the Marquardt damping seed instead of the raw `206265.0` literal.

Part of #360. After this lands, the remaining #360 items (compute_single_residuals split, `obs_kind`→`ObsKind` enum, shared LM-step helper, error-handling convention, unity-build) are out of v1.0 scope and #360 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)