### PR TITLE
Don't crash debiasing on blank/unknown star-catalog codes (Closes #401)

### DIFF
--- a/src/layup/utilities/debiasing.py
+++ b/src/layup/utilities/debiasing.py
@@ -76,8 +76,12 @@ def generate_bias_dict(cache_dir=None):
 
 def debias(ra, dec, epoch_jd_tdb, catalog, bias_dict, nside=256):
 
-    catalog_key = MPC_CATALOGS[catalog]
-    if catalog_key not in bias_dict.keys():
+    # A blank, None, or unrecognized star-catalog code has no bias model (common
+    # in historical / uncatalogued astrometry, or when no astCat column is
+    # present). Leave the astrometry unchanged rather than raising KeyError, which
+    # would otherwise abort the whole object's fit (issue #401).
+    catalog_key = MPC_CATALOGS.get(catalog)
+    if catalog_key is None or catalog_key not in bias_dict:
         return ra, dec
 
     # find pixel from RADEC

--- a/tests/layup/test_debias.py
+++ b/tests/layup/test_debias.py
@@ -70,3 +70,21 @@ def test_debias():
 
     # Check that the returned values are different from the input values (indicating debiasing occurred)
     assert debiased_ra != ra or debiased_dec != dec, "Debiased values should differ from input values."
+
+
+@pytest.mark.parametrize("catalog", ["", None, "NOT_A_REAL_CATALOG"])
+def test_debias_unknown_catalog_returns_unchanged(catalog):
+    """A blank, None, or unrecognized star-catalog code has no bias model and must
+    leave the astrometry unchanged instead of raising KeyError -- which would
+    otherwise abort the whole object's fit on real/historical data (issue #401).
+    These cases return before ``bias_dict`` is used, so an empty dict is fine.
+    """
+    ra, dec = 123.456, -7.89
+    assert debias(ra, dec, 2451545.0, catalog, bias_dict={}) == (ra, dec)
+
+
+def test_debias_known_catalog_absent_from_bias_dict_returns_unchanged():
+    """A known catalog name that is not present in the supplied bias_dict also
+    returns the astrometry unchanged (the pre-existing second guard)."""
+    ra, dec = 50.0, 10.0
+    assert debias(ra, dec, 2451545.0, "PPM", bias_dict={}) == (ra, dec)


### PR DESCRIPTION
## Summary

`debias()` raised `KeyError` when an observation's star-catalog code was blank, `None`, or otherwise not a known catalog name. Because debiasing runs inside the per-object fit loop, that aborted the **entire** object's fit — which happens routinely on real/historical astrometry (pre-catalogue observations, or any observation with no `astCat`).

Found while fitting the MPC catalog with `debias=True`:

```
KeyError: np.str_('')
  File ".../layup/utilities/debiasing.py", line 79, in debias
    catalog_key = MPC_CATALOGS[catalog]
```

## Fix

Guard the lookup with `MPC_CATALOGS.get(...)` and treat an unknown / blank / `None` catalog as "no bias model available", returning the astrometry unchanged. This matches the intended semantics — a bias correction is only defined for a known reference catalog — and mirrors the existing guard just below it for a known catalog that is absent from `bias_dict`.

```python
catalog_key = MPC_CATALOGS.get(catalog)
if catalog_key is None or catalog_key not in bias_dict:
    return ra, dec
```

## Tests

Added regression tests (network-free) covering blank, `None`, and unrecognized catalog codes (all return the astrometry unchanged rather than raising), plus the known-catalog-absent-from-bias_dict case.

Closes #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)