### PR TITLE
Don't block on the MPC obscodes download in LayupObservatory (Closes #388)

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -8,6 +8,7 @@ from concurrent.futures import ProcessPoolExecutor
 from importlib.resources import files
 
 import numpy as np
+import pooch
 import requests
 import spiceypy as spice
 from sorcha.ephemeris.simulation_geometry import barycentricObservatoryRates
@@ -357,18 +358,33 @@ class LayupObservatory(SorchaObservatory):
         # Furnish the spiceypy kernels
         layup_furnish_spiceypy(cache_dir)
 
+        # Decide the observatory-codes source *before* handing off to Sorcha's
+        # Observatory. Sorcha downloads the codes from the MPC when the
+        # uncompressed file is not already cached -- and that download is a
+        # 25-retry pooch fetch (see make_retriever) with no short timeout, so a
+        # slow/flaky MPC can wedge it for over an hour. When that happens at
+        # pytest collection/fixture time it even escapes pytest-timeout, hanging
+        # CI runs (issue #388). We therefore only allow the network copy when it
+        # is *already cached* (put there by `layup bootstrap`); otherwise we hand
+        # Sorcha the copy bundled with layup immediately -- no blocking download
+        # on the fit path. `layup bootstrap` remains the way to refresh the codes.
+        oc_file = (
+            None if self._cached_obscodes_present(cache_dir, config.auxiliary) else write_fallback_obscodes()
+        )
+        if oc_file is not None:
+            logger.info(
+                "Observatory codes not found in the cache; using the copy bundled "
+                "with layup. Run `layup bootstrap` to fetch the latest from the MPC."
+            )
+
         try:
-            super().__init__(FakeSorchaArgs(cache_dir), config.auxiliary)
+            super().__init__(FakeSorchaArgs(cache_dir), config.auxiliary, oc_file=oc_file)
         except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
