### PR TITLE
Resolve space-based observatories via JPL Horizons (Closes #55)

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -17,6 +17,11 @@ from sorcha.ephemeris.simulation_setup import furnish_spiceypy
 from layup.constants import AU_KM
 from layup.routines import FitResult
 from layup.utilities.layup_configs import LayupConfigs
+from layup.utilities.special_observatories import (
+    SPACE_OBSERVATORIES,
+    et_to_jd_tdb,
+    query_horizons_geocentric,
+)
 
 """ A module for utilities useful for processing data in structured numpy arrays """
 
@@ -464,6 +469,16 @@ class LayupObservatory(SorchaObservatory):
         # Update the cached coordinates and obscode_cache_key for the case of a moving observatory
         if coords is None or None in coords or np.isnan(coords).any():
             obscode_cache_key = self.create_obscode_cache_key(obscode, et)
+
+            # A space-based ("special case") observatory -- a spacecraft such as
+            # HST or JWST (issue #55) -- has no parallax constants. When the user
+            # does not supply an explicit per-observation position for it, resolve
+            # its geocentric state from JPL Horizons. A user-supplied ADES
+            # position always takes priority (handled by the block below).
+            if obscode in SPACE_OBSERVATORIES and not self._has_ades_position(data):
+                self._populate_space_observatory(obscode, et, obscode_cache_key)
+                return obscode_cache_key
+
             # The observatory does not have a fixed position, so don't try to calculate barycentric coordinates.
             # A non-fixed observatory must carry its reference frame ('sys'), center ('ctr') and the three
             # position components ('pos1'/'pos2'/'pos3') in the data.
@@ -566,6 +581,75 @@ class LayupObservatory(SorchaObservatory):
             return vel * AU_KM / (24 * 60 * 60)
         return vel
 
+    @staticmethod
+    def _has_ades_position(data):
+        """Whether the row carries a usable ADES per-observation position.
+
+        True only when all of ``sys``/``ctr``/``pos1``/``pos2``/``pos3`` are
+        present and the three position components are finite. Used to let a
+        user-supplied position override the JPL-Horizons lookup for a
+        space-based observatory (issue #55).
+        """
+        fields = ("sys", "ctr", "pos1", "pos2", "pos3")
+        if not all(field in data.dtype.names for field in fields):
+            return False
+        pos = np.array([data["pos1"], data["pos2"], data["pos3"]], dtype=float)
+        return not np.isnan(pos).any()
+
+    def _fetch_space_observatory_states(self, naif_id, jd_tdb_list):
+        """Geocentric states of a spacecraft at the given JD(TDB) epochs.
+
+        Thin wrapper around :func:`query_horizons_geocentric` -- a seam that
+        tests monkeypatch so they never touch the network.
+        """
+        return query_horizons_geocentric(naif_id, jd_tdb_list)
+
+    def _populate_space_observatory(self, obscode, et, obscode_cache_key):
+        """Resolve a space-based observatory's geocentric state via JPL Horizons.
+
+        Stores the geocentric position (km) and velocity (km/s) under the
+        per-epoch cache key, exactly as an ADES-supplied moving observer would,
+        so :meth:`_barycentric_moving_observatory` then adds Earth's barycentric
+        state to it (issue #55). A no-op if the key is already cached (e.g. warmed
+        by :meth:`_prefetch_space_observatories`).
+        """
+        if obscode_cache_key in self.ObservatoryXYZ:
+            return
+        naif_id, _ = SPACE_OBSERVATORIES[obscode]
+        jd = et_to_jd_tdb(et)
+        pos_km, vel_km_s = self._fetch_space_observatory_states(naif_id, [jd])[jd]
+        self.ObservatoryXYZ[obscode_cache_key] = np.asarray(pos_km, dtype=float)
+        self.ObservatoryVel[obscode_cache_key] = np.asarray(vel_km_s, dtype=float)
+
+    def _prefetch_space_observatories(self, data):
+        """Warm the cache for space-based observatories, one request per spacecraft.
+
+        Groups every epoch of each space-based obscode (that the user has not
+        overridden with an explicit ADES position) and resolves them in a single
+        batched JPL Horizons request, so a fit with N space-based observations
+        makes one HTTP call per spacecraft rather than N (issue #55).
+        """
+        if "stn" not in data.dtype.names:
+            return
+        wanted = {}  # obscode -> {et: jd_tdb}
+        for row in np.atleast_1d(data):
+            obscode = row["stn"]
+            if obscode not in SPACE_OBSERVATORIES or self._has_ades_position(row):
+                continue
+            et = row["et"]
+            if self.create_obscode_cache_key(obscode, et) in self.ObservatoryXYZ:
+                continue
+            wanted.setdefault(obscode, {})[et] = et_to_jd_tdb(et)
+
+        for obscode, et_to_jd in wanted.items():
+            naif_id, _ = SPACE_OBSERVATORIES[obscode]
+            states = self._fetch_space_observatory_states(naif_id, list(et_to_jd.values()))
+            for et, jd in et_to_jd.items():
+                pos_km, vel_km_s = states[jd]
+                key = self.create_obscode_cache_key(obscode, et)
+                self.ObservatoryXYZ[key] = np.asarray(pos_km, dtype=float)
+                self.ObservatoryVel[key] = np.asarray(vel_km_s, dtype=float)
+
     def _barycentric_moving_observatory(self, et, obscode_cache_key):
         """Barycentric position and velocity (km, km/s) of a moving observatory.
 
@@ -620,6 +704,10 @@ class LayupObservatory(SorchaObservatory):
         """
         if "stn" not in data.dtype.names:
             raise ValueError("The data must have a 'stn' field.")
+
+        # Resolve any space-based observatories up front, batching all of a
+        # spacecraft's epochs into a single JPL Horizons request (issue #55).
+        self._prefetch_space_observatories(data)
 
         res = []
         for row in data:

--- a/src/layup/utilities/special_observatories.py
+++ b/src/layup/utilities/special_observatories.py
@@ -82,6 +82,25 @@ def query_horizons_geocentric(naif_id, jd_tdb_list, timeout=30):
         state at the requested TDB epoch is returned, matching how layup
         supplies every other observer position (light time is handled later, in
         the integrator).
+
+    Notes
+    -----
+    We deliberately query the **geocentric** spacecraft state (center = Earth's
+    body center) rather than the barycentric one, so this plugs into the same
+    "geocentric observer offset + Earth's barycentric state" path the ground
+    stations use: ``_barycentric_moving_observatory`` adds Earth's barycentric
+    state (from layup's own SPICE kernel) to this offset. Referencing the offset
+    against a physical body (Earth) is more reproducible than referencing against
+    the solar-system barycenter, whose definition shifts between ephemeris
+    versions.
+
+    Caveat for high-precision work: Earth's geocenter as realized by layup's
+    SPICE kernel may differ slightly from the geocenter implied by the
+    spacecraft's Horizons reference ephemeris. The geocentric offset cancels
+    Earth's own position to first order, but a small residual inconsistency
+    (~meters) can remain. That is negligible for normal astrometry, but could
+    matter for very high precision applications such as space-based stellar
+    occultations -- flagged here as a known limitation (see PR #377 discussion).
     """
     out = {}
     jd_list = list(jd_tdb_list)
@@ -97,7 +116,7 @@ def _query_chunk(naif_id, jd_chunk, timeout):
         "OBJ_DATA": "NO",
         "MAKE_EPHEM": "YES",
         "EPHEM_TYPE": "VECTORS",
-        "CENTER": "'@399'",  # geocentric (Earth body center)
+        "CENTER": "'@399'",  # geocentric offset (see precision caveat in the docstring)
         "REF_PLANE": "FRAME",  # ICRF equatorial (not the ecliptic)
         "REF_SYSTEM": "ICRF",
         "VEC_CORR": "NONE",  # geometric state at the epoch

--- a/src/layup/utilities/special_observatories.py
+++ b/src/layup/utilities/special_observatories.py
@@ -1,0 +1,151 @@
+"""Resolve space-based ("special case") MPC observatory codes via JPL Horizons.
+
+A handful of MPC observatory codes denote *spacecraft* rather than fixed ground
+stations (issue #55). They have no parallax constants, so layup cannot compute
+their position geometrically, and -- unlike a roving ground observer -- the user
+usually does not carry an explicit per-observation position for them. For these
+codes we query the JPL Horizons vector API for the spacecraft's geocentric state
+at each observation epoch and feed it into the same moving-observer path that an
+ADES-supplied position uses (issue #147).
+
+The obscode -> NAIF-id map is ported from the Rust ``spacerocks`` project
+(``~/Dropbox/roman-footprint/spacerocks``). Spacecraft carry negative NAIF ids
+by JPL convention.
+
+This is intentionally a *live* HTTP lookup (the case is rare); a user-supplied
+ADES position always takes priority, so fits never depend on Horizons being
+reachable when a position is provided.
+"""
+
+import logging
+
+import numpy as np
+import requests
+
+logger = logging.getLogger(__name__)
+
+#: JPL Horizons REST endpoint.
+HORIZONS_API = "https://ssd.jpl.nasa.gov/api/horizons.api"
+
+#: MPC observatory code -> (JPL/NAIF id, human-readable name). Ported from the
+#: Rust ``spacerocks`` ``SPACEOBSERVATORIES`` map.
+SPACE_OBSERVATORIES = {
+    "245": ("-79", "Spitzer Space Telescope"),
+    "250": ("-48", "Hubble Space Telescope"),
+    "274": ("-170", "James Webb Space Telescope"),
+    "C49": ("-234", "STEREO-A"),
+    "C50": ("-235", "STEREO-B"),
+    "C51": ("-163", "WISE"),
+    "C54": ("-98", "New Horizons"),
+    "C55": ("-227", "Kepler"),
+    "C58": ("-33", "NEO Surveyor"),
+}
+
+#: Julian Date of the J2000 epoch.
+J2000_JD = 2451545.0
+SECONDS_PER_DAY = 86400.0
+
+#: Max epochs per Horizons request. Keeps the GET URL well within limits while
+#: still collapsing a many-observation fit into a few requests per spacecraft.
+_TLIST_CHUNK = 40
+
+
+def et_to_jd_tdb(et):
+    """SPICE ephemeris time (seconds past J2000 TDB) -> Julian Date (TDB)."""
+    return J2000_JD + et / SECONDS_PER_DAY
+
+
+def is_space_observatory(obscode):
+    """Whether ``obscode`` is a spacecraft we resolve via JPL Horizons."""
+    return obscode in SPACE_OBSERVATORIES
+
+
+def query_horizons_geocentric(naif_id, jd_tdb_list, timeout=30):
+    """Geocentric ICRF state of a spacecraft at the given epochs, via JPL Horizons.
+
+    Parameters
+    ----------
+    naif_id : str
+        JPL/NAIF id of the spacecraft (e.g. ``"-48"`` for Hubble).
+    jd_tdb_list : sequence of float
+        Observation epochs as Julian Date (TDB).
+    timeout : float, optional
+        Per-request HTTP timeout in seconds.
+
+    Returns
+    -------
+    dict
+        ``{jd_tdb: (pos_km, vel_km_s)}``; each value is a length-3 ``numpy``
+        array. Positions are geocentric (center = Earth body center), ICRF /
+        equatorial-J2000, in km, and velocities in km/s. No light-time or
+        aberration correction is applied (``VEC_CORR='NONE'``): the *geometric*
+        state at the requested TDB epoch is returned, matching how layup
+        supplies every other observer position (light time is handled later, in
+        the integrator).
+    """
+    out = {}
+    jd_list = list(jd_tdb_list)
+    for start in range(0, len(jd_list), _TLIST_CHUNK):
+        out.update(_query_chunk(naif_id, jd_list[start : start + _TLIST_CHUNK], timeout))
+    return out
+
+
+def _query_chunk(naif_id, jd_chunk, timeout):
+    params = {
+        "format": "json",
+        "COMMAND": f"'{naif_id}'",
+        "OBJ_DATA": "NO",
+        "MAKE_EPHEM": "YES",
+        "EPHEM_TYPE": "VECTORS",
+        "CENTER": "'@399'",  # geocentric (Earth body center)
+        "REF_PLANE": "FRAME",  # ICRF equatorial (not the ecliptic)
+        "REF_SYSTEM": "ICRF",
+        "VEC_CORR": "NONE",  # geometric state at the epoch
+        "OUT_UNITS": "KM-S",  # km and km/s -> layup's internal moving-observer units
+        "VEC_TABLE": "2",  # position + velocity
+        "VEC_LABELS": "NO",
+        "VEC_DELTA_T": "NO",
+        "CSV_FORMAT": "YES",
+        "TLIST_TYPE": "JD",
+        "TLIST": " ".join(f"{jd:.9f}" for jd in jd_chunk),
+    }
+    resp = requests.get(HORIZONS_API, params=params, timeout=timeout)
+    resp.raise_for_status()
+    text = resp.json().get("result", "")
+    return _parse_vectors(text, jd_chunk, naif_id)
+
+
+def _parse_vectors(text, jd_chunk, naif_id):
+    """Parse the CSV vector table between the ``$$SOE``/``$$EOE`` markers.
+
+    With ``CSV_FORMAT='YES'``, ``VEC_TABLE='2'`` and ``VEC_LABELS='NO'`` each
+    data row is ``JDTDB, CalendarDate, X, Y, Z, VX, VY, VZ`` (trailing comma).
+    """
+    lines = text.splitlines()
+    try:
+        soe = lines.index("$$SOE")
+        eoe = lines.index("$$EOE")
+    except ValueError:
+        raise RuntimeError(
+            f"JPL Horizons returned no vector data for target {naif_id}. " f"Response begins:\n{text[:500]}"
+        )
+
+    parsed = {}
+    for line in lines[soe + 1 : eoe]:
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 8:
+            continue
+        jd = float(parts[0])
+        state = np.array([float(p) for p in parts[2:8]], dtype=float)
+        parsed[round(jd, 6)] = (state[0:3], state[3:6])
+
+    result = {}
+    for jd in jd_chunk:
+        match = parsed.get(round(jd, 6))
+        if match is None:
+            raise RuntimeError(
+                f"JPL Horizons did not return a state for target {naif_id} at "
+                f"JD(TDB) {jd:.9f} (outside the spacecraft's SPK coverage?)."
+            )
+        result[jd] = match
+    return result

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -216,8 +216,11 @@ def test_moving_observatory_coordinate_cache():
     """Test that populate_observatory correctly populates the cache, is consistent across calls, and raises errors when required fields are missing."""
     observatory = LayupObservatory()
 
-    # Define test data
-    obscode = "C51"  # WISE (space observatory)
+    # Define test data. Use a roving observer (247): a moving observatory that
+    # must carry its own ADES position, and -- unlike a spacecraft code such as
+    # C51 -- is NOT resolved via JPL Horizons (issue #55), so a missing/NaN
+    # position is the error this test exercises.
+    obscode = "247"  # Roving Observer (ADES position required)
     ets = np.array([2451545.0, 2451546.0, 2451547.0])  # Example ephemeris times
     row_dtype = [
         ("sys", "U7"),
@@ -330,8 +333,10 @@ def test_fixed_observatory_with_zero_parallax_constant():
         if expected is not None:
             assert np.allclose(coords, expected)
 
-    # Codes with no parallax-constant keys (roving observer, space telescopes)
-    # must still report no fixed position so they take the ADES-position path.
+    # Codes with no parallax-constant keys must still report no fixed position,
+    # so they take a per-observation path: roving/other codes use the ADES
+    # position; spacecraft codes (C51, 250, ...) are resolved via JPL Horizons
+    # (issue #55).
     for obscode in ("247", "C51", "C57", "250"):
         coords = observatory.ObservatoryXYZ.get(obscode)
         assert coords == (None, None, None)

--- a/tests/layup/test_special_observatories.py
+++ b/tests/layup/test_special_observatories.py
@@ -1,0 +1,271 @@
+"""Tests for JPL-Horizons resolution of space-based observatories (issue #55).
+
+The pure-logic tests (the obscode map, the JD conversion, the Horizons
+response parser, and the HTTP client with the network mocked) run everywhere.
+The integration tests construct a ``LayupObservatory``, which furnishes SPICE
+kernels, so they are gated behind ``requires_ephem``; they still mock the HTTP
+layer so they never touch the network.
+"""
+
+import numpy as np
+import pytest
+
+from layup.utilities import special_observatories as so
+from layup.utilities.data_processing_utilities import AU_KM, LayupObservatory
+from layup.utilities.special_observatories import (
+    SPACE_OBSERVATORIES,
+    _parse_vectors,
+    et_to_jd_tdb,
+    is_space_observatory,
+    query_horizons_geocentric,
+)
+
+from _bk_guards import requires_ephem
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _vector_block(rows):
+    """Build a CSV Horizons ``result`` payload for (jd, pos_km, vel_km_s) rows.
+
+    Mirrors the format produced by CSV_FORMAT=YES, VEC_TABLE=2, VEC_LABELS=NO:
+    ``JDTDB, CalendarDate, X, Y, Z, VX, VY, VZ,`` between the $$SOE/$$EOE marks.
+    """
+    lines = ["$$SOE"]
+    for jd, pos, vel in rows:
+        nums = ", ".join(f"{v:.16E}" for v in (*pos, *vel))
+        lines.append(f"{jd:.9f}, A.D. 2000-Jan-01 00:00:00.0000, {nums},")
+    lines.append("$$EOE")
+    return "\n".join(["JPL Horizons preamble...", *lines, "trailing"])
+
+
+class _FakeResponse:
+    def __init__(self, text):
+        self._text = text
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"result": self._text}
+
+
+# ---------------------------------------------------------------------------
+# pure logic: map + conversions
+# ---------------------------------------------------------------------------
+
+
+def test_space_observatory_map():
+    # A few anchor mappings ported from spacerocks.
+    assert SPACE_OBSERVATORIES["250"][0] == "-48"  # Hubble
+    assert SPACE_OBSERVATORIES["274"][0] == "-170"  # JWST
+    assert SPACE_OBSERVATORIES["C51"][0] == "-163"  # WISE
+    # Every NAIF id is a negative integer (spacecraft convention) + a name.
+    for code, (naif, name) in SPACE_OBSERVATORIES.items():
+        assert int(naif) < 0, code
+        assert isinstance(name, str) and name
+
+
+def test_is_space_observatory():
+    assert is_space_observatory("250")
+    assert is_space_observatory("C51")
+    assert not is_space_observatory("247")  # roving observer
+    assert not is_space_observatory("500")  # geocenter
+    assert not is_space_observatory("568")  # Mauna Kea (ground station)
+
+
+def test_et_to_jd_tdb():
+    assert et_to_jd_tdb(0.0) == 2451545.0
+    assert et_to_jd_tdb(86400.0) == 2451546.0
+    assert et_to_jd_tdb(-43200.0) == 2451544.5
+
+
+# ---------------------------------------------------------------------------
+# pure logic: response parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_vectors_extracts_state():
+    pos = np.array([1.0e3, 2.0e3, 3.0e3])
+    vel = np.array([1.0, -2.0, 3.0])
+    text = _vector_block([(2451545.0, pos, vel)])
+
+    out = _parse_vectors(text, [2451545.0], "-48")
+    got_pos, got_vel = out[2451545.0]
+    np.testing.assert_allclose(got_pos, pos)
+    np.testing.assert_allclose(got_vel, vel)
+
+
+def test_parse_vectors_no_data_raises():
+    with pytest.raises(RuntimeError, match="no vector data"):
+        _parse_vectors("some error message, no markers here", [2451545.0], "-48")
+
+
+def test_parse_vectors_missing_epoch_raises():
+    # Requested two epochs; response only carries one.
+    text = _vector_block([(2451545.0, np.zeros(3), np.zeros(3))])
+    with pytest.raises(RuntimeError, match="did not return a state"):
+        _parse_vectors(text, [2451545.0, 2451546.0], "-48")
+
+
+# ---------------------------------------------------------------------------
+# HTTP client (network mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_query_horizons_geocentric_mocked(monkeypatch):
+    pos = np.array([10.0, 20.0, 30.0])
+    vel = np.array([0.1, 0.2, 0.3])
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResponse(_vector_block([(2451545.0, pos, vel)]))
+
+    monkeypatch.setattr(so.requests, "get", fake_get)
+
+    out = query_horizons_geocentric("-48", [2451545.0])
+    np.testing.assert_allclose(out[2451545.0][0], pos)
+    np.testing.assert_allclose(out[2451545.0][1], vel)
+
+    # The request must ask for a geometric, geocentric, ICRF state in km / km-s.
+    p = captured["params"]
+    assert captured["url"] == so.HORIZONS_API
+    assert p["COMMAND"] == "'-48'"
+    assert p["CENTER"] == "'@399'"
+    assert p["VEC_CORR"] == "NONE"
+    assert p["OUT_UNITS"] == "KM-S"
+    assert p["REF_PLANE"] == "FRAME"
+    assert "2451545.0" in p["TLIST"]
+
+
+def test_query_horizons_batches_in_chunks(monkeypatch):
+    # More epochs than one chunk -> multiple requests, all results returned.
+    n = so._TLIST_CHUNK + 5
+    jds = [2451545.0 + i for i in range(n)]
+    calls = {"n": 0}
+
+    def fake_get(url, params=None, timeout=None):
+        calls["n"] += 1
+        rows = [(float(jd), np.array([float(jd), 0.0, 0.0]), np.zeros(3)) for jd in params["TLIST"].split()]
+        return _FakeResponse(_vector_block(rows))
+
+    monkeypatch.setattr(so.requests, "get", fake_get)
+
+    out = query_horizons_geocentric("-48", jds)
+    assert calls["n"] == 2  # ceil(45 / 40)
+    assert len(out) == n
+    np.testing.assert_allclose(out[jds[0]][0], [jds[0], 0, 0])
+
+
+# ---------------------------------------------------------------------------
+# integration with LayupObservatory (ephem-gated, HTTP mocked)
+# ---------------------------------------------------------------------------
+
+
+def _row(dtype_fields, values):
+    return np.array([tuple(values)], dtype=dtype_fields)[0]
+
+
+@requires_ephem
+def test_populate_space_observatory_uses_horizons(monkeypatch):
+    obs = LayupObservatory()
+    pos_km = np.array([-6905.9, -673.9, -353.1])
+    vel_km_s = np.array([1.0, -2.0, 3.0])
+
+    monkeypatch.setattr(
+        obs, "_fetch_space_observatory_states", lambda naif, jds: {jds[0]: (pos_km, vel_km_s)}
+    )
+
+    et = 1.0e8
+    row = _row([("stn", "U4"), ("et", "<f8")], ("250", et))
+    key = obs.populate_observatory("250", et, row)
+
+    assert key == f"250_{et}"
+    np.testing.assert_allclose(obs.ObservatoryXYZ[key], pos_km)
+    np.testing.assert_allclose(obs.ObservatoryVel[key], vel_km_s)
+
+
+@requires_ephem
+def test_ades_position_overrides_horizons(monkeypatch):
+    """A user-supplied ADES position for a spacecraft code must win over Horizons."""
+    obs = LayupObservatory()
+
+    def explode(naif, jds):  # pragma: no cover - must not be called
+        raise AssertionError("Horizons must not be queried when a position is supplied")
+
+    monkeypatch.setattr(obs, "_fetch_space_observatory_states", explode)
+
+    et = 1.0e8
+    dtype = [
+        ("stn", "U4"),
+        ("et", "<f8"),
+        ("sys", "U7"),
+        ("ctr", "i4"),
+        ("pos1", "<f8"),
+        ("pos2", "<f8"),
+        ("pos3", "<f8"),
+    ]
+    row = _row(dtype, ("250", et, "ICRF_KM", 399, 1000.0, 2000.0, 3000.0))
+    key = obs.populate_observatory("250", et, row)
+
+    np.testing.assert_allclose(obs.ObservatoryXYZ[key], [1000.0, 2000.0, 3000.0])
+
+
+@requires_ephem
+def test_prefetch_batches_one_request_per_spacecraft(monkeypatch):
+    obs = LayupObservatory()
+    calls = []
+
+    def fake_fetch(naif, jds):
+        calls.append((naif, tuple(jds)))
+        return {jd: (np.array([jd, 0.0, 0.0]), np.zeros(3)) for jd in jds}
+
+    monkeypatch.setattr(obs, "_fetch_space_observatory_states", fake_fetch)
+
+    ets = [1.0e8, 2.0e8, 3.0e8]
+    dtype = [("stn", "U4"), ("et", "<f8")]
+    data = np.array(
+        [("250", ets[0]), ("250", ets[1]), ("C51", ets[2])],
+        dtype=dtype,
+    )
+    obs._prefetch_space_observatories(data)
+
+    # One request per spacecraft (250 and C51), not one per observation.
+    assert len(calls) == 2
+    assert {c[0] for c in calls} == {"-48", "-163"}
+    # HST's request batched both of its epochs.
+    hst = next(c for c in calls if c[0] == "-48")
+    assert len(hst[1]) == 2
+    # Cache populated for every epoch.
+    for et in ets[:2]:
+        assert f"250_{et}" in obs.ObservatoryXYZ
+    assert f"C51_{ets[2]}" in obs.ObservatoryXYZ
+
+
+@requires_ephem
+def test_obscodes_to_barycentric_space_observatory(monkeypatch):
+    """End-to-end: a space-based obs is placed at Earth + its geocentric state."""
+    import spiceypy as spice
+
+    obs = LayupObservatory()
+    et = spice.str2et("2003-01-26T00:24:24.480Z")
+    geocentric_km = np.array([-6905.9, -673.9, -353.1])  # HST-like LEO offset
+    geocentric_vel = np.array([1.0, -2.0, 3.0])
+
+    monkeypatch.setattr(
+        obs,
+        "_fetch_space_observatory_states",
+        lambda naif, jds: {jds[0]: (geocentric_km, geocentric_vel)},
+    )
+
+    row = np.array([("250", et)], dtype=[("stn", "U4"), ("et", "<f8")])
+    bary = np.atleast_1d(obs.obscodes_to_barycentric(row))
+
+    obs_pos_km = np.array([bary["x"][0], bary["y"][0], bary["z"][0]]) * AU_KM
+    earth_state, _ = spice.spkezr("EARTH", et, "J2000", "NONE", "SSB")
+    offset_km = obs_pos_km - np.array(earth_state[:3])
+    np.testing.assert_allclose(offset_km, geocentric_km, atol=1.0)


### PR DESCRIPTION
Closes #55. Scoped in https://github.com/Smithsonian/layup/issues/55#issuecomment-4846807848.

Spacecraft observatory codes (HST, JWST, WISE, ...) have no MPC parallax constants, so layup could only place them when the user supplied an explicit ADES per-observation position; otherwise the fit raised `ValueError`. This ports the spacecraft `obscode -> NAIF-id` map from the Rust `spacerocks` project and queries **JPL Horizons** for the observer's geocentric state when no position is given.

### What it does
- **New `utilities/special_observatories.py`** — the 9-entry `SPACE_OBSERVATORIES` map + `query_horizons_geocentric()`. Asks Horizons for a **geometric** (`VEC_CORR=NONE`), **geocentric** (`CENTER=@399`), **ICRF-equatorial** state in **km / km·s⁻¹** (`OUT_UNITS=KM-S` — layup's internal moving-observer units), and parses the CSV vector table. Epochs are **batched** (one request per spacecraft).
- **`populate_observatory()`** — in the no-parallax-constants branch, a space-based obscode *without* a usable ADES position is routed to Horizons; the geocentric position + velocity are cached under the same per-epoch key #147 uses, so `_barycentric_moving_observatory` adds Earth's barycentric state to it. **A user-supplied ADES position always takes priority.**
- **`obscodes_to_barycentric()`** — pre-pass warms the cache for all space-based epochs, one batched HTTP call per spacecraft.

### Design decisions (per the issue)
1. **Horizons HTTP** (not SPK kernels) — the case is rare; avoids per-spacecraft kernel management. SPK-backed resolution can be a future enhancement.
2. **Geocentric query** (`CENTER=@399`) — drops straight into the existing #147 "geocentric + add Earth" path; no new downstream code.
3. **In-run batched cache** only; cross-run disk caching deferred.

Scope boundaries: roving (`247`/`270`) and occultation (`275`) codes stay ADES-supplied (not Horizons-resolved).

### Validation
- 63 tests pass; black clean.
- **Live Horizons cross-check** (HST): |r| ≈ 6916 km (≈537 km LEO altitude ✓), |v| ≈ 7.59 km/s ✓ — confirms units, frame, and parsing against the real server.
- `test_tno_validation` (real HST data) still passes — confirmed no-op, since its fixture supplies ADES positions (which keep priority).

### Tests
Pure-logic tests (map, JD conversion, CSV parser, HTTP client with the network **mocked**) run everywhere. `LayupObservatory` integration tests (ephem-gated, HTTP mocked) cover the Horizons path, the ADES-override priority, request batching, and end-to-end barycentric placement. No test touches the network.

The one existing-test change swaps the generic moving-observer code `C51` → the roving code `247` in `test_moving_observatory_coordinate_cache` (since `C51` is now Horizons-resolved, it no longer exercises the "ADES position required" error path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)