### PR TITLE
Fail-fast timeout + bounded retries for data downloads (Closes #388)

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -18,6 +18,12 @@ jobs:
         python-version: ['3.13', '3.14']
 
     runs-on: ${{ matrix.os }}
+    # Fail a wedged leg fast instead of running to the 6-hour default. The unit
+    # suite is ~5-6 min warm (~12 min on a cold cache); a leg far exceeding this
+    # is the recurring flaky-download hang (issue #388), which escapes
+    # pytest-timeout when it happens in a spawned worker. Capping keeps reruns
+    # cheap instead of burning ~2 hours per hang.
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v7
     - name: Set up - ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/src/layup/orbit_maths.py
+++ b/src/layup/orbit_maths.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional
 import numpy as np
 
 from layup.utilities.layup_configs import LayupConfigs
-from layup.utilities.bootstrap_utilties.download_utilities import make_retriever
+from layup.utilities.bootstrap_utilties.download_utilities import make_retriever, layup_downloader
 
 from sorcha.ephemeris.simulation_geometry import equatorial_to_ecliptic
 from sorcha.ephemeris.simulation_constants import ECL_TO_EQ_ROTATION_MATRIX, EQ_TO_ECL_ROTATION_MATRIX
@@ -318,7 +318,8 @@ def build_ephem_and_mus(cache_dir: Optional[str] = None) -> tuple[Ephem, float, 
 
     retriever = make_retriever(aux, cache_dir)
     ephem = Ephem(
-        planets_path=retriever.fetch(aux.jpl_planets), asteroids_path=retriever.fetch(aux.jpl_small_bodies)
+        planets_path=retriever.fetch(aux.jpl_planets, downloader=layup_downloader()),
+        asteroids_path=retriever.fetch(aux.jpl_small_bodies, downloader=layup_downloader()),
     )
 
     # calculate mu same way as in sorcha

--- a/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
+++ b/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
@@ -26,7 +26,7 @@ from layup.utilities.layup_configs import AuxiliaryConfigs
 """
 
 
-def build_meta_kernel_file(auxconfigs: AuxiliaryConfigs, retriever: pooch.Pooch) -> None:
+def build_meta_kernel_file(auxconfigs: AuxiliaryConfigs, retriever: pooch.Pooch, downloader=None) -> None:
     """Builds a specific text file that will be fed into `spiceypy` that defines
     the list of spice kernel to load, as well as the order to load them.
 
@@ -36,6 +36,10 @@ def build_meta_kernel_file(auxconfigs: AuxiliaryConfigs, retriever: pooch.Pooch)
         Dataclass of auxiliary configuration file arguments.
     retriever : pooch
         Pooch object that maintains the registry of files to download
+    downloader : callable, optional
+        pooch downloader to use for any file that still needs fetching (passed to
+        ``Pooch.fetch``). Defaults to None (pooch's default downloader). Callers
+        pass ``layup_downloader()`` for the fail-fast timeout (issue #388).
 
     Returns
     ---------
@@ -51,7 +55,9 @@ def build_meta_kernel_file(auxconfigs: AuxiliaryConfigs, retriever: pooch.Pooch)
         meta_file.write("PATH_SYMBOLS = ('A')\n\n")
         meta_file.write("KERNELS_TO_LOAD=(\n")
         for file_name in auxconfigs.ordered_kernel_files:
-            shortened_file_name = _build_file_name(retriever.abspath, retriever.fetch(file_name))
+            shortened_file_name = _build_file_name(
+                retriever.abspath, retriever.fetch(file_name, downloader=downloader)
+            )
             meta_file.write(f"    '{shortened_file_name}',\n")
         meta_file.write(")\n\n")
         meta_file.write("\\begintext\n")

--- a/src/layup/utilities/bootstrap_utilties/download_utilities.py
+++ b/src/layup/utilities/bootstrap_utilties/download_utilities.py
@@ -2,10 +2,30 @@ from argparse import Namespace
 import concurrent.futures
 import os
 import pooch
-from functools import partial
 from typing import Optional
 from layup.utilities.layup_configs import AuxiliaryConfigs
 from layup.utilities.bootstrap_utilties.create_meta_kernel import build_meta_kernel_file
+
+# Fail-fast network policy for all layup data downloads (issue #388).
+# Previously a stalled MPC/JPL connection was retried 25 times with no request
+# timeout, wedging a fit or a CI run for 20-76 minutes (and escaping
+# pytest-timeout when it happened at fixture time). Now every request times out
+# quickly and is retried a small, bounded number of times, so a flaky host fails
+# in about a minute rather than hours.
+_CONNECT_TIMEOUT = 15  # seconds to establish the connection
+_READ_TIMEOUT = 30  # max seconds between received bytes (bounds a *stall*, not total)
+_RETRY_IF_FAILED = 3  # bounded retries (was 25)
+
+
+def layup_downloader(progressbar: bool = False) -> pooch.HTTPDownloader:
+    """A pooch HTTP downloader with a fail-fast timeout (issue #388).
+
+    ``timeout`` is forwarded to ``requests.get`` as ``(connect, read)``. The read
+    timeout is the maximum gap between received bytes, so it bounds a *stalled*
+    connection without interrupting a slow-but-progressing large download (e.g.
+    the ~600 MB JPL ephemeris keeps flowing, so it is never falsely cut off).
+    """
+    return pooch.HTTPDownloader(timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT), progressbar=progressbar)
 
 
 def make_retriever(aux_config: AuxiliaryConfigs, directory_path: Optional[str] = None) -> pooch.Pooch:
@@ -30,7 +50,7 @@ def make_retriever(aux_config: AuxiliaryConfigs, directory_path: Optional[str] =
         base_url="",
         urls=aux_config.urls,
         registry=aux_config.registry,
-        retry_if_failed=25,
+        retry_if_failed=_RETRY_IF_FAILED,
     )
 
 
@@ -58,15 +78,20 @@ def download_files_if_missing(aux_config: AuxiliaryConfigs, args: Namespace) -> 
     found_all_files = _check_for_existing_files(aux_config, retriever)
 
     if not found_all_files:
-        # create a partial function of `Pooch.fetch` including the `_decompress` method
-        fetch_partial = partial(retriever.fetch, processor=_decompress, progressbar=True)
+        # Fetch each file with its own fail-fast downloader (issue #388); a fresh
+        # downloader per call keeps the per-file progress bars independent across
+        # the parallel threads.
+        def _fetch(file_name):
+            return retriever.fetch(
+                file_name, processor=_decompress, downloader=layup_downloader(progressbar=True)
+            )
 
         # download the data files in parallel
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            executor.map(fetch_partial, aux_config.data_files_to_download)
+            executor.map(_fetch, aux_config.data_files_to_download)
 
         # build the meta_kernel.txt file
-        build_meta_kernel_file(aux_config, retriever)
+        build_meta_kernel_file(aux_config, retriever, downloader=layup_downloader())
 
         print("Checking cache after attempting to download and create files.")
         _check_for_existing_files(aux_config, retriever)

--- a/tests/layup/test_download_utilities.py
+++ b/tests/layup/test_download_utilities.py
@@ -1,0 +1,37 @@
+"""Fail-fast download policy (issue #388).
+
+A stalled MPC/JPL connection was previously retried 25 times with no request
+timeout, wedging a fit or a CI run for 20-76 minutes. These tests pin the
+bounded-retry + fail-fast-timeout policy so it cannot silently regress. All are
+network-free (they only inspect the pooch objects layup constructs).
+"""
+
+import pooch
+
+from layup.utilities.bootstrap_utilties.download_utilities import (
+    make_retriever,
+    layup_downloader,
+    _RETRY_IF_FAILED,
+    _CONNECT_TIMEOUT,
+    _READ_TIMEOUT,
+)
+from layup.utilities.layup_configs import AuxiliaryConfigs
+
+
+def test_make_retriever_uses_bounded_retries(tmp_path):
+    retriever = make_retriever(AuxiliaryConfigs(), str(tmp_path))
+    assert retriever.retry_if_failed == _RETRY_IF_FAILED
+    # The whole point of #388: far fewer than the old, unbounded-feeling 25.
+    assert retriever.retry_if_failed < 25
+
+
+def test_layup_downloader_has_fail_fast_timeout():
+    dl = layup_downloader()
+    assert isinstance(dl, pooch.HTTPDownloader)
+    # timeout is forwarded to requests.get as (connect, read) seconds.
+    assert dl.kwargs.get("timeout") == (_CONNECT_TIMEOUT, _READ_TIMEOUT)
+
+
+def test_layup_downloader_progressbar_flag():
+    assert layup_downloader(progressbar=True).progressbar is True
+    assert layup_downloader().progressbar is False


### PR DESCRIPTION
## Summary

Durable fix for the recurring CI download flake (issue #388): make every layup data download **fail fast** instead of hanging for 20-76 minutes.

The root cause is in `make_retriever` (`bootstrap_utilties/download_utilities.py`): pooch was configured with `retry_if_failed=25` and **no request timeout**, so a stalled MPC/JPL connection could hang long enough to escape `pytest-timeout` when it happened at fixture-collection time, wedging CI runs (and, off-CI, wedging a fit for ~an hour). #389 patched only the observatory-codes path; this addresses the general cause for **every** data download (JPL ephemeris in `orbit_maths`, the meta-kernel kernels, and the `bootstrap` fetch).

## Changes

- **`layup_downloader()`** — a pooch `HTTPDownloader` with a `(connect, read) = (15, 30)s` timeout. The read timeout is the max gap between received bytes, so it bounds a *stalled* connection **without** interrupting a slow-but-progressing large download (the ~600 MB ephemeris keeps flowing, so it is never falsely cut off).
- **`make_retriever`**: `retry_if_failed` **25 -> 3**. Combined with the timeout, a flaky host now fails in about a minute instead of hours.
- Threaded `layup_downloader()` through every fetch site: `download_files_if_missing` (bootstrap), `build_meta_kernel_file` (via a new optional `downloader` arg), and the two ephemeris fetches in `orbit_maths`.
- **New network-free test** (`test_download_utilities.py`) pinning the bounded-retry + fail-fast-timeout policy so it cannot silently regress.

## Notes

- Backward-compatible: `make_retriever`'s signature is unchanged; `build_meta_kernel_file` gains an optional `downloader=None` arg.
- The read timeout only fires on a genuine stall (no bytes for 30s), so legitimate large downloads are unaffected.
- Should end the flake class that has been repeatedly hanging the PR queue (e.g. #398's three consecutive ~2-hour hangs).

Closes #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)