-            # Loading the MPC observatory-codes file failed. Either the download
-            # itself errored (server unreachable, timeout, etc.), or it
-            # "succeeded" but produced an empty/corrupt file that does not parse
-            # as JSON -- both have been seen as transient CI failures. Either
-            # way, fall back to the copy bundled with layup rather than failing
-            # the run over a transient outage.
+            # Defensive fallback: the cached codes file was unreadable/corrupt (or
+            # a download slipped through and failed). Use the bundled copy rather
+            # than failing the run.
             logger.warning(
-                "Could not load observatory codes from the MPC (%s); "
-                "falling back to the copy bundled with layup.",
+                "Could not load observatory codes (%s); " "falling back to the copy bundled with layup.",
                 exc,
             )
             super().__init__(
@@ -386,6 +402,19 @@ class LayupObservatory(SorchaObservatory):
         # observer; _barycentric_moving_observatory falls back to Earth's
         # velocity for keys that are absent here.
         self.ObservatoryVel = {}
+
+    @staticmethod
+    def _cached_obscodes_present(cache_dir, auxconfigs):
+        """Whether the decompressed observatory-codes file is already cached.
+
+        Mirrors the check inside Sorcha's ``Observatory`` -- which downloads the
+        codes from the MPC only when this uncompressed file is absent -- so we can
+        make the same decision *before* the download would happen and avoid it
+        (see :meth:`__init__`). ``cache_dir`` defaults to pooch's per-user cache,
+        exactly as the retriever does.
+        """
+        cache_path = cache_dir if cache_dir else pooch.os_cache("layup")
+        return os.path.isfile(os.path.join(str(cache_path), auxconfigs.observatory_codes))
 
     def convert_to_geocentric(self, obs_location: dict) -> tuple:
         """Convert an observatory's parallax constants to geocentric coordinates.

--- a/tests/layup/test_obscodes_fallback.py
+++ b/tests/layup/test_obscodes_fallback.py
@@ -1,0 +1,60 @@
+"""Regression tests for the observatory-codes fallback (issue #388).
+
+When the MPC observatory-codes file is not already cached, ``LayupObservatory``
+must use the copy bundled with layup immediately, rather than letting Sorcha's
+``Observatory`` attempt a 25-retry MPC download that can wedge CI for over an
+hour (and, at pytest collection time, escape pytest-timeout).
+
+These tests stub SPICE furnishing and Sorcha's ``Observatory.__init__`` so they
+need neither the ephemeris nor the network.
+"""
+
+import os
+
+import layup.utilities.data_processing_utilities as dpu
+from layup.utilities.data_processing_utilities import LayupObservatory
+from layup.utilities.layup_configs import LayupConfigs
+
+
+def test_cached_obscodes_present(tmp_path):
+    aux = LayupConfigs().auxiliary
+    # Empty cache dir -> the codes are not present.
+    assert LayupObservatory._cached_obscodes_present(str(tmp_path), aux) is False
+    # Once the decompressed file exists, they are present.
+    (tmp_path / aux.observatory_codes).write_text("{}")
+    assert LayupObservatory._cached_obscodes_present(str(tmp_path), aux) is True
+
+
+def _capture_oc_file(monkeypatch):
+    """Stub SPICE furnishing + Sorcha's Observatory.__init__; capture oc_file."""
+    recorded = {}
+
+    def fake_super_init(self, args, auxconfigs, oc_file=None):
+        recorded["oc_file"] = oc_file
+
+    monkeypatch.setattr(dpu, "layup_furnish_spiceypy", lambda cache_dir: None)
+    monkeypatch.setattr(dpu.SorchaObservatory, "__init__", fake_super_init)
+    return recorded
+
+
+def test_uncached_obscodes_uses_bundled(tmp_path, monkeypatch):
+    """No cached codes -> hand Sorcha the bundled copy (never a blocking download)."""
+    recorded = _capture_oc_file(monkeypatch)
+
+    LayupObservatory(cache_dir=str(tmp_path))
+
+    # oc_file must be a real file (the bundled copy), NOT None -- None would let
+    # Sorcha attempt the retry-heavy MPC download.
+    assert recorded["oc_file"] is not None
+    assert os.path.isfile(recorded["oc_file"])
+
+
+def test_cached_obscodes_uses_cache(tmp_path, monkeypatch):
+    """Cached codes -> let Sorcha read the local file (oc_file=None), no download."""
+    aux = LayupConfigs().auxiliary
+    (tmp_path / aux.observatory_codes).write_text("{}")  # pretend `layup bootstrap` cached it
+    recorded = _capture_oc_file(monkeypatch)
+
+    LayupObservatory(cache_dir=str(tmp_path))
+
+    assert recorded["oc_file"] is None


### PR DESCRIPTION
Closes #388 — the durable fix for the recurring CI hang that's needed cancel+rerun on many PRs today.

### Root cause
Sorcha's `Observatory.__init__` downloads the MPC observatory-codes file via a pooch retriever with **`retry_if_failed=25`** and no short timeout, whenever the *decompressed* file isn't already cached. A slow/flaky MPC turns that into a tens-of-minutes stall. Because the first `LayupObservatory()` is often built at **pytest collection / session-fixture time**, it escapes `pytest-timeout` and wedges the whole job for up to ~76 min (the "Will attempt the download again 25 more times" hang).

### Fix
Decide the obscodes source *before* handing off to Sorcha: only use the network copy when it's **already cached** (put there by `layup bootstrap`); otherwise hand Sorcha the **bundled copy immediately** — so there is never a blocking MPC download on the fit/test path. The existing try/except bundled fallback is kept defensively for a cached-but-corrupt file. `layup bootstrap` remains the way to refresh the codes.

Net effect: a flaky/slow MPC costs ~nothing (falls back to the shipped copy) instead of wedging CI. Observatory codes change rarely, so the bundled copy is a fine default between bootstraps.

### Validation
- 3 new tests in `tests/layup/test_obscodes_fallback.py`, **no ephemeris/network** (SPICE furnishing and Sorcha's `Observatory.__init__` are stubbed), so they run everywhere: `_cached_obscodes_present` detects the cached file; an **uncached** dir makes `LayupObservatory` hand Sorcha the bundled copy (never `None`, which would allow the download); a **cached** file uses the local copy (`oc_file=None`).
- The 12 existing `LayupObservatory` tests still pass; black-clean.

### Scope note
I deliberately did **not** lower `retry_if_failed=25` globally in `make_retriever` — it's shared with the large ephemeris downloads where more retries are reasonable. This targets only the obscodes path that actually wedges. A short per-request timeout on `make_retriever` could be a good follow-up hardening for the `layup bootstrap` path itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)