### PR TITLE
visualize: configurable primary-id column via -pid (Closes #383)

### DIFF
--- a/src/layup/visualize.py
+++ b/src/layup/visualize.py
@@ -31,6 +31,7 @@ def build_fig_caches(
     n_points: int = 500,
     r_max: float = 50.0,
     cache_dir: Optional[str] = None,
+    primary_id_column_name: str = "provID",
 ):
     """ """
     # get the assist ephem object and build epoch array
@@ -48,15 +49,16 @@ def build_fig_caches(
         n_points=900,
     )
 
-    # if a special file was provided, drop any rows from the main set whose ObjID
+    # if a special file was provided, drop any rows from the main set whose id
     # appears in the special set to avoid double-plotting the same orbit
-    if special_rows is not None and special_rows.size > 0 and "ObjID" in rows.dtype.names:
-        special_obj_ids = set(str(oid) for oid in special_rows["ObjID"])
-        mask = np.array([str(oid) not in special_obj_ids for oid in rows["ObjID"]])
+    if special_rows is not None and special_rows.size > 0 and primary_id_column_name in rows.dtype.names:
+        special_obj_ids = set(str(oid) for oid in special_rows[primary_id_column_name])
+        mask = np.array([str(oid) not in special_obj_ids for oid in rows[primary_id_column_name]])
         n_dropped = int((~mask).sum())
         if n_dropped > 0:
             logger.info(
-                f"Dropping {n_dropped} orbit(s) from main set whose ObjID also appears in the special file"
+                f"Dropping {n_dropped} orbit(s) from main set whose {primary_id_column_name} "
+                "also appears in the special file"
             )
             rows = rows[mask]
 
@@ -167,6 +169,7 @@ def visualize_cli(
     random: bool = False,
     cache_dir: Optional[str] = None,
     special: Optional[str] = None,
+    primary_id_column_name: str = "provID",
 ):
     """
     Create visualisation plots of a given set of input orbits from the command line
@@ -197,6 +200,11 @@ def visualize_cli(
     special : str, optional (default=None)
         Path to a second orbit file whose orbits are highlighted in a distinct accent colour;
         regular orbits are greyed out when this is supplied
+
+    primary_id_column_name : str, optional (default="provID")
+        Name of the column identifying each object. Defaults to "provID" (the
+        column orbit-fit and predict write); pass e.g. "ObjID" for files that use
+        that instead.
     """
 
     logger.info(f"Reading input file: {input}")
@@ -211,11 +219,17 @@ def visualize_cli(
     suffix = input_file.suffix.lower()
     if suffix == ".csv":
         probe_reader = CSVDataReader(
-            input_file, format_column_name="FORMAT", required_column_names=["FORMAT"]
+            input_file,
+            format_column_name="FORMAT",
+            required_column_names=["FORMAT"],
+            primary_id_column_name=primary_id_column_name,
         )
     else:
         probe_reader = HDF5DataReader(
-            input_file, format_column_name="FORMAT", required_column_names=["FORMAT"]
+            input_file,
+            format_column_name="FORMAT",
+            required_column_names=["FORMAT"],
+            primary_id_column_name=primary_id_column_name,
         )
     probe_rows = probe_reader.read_rows(block_start=0, block_size=100)
     if "FORMAT" in probe_rows.dtype.names:
@@ -249,9 +263,19 @@ def visualize_cli(
     logger.info(f"Reading full input file: {input}")
     required_cols = REQUIRED_COLUMN_NAMES[orbit_format]
     if suffix == ".csv":
-        reader = CSVDataReader(input_file, format_column_name="FORMAT", required_column_names=required_cols)
+        reader = CSVDataReader(
+            input_file,
+            format_column_name="FORMAT",
+            required_column_names=required_cols,
+            primary_id_column_name=primary_id_column_name,
+        )
     else:
-        reader = HDF5DataReader(input_file, format_column_name="FORMAT", required_column_names=required_cols)
+        reader = HDF5DataReader(
+            input_file,
+            format_column_name="FORMAT",
+            required_column_names=required_cols,
+            primary_id_column_name=primary_id_column_name,
+        )
     rows = reader.read_rows(block_start=0, block_size=block_size)
 
     # make sure we actually have the requested number of orbits, else return all,
@@ -288,11 +312,17 @@ def visualize_cli(
         special_suffix = special_file.suffix.lower()
         if special_suffix == ".csv":
             special_reader = CSVDataReader(
-                special_file, format_column_name="FORMAT", required_column_names=required_cols
+                special_file,
+                format_column_name="FORMAT",
+                required_column_names=required_cols,
+                primary_id_column_name=primary_id_column_name,
             )
         else:
             special_reader = HDF5DataReader(
-                special_file, format_column_name="FORMAT", required_column_names=required_cols
+                special_file,
+                format_column_name="FORMAT",
+                required_column_names=required_cols,
+                primary_id_column_name=primary_id_column_name,
             )
         special_rows = special_reader.read_rows(block_start=0, block_size=block_size)
         special_format = get_format(special_rows)
@@ -314,6 +344,7 @@ def visualize_cli(
         n_points=n_points,
         r_max=r_max,
         cache_dir=cache_dir,
+        primary_id_column_name=primary_id_column_name,
     )
 
     logger.info(f"Running Dash web app")
@@ -329,6 +360,7 @@ def visualize_notebook(
     random: bool = False,
     cache_dir: Optional[str] = None,
     special: Optional[str | Path | np.ndarray] = None,
+    primary_id_column_name: str = "provID",
 ):
     """
     Create visualisation plots of a given set of input orbits in a Jupyter notebook
@@ -367,6 +399,7 @@ def visualize_notebook(
             random=random,
             cache_dir=cache_dir,
             special=special_path,
+            primary_id_column_name=primary_id_column_name,
         )
     elif isinstance(data, np.ndarray):
         if data.dtype.names is None or "FORMAT" not in data.dtype.names:
@@ -445,6 +478,7 @@ def visualize_notebook(
             n_points=n_points,
             r_max=r_max,
             cache_dir=cache_dir,
+            primary_id_column_name=primary_id_column_name,
         )
 
         run_dash_app(fig2d_cache, fig3d_cache, special_ids=special_ids)

--- a/src/layup_cmdline/visualize.py
+++ b/src/layup_cmdline/visualize.py
@@ -71,6 +71,15 @@ def main():
         required=False,
     )
     optional.add_argument(
+        "-pid",
+        "--primary-id-column-name",
+        help="name of the column identifying each object (default: provID, as written by orbitfit/predict; use ObjID for files that use that)",
+        dest="primary_id_column_name",
+        type=str,
+        default="provID",
+        required=False,
+    )
+    optional.add_argument(
         "--ar-data-file-path",
         dest="ar_data_file_path",
         type=str,
@@ -107,6 +116,7 @@ def execute(args):
         random=args.random,
         cache_dir=cache_dir,
         special=args.special,
+        primary_id_column_name=args.primary_id_column_name,
     )
 
 

--- a/tests/layup/test_visualize_primary_id.py
+++ b/tests/layup/test_visualize_primary_id.py
@@ -1,0 +1,52 @@
+"""Tests for visualize's configurable primary-id column (issue #383).
+
+`visualize` previously hard-coded an ``ObjID`` column, so an orbit-fit result
+(which uses ``provID``) could not be visualized without renaming the column.
+These tests cover the new ``primary_id_column_name`` argument (CLI ``-pid``),
+which defaults to ``provID``. The ephemeris-backed figure build and the blocking
+Dash server are stubbed so only the read path is exercised (no ephemeris).
+"""
+
+import pytest
+
+from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.visualize import visualize_cli
+
+# An orbit-fit-style output file: keyed by provID, FORMAT=BCART_EQ.
+PROVID_FILE = "predict_chunk_BCART_EQ.csv"
+
+
+@pytest.fixture
+def _stub_render(monkeypatch):
+    """Stub the ephemeris/figure build and the Dash server; record if reached."""
+    calls = {}
+    monkeypatch.setattr("layup.visualize.build_fig_caches", lambda **kwargs: ({}, {}, []))
+    monkeypatch.setattr(
+        "layup.visualize.run_dash_app",
+        lambda *args, **kwargs: calls.__setitem__("ran", True),
+    )
+    return calls
+
+
+def test_visualize_defaults_to_provid(_stub_render):
+    """A provID-keyed orbit-fit output visualizes with no flag (default provID)."""
+    visualize_cli(get_test_filepath(PROVID_FILE))
+    assert _stub_render.get("ran"), "default provID should read an orbit-fit output file"
+
+
+def test_visualize_accepts_objid_via_pid(tmp_path, _stub_render):
+    """Files keyed by ObjID still work when primary_id_column_name='ObjID'."""
+    with open(get_test_filepath(PROVID_FILE)) as fh:
+        header, rest = fh.read().split("\n", 1)
+    objid_file = tmp_path / "objid.csv"
+    objid_file.write_text(header.replace("provID", "ObjID", 1) + "\n" + rest)
+
+    visualize_cli(str(objid_file), primary_id_column_name="ObjID")
+    assert _stub_render.get("ran")
+
+
+def test_visualize_wrong_primary_id_errors(_stub_render):
+    """Asking for a column the file doesn't have is a clear error, not a crash."""
+    with pytest.raises(SystemExit):
+        visualize_cli(get_test_filepath(PROVID_FILE), primary_id_column_name="ObjID")
+    assert not _stub_render.get("ran")


### PR DESCRIPTION
Closes #383.

`visualize` hard-coded an `ObjID` column, so an orbit-fit result (which uses `provID`) couldn't be visualized without renaming the column. This adds a `primary_id_column_name` argument — CLI **`-pid`/`--primary-id-column-name`**, mirroring `orbitfit`/`predict`.

### What it does
- Threads `primary_id_column_name` through both public entry points (`visualize_cli`, `visualize_notebook`) into **all six reader constructions** (probe / full / special × csv / hdf5) and into `build_fig_caches` (which hard-coded `ObjID` for the special-file dedup).
- Adds the `-pid` CLI flag.

### Default choice: `provID`
Per discussion, the default is **`provID`** — the column `orbitfit` and `predict` write — so `orbitfit → visualize` works with **no flag** (the friction #383/#384 describe). This is a behavior change: `visualize` previously assumed `ObjID`; files keyed by `ObjID` now pass `-pid ObjID`. (The ecosystem is already mixed — orbitfit/predict default `provID`, `convert` defaults `ObjID`.)

The **demo notebook is unaffected**: it uses the numpy-array path with no `special` file, where the id column is never consulted.

### Validation
- New `tests/layup/test_visualize_primary_id.py` (3 tests, ~1s, ephemeris + Dash stubbed): a provID-keyed **BCART_EQ** file (native orbit-fit output) visualizes with no flag; an `ObjID` file works via `-pid ObjID`; a wrong id column raises a clear error. All pass; black-clean; `-pid` shows in `layup visualize --help`.

### ⚠️ Merge-order note vs #386
This flips visualize's default to `provID`, so **#386's** `test_visualize.py::test_visualize_cli_accepts_bcart_eq` (which renames its data to `ObjID` and relies on the default) will need `primary_id_column_name="ObjID"` once both are on `main`. I'll reconcile in whichever PR merges second (a one-line test edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)