### PR TITLE
Make obs_kind a type-safe ObsKind enum class (#360)

### DIFF
--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -268,7 +268,7 @@ namespace orbit_fit
 
             int nrows = (rd.has_delay ? 1 : 0) + (rd.has_doppler ? 1 : 0);
             resid.n_resid = parts.n_resid = nrows;
-            resid.obs_kind = parts.obs_kind = RADAR;
+            resid.obs_kind = parts.obs_kind = ObsKind::Radar;
             resid.has_delay = parts.has_delay = rd.has_delay;
             resid.has_doppler = parts.has_doppler = rd.has_doppler;
             return;
@@ -561,7 +561,7 @@ namespace orbit_fit
             // Radar observations contribute a delay row and/or a Doppler row;
             // they have no astrometry rows, so handle them separately. Loop npar
             // so non-grav columns are filled when active.
-            if (partials_vec[i].obs_kind == RADAR)
+            if (partials_vec[i].obs_kind == ObsKind::Radar)
             {
                 int row = r0;
                 if (partials_vec[i].has_delay)

--- a/src/lib/orbit_fit/orbit_fit.h
+++ b/src/lib/orbit_fit/orbit_fit.h
@@ -35,21 +35,21 @@ struct detection
     double mag_unc; // magnitude uncertainty
 };
 
-// Discriminates the residual layout an observation contributes. OPTICAL covers
-// both astrometry (2 rows) and streak (4 rows); RADAR covers delay/Doppler
+// Discriminates the residual layout an observation contributes. Optical covers
+// both astrometry (2 rows) and streak (4 rows); Radar covers delay/Doppler
 // (1 or 2 rows). The LM assembly (compute_dX) only sees the partials struct, so
 // the kind/flags travel with it rather than the Observation.
-enum ObsKind
+enum class ObsKind
 {
-    OPTICAL = 0,
-    RADAR = 1
+    Optical = 0,
+    Radar = 1
 };
 
 struct residuals
 {
 
     residuals() : x_resid(), y_resid(), ra_rate_resid(), dec_rate_resid(),
-                  delay_resid(), doppler_resid(), n_resid(2), obs_kind(OPTICAL),
+                  delay_resid(), doppler_resid(), n_resid(2), obs_kind(ObsKind::Optical),
                   has_delay(false), has_doppler(false)
     {
     }
@@ -59,20 +59,20 @@ struct residuals
     // the LM normal equations, when n_resid == 4 (a StreakObservation).
     double ra_rate_resid;
     double dec_rate_resid;
-    // Radar residuals (RADAR only): delay in days, doppler in au/day (round-trip).
+    // Radar residuals (Radar only): delay in days, doppler in au/day (round-trip).
     double delay_resid;
     double doppler_resid;
-    int n_resid; // number of residual rows this observation contributes
-    int obs_kind;     // ObsKind: OPTICAL or RADAR
-    bool has_delay;   // RADAR only: a delay row is present
-    bool has_doppler; // RADAR only: a doppler row is present
+    int n_resid;         // number of residual rows this observation contributes
+    ObsKind obs_kind;    // Optical or Radar
+    bool has_delay;      // Radar only: a delay row is present
+    bool has_doppler;    // Radar only: a doppler row is present
 };
 
 struct partials
 {
 
     partials() : x_partials(), y_partials(), ra_rate_partials(), dec_rate_partials(),
-                 delay_partials(), doppler_partials(), n_resid(2), obs_kind(OPTICAL),
+                 delay_partials(), doppler_partials(), n_resid(2), obs_kind(ObsKind::Optical),
                  has_delay(false), has_doppler(false)
     {
     }
@@ -82,11 +82,11 @@ struct partials
     // Partials of the rate residuals w.r.t. the 6 state parameters (streaks only).
     std::vector<double> ra_rate_partials;
     std::vector<double> dec_rate_partials;
-    // Partials of the radar residuals w.r.t. the 6 state parameters (RADAR only).
+    // Partials of the radar residuals w.r.t. the 6 state parameters (Radar only).
     std::vector<double> delay_partials;
     std::vector<double> doppler_partials;
-    int n_resid;      // rows this observation contributes; mirrors residuals::n_resid
-    int obs_kind;     // ObsKind: OPTICAL or RADAR
-    bool has_delay;   // RADAR only: a delay row is present
-    bool has_doppler; // RADAR only: a doppler row is present
+    int n_resid;         // rows this observation contributes; mirrors residuals::n_resid
+    ObsKind obs_kind;    // Optical or Radar
+    bool has_delay;      // Radar only: a delay row is present
+    bool has_doppler;    // Radar only: a doppler row is present
 };


### PR DESCRIPTION
Quality initiative #3 (structural debt), next item: type-safe `ObsKind`.

`ObsKind` already existed as a plain (unscoped) `enum`, but the `residuals`/`partials` structs stored it as a bare **`int obs_kind`**, and the code used the unqualified `OPTICAL`/`RADAR` values — a deferred #360 clarity item ("`obs_kind` → `ObsKind`").

Promote it to a scoped **`enum class ObsKind { Optical, Radar }`** and type the struct fields as `ObsKind`, so the compiler rejects an arbitrary int and the intent is explicit at each use (`ObsKind::Radar`).

**Fully contained** — 6 sites in `orbit_fit.h`/`.cpp`; `residuals`/`partials` are not pybind-exposed, so there is **no Python-facing change**. `bk_fit.cpp` doesn't reference `obs_kind`.

**Behavior-preserving:** rebuilt and ran 30 fit tests — `test_radar_end_to_end`, `test_radar_validation`, `test_radar_realdata_validation`, `test_orbit_fit`, `test_streak_validation`, `test_nongrav_a2` — all pass unchanged. (The radar tests are the key ones, since `obs_kind` gates the radar rows in the B-matrix assembly.)

Remaining #360 structural items (separate PRs): the shared LM-step helper (`orbit_fit()`↔`bk_fit` dedup) and a single error-handling convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)