### PR TITLE
Suppress the cosmetic sbpy TestRunner deprecation warning (Closes #376)

### DIFF
--- a/src/layup/__init__.py
+++ b/src/layup/__init__.py
@@ -1,3 +1,13 @@
+import warnings as _warnings
+
+# Silence a cosmetic AstropyDeprecationWarning emitted at import time by sbpy
+# (sbpy/_astropy_init.py builds a deprecated astropy TestRunner). sbpy is a
+# transitive dependency of layup, so the warning is pure noise on the layup CLI
+# and in notebooks. The filter is narrow -- it matches only the TestRunner
+# message, so unrelated astropy deprecation warnings are unaffected -- and is
+# installed here, before any layup submodule imports sbpy. See issue #376.
+_warnings.filterwarnings("ignore", message=r".*TestRunner.*")
+
 try:
     from ._version import version as __version__
     from ._version import version_tuple

--- a/tests/layup/test_warning_suppression.py
+++ b/tests/layup/test_warning_suppression.py
@@ -1,0 +1,20 @@
+"""Regression test for the sbpy TestRunner warning suppression (issue #376)."""
+
+import subprocess
+import sys
+
+
+def test_no_sbpy_testrunner_warning_on_import():
+    """Importing a layup module that pulls in sbpy must not surface the cosmetic
+    ``AstropyDeprecationWarning`` about the deprecated ``TestRunner``.
+
+    Run in a fresh subprocess so the check isn't affected by warning state (or
+    imports) from the rest of the test session.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import layup.orbitfit"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "TestRunner" not in result.stderr, result.stderr


### PR DESCRIPTION
Closes #376.

Running `orbitfit`/`predict` (or importing any layup module that pulls in `sbpy`) printed two `AstropyDeprecationWarning`s about the deprecated astropy `TestRunner`. The source is **sbpy** (`sbpy/_astropy_init.py` builds a `TestRunner` at import) — a transitive dependency, not layup code — so it's pure CLI/notebook noise (flagged by @Little-Ryugu in review of #370).

Installs a **narrow** warnings filter (matches only the `TestRunner` message, so unrelated astropy deprecations still show) at the top of `layup/__init__.py`, before any layup submodule imports sbpy. `import layup` doesn't pull sbpy itself, so the filter is always set first.

**Test** (subprocess, no ephem — runs everywhere): importing `layup.orbitfit` emits no `TestRunner` warning. Verified locally the warning count drops 2 → 0; black-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)