### PR TITLE
tests: fix visualize BCART_EQ test for the provID default (main hotfix)

### DIFF
--- a/tests/layup/test_visualize.py
+++ b/tests/layup/test_visualize.py
@@ -4,20 +4,7 @@ from layup.utilities.data_utilities_for_tests import get_test_filepath
 from layup.visualize import visualize_cli
 
 
-def _bcart_eq_file_with_objid(src_name, tmp_path):
-    """Copy a shipped BCART_EQ fixture, renaming its ``provID`` header to ``ObjID``.
-
-    ``visualize``'s readers key on an ``ObjID`` column, while the shipped
-    orbit-fit fixtures use ``provID``; only the header needs adjusting.
-    """
-    with open(get_test_filepath(src_name)) as fh:
-        header, rest = fh.read().split("\n", 1)
-    out = tmp_path / "bcart_eq_objid.csv"
-    out.write_text(header.replace("provID", "ObjID", 1) + "\n" + rest)
-    return out
-
-
-def test_visualize_cli_accepts_bcart_eq(tmp_path, monkeypatch):
+def test_visualize_cli_accepts_bcart_eq(monkeypatch):
     """Regression for #384: BCART_EQ is orbit-fit's default output format and must
     be visualizable.
 
@@ -25,10 +12,14 @@ def test_visualize_cli_accepts_bcart_eq(tmp_path, monkeypatch):
     ``REQUIRED_COLUMN_NAMES['BCART_EQ']`` (that dict only has the base ``BCART``
     key). The fix normalizes the inferred format to ``BCART`` (barycentric,
     equatorial). We stub the ephemeris-backed figure build and the blocking Dash
-    server so the test exercises only the read / format-inference path the fix
-    touches, and assert the call reaches the render step.
+    server so the test exercises only the read / format-inference path, and
+    assert the call reaches the render step.
+
+    The fixture is keyed by ``provID`` -- visualize's default primary-id column
+    since #383 -- so a fresh orbit-fit output (provID + BCART_EQ) visualizes with
+    no extra flag.
     """
-    orbit_file = _bcart_eq_file_with_objid("predict_chunk_BCART_EQ.csv", tmp_path)
+    orbit_file = get_test_filepath("predict_chunk_BCART_EQ.csv")
 
     calls = {}
     monkeypatch.setattr("layup.visualize.build_fig_caches", lambda **kwargs: ({}, {}, []))


### PR DESCRIPTION
**Hotfix for a red `main`.** #387 changed visualize's default primary-id column to `provID`, which broke `test_visualize.py::test_visualize_cli_accepts_bcart_eq` on `main`: that test renamed the fixture's `provID` column to `ObjID` and relied on the old default, so the reader can no longer find the id column (this was the merge-order interaction flagged in #387).

Now that `main` has **both** #385's BCART_EQ fix **and** #387's `provID` default, the fix is to drop the ObjID rename and use the `provID`-keyed fixture directly — which also turns this into the real "a fresh orbit-fit output (provID + BCART_EQ) visualizes with no flag" regression. Removes the now-unused helper.

Verified locally: `test_visualize.py` + `test_visualize_primary_id.py` both pass; black-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)