### PR TITLE
Apply debiasing for obs80 catalog codes, not just names (Closes #409)

### DIFF
--- a/src/layup/utilities/debiasing.py
+++ b/src/layup/utilities/debiasing.py
@@ -76,11 +76,18 @@ def generate_bias_dict(cache_dir=None):
 
 def debias(ra, dec, epoch_jd_tdb, catalog, bias_dict, nside=256):
 
-    # A blank, None, or unrecognized star-catalog code has no bias model (common
-    # in historical / uncatalogued astrometry, or when no astCat column is
-    # present). Leave the astrometry unchanged rather than raising KeyError, which
-    # would otherwise abort the whole object's fit (issue #401).
-    catalog_key = MPC_CATALOGS.get(catalog)
+    # ``catalog`` may be a catalog NAME (an MPC_CATALOGS key, e.g. "UCAC4", as
+    # ADES provides) or the single-char CODE that obs80 supplies (an MPC_CATALOGS
+    # value, e.g. "q"). bias_dict is keyed by the code, so map a name to its code
+    # and let a code pass through -- otherwise debiasing silently no-ops on all
+    # obs80 input (issue #409).
+    #
+    # A blank, None, or unrecognized catalog has no bias model (common in
+    # historical / uncatalogued astrometry, or when no astCat column is present);
+    # it falls through the ``not in bias_dict`` guard and the astrometry is left
+    # unchanged rather than raising KeyError, which would abort the whole object's
+    # fit (issue #401).
+    catalog_key = MPC_CATALOGS.get(catalog, catalog)
     if catalog_key is None or catalog_key not in bias_dict:
         return ra, dec
 

--- a/tests/layup/test_debias.py
+++ b/tests/layup/test_debias.py
@@ -88,3 +88,22 @@ def test_debias_known_catalog_absent_from_bias_dict_returns_unchanged():
     returns the astrometry unchanged (the pre-existing second guard)."""
     ra, dec = 50.0, 10.0
     assert debias(ra, dec, 2451545.0, "PPM", bias_dict={}) == (ra, dec)
+
+
+def test_debias_accepts_catalog_code_like_a_name():
+    """obs80 supplies the single-char catalog CODE (an MPC_CATALOGS value, e.g.
+    ``"p"``), while ADES supplies the NAME (a key, e.g. ``"PPM"``). Both must apply
+    the same bias correction -- otherwise debiasing silently no-ops on all obs80
+    input (issue #409)."""
+    cache_dir = pooch.os_cache("layup")
+    bias_dict = generate_bias_dict(cache_dir=cache_dir)
+    ra, dec, epoch = 10.0, 20.0, 2451545.0
+
+    name, code = "PPM", MPC_CATALOGS["PPM"]  # "PPM" -> "p"
+    ra_name, dec_name = debias(ra, dec, epoch, name, bias_dict)
+    ra_code, dec_code = debias(ra, dec, epoch, code, bias_dict)
+
+    # The code must resolve to the same correction as its name...
+    assert (ra_code, dec_code) == (ra_name, dec_name)
+    # ...and actually apply one (not silently return the input unchanged).
+    assert (ra_code, dec_code) != (ra, dec)


### PR DESCRIPTION
## Summary

`debias()` silently applied **no correction** on obs80 input: `Obs80DataReader` supplies the single-char catalog **code** (`W`, `q`, …), but `debias()` looked the catalog up as an `MPC_CATALOGS` **key** (a name like `UCAC4`). Since `bias_dict` is keyed by the **code**, a code never resolved → the guard returned the astrometry unchanged. So debiasing never fired on obs80 — including the bulk MPC archive the catalogue fit ingests.

## Fix

```python
catalog_key = MPC_CATALOGS.get(catalog, catalog)  # name -> code, or a code passes through
if catalog_key is None or catalog_key not in bias_dict:
    return ra, dec
```

- **Name** (`"UCAC4"`) → its code `"q"` → in `bias_dict` ✓ (unchanged behaviour for ADES-style input)
- **Code** (`"q"`) → passes through → in `bias_dict` ✓ (obs80 now debiases)
- **blank / None / unknown** → falls through the `not in bias_dict` guard unchanged ✓ (preserves #401)

## Validation

End-to-end, fitting the same objects with `debias=False` vs `debias=True` now **differs** (it was byte-identical before the fix):

| obj | Δa (debias off) | Δa (debias on) |
|---|---|---|
| 20000 | 3.83×10⁻⁴ | 2.16×10⁻⁴ |
| 90377 | 4.08×10⁻² | 1.14×10⁻¹ |
| 944 | 5.27×10⁻⁸ | 6.89×10⁻⁸ |

Corrections are small (sub-arcsec), as expected — but they now actually apply, which the "faithful to JPL" weighting+debiasing story needs on obs80 data.

## Tests

Adds a regression test asserting a code (`"p"`) yields the same correction as its name (`"PPM"`) and actually changes the astrometry. All 8 `test_debias` tests pass.

Closes #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)