### PR TITLE
Actionable error for unknown/stale observatory codes (Closes #404)

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -517,9 +517,20 @@ class LayupObservatory(SorchaObservatory):
                         f"The data must have a '{field}' field for non-fixed position observatory {obscode}."
                     )
             coords = np.array([data["pos1"], data["pos2"], data["pos3"]])
-            # If any of the coordinates are None or NaN, raise an error
+            # NaN here means this obscode has no parallax constants in the local
+            # ObsCodes.json AND the observation carried no position. That is almost
+            # always a *ground* station added to the MPC list after the cached
+            # ObsCodes.json -- not a genuinely non-fixed observatory (those carry a
+            # real pos1/pos2/pos3). Give an actionable message pointing at the stale
+            # codes file rather than the misleading "invalid coordinates" (issue #404).
             if coords is None or np.isnan(coords).any():
-                raise ValueError(f"Observatory {obscode} has invalid coordinates at epoch {et}: {coords}")
+                raise ValueError(
+                    f"Observatory code '{obscode}' is not in the local observatory-codes "
+                    f"file (ObsCodes.json) and no position was supplied with the observation. "
+                    f"If it is a ground station, refresh the codes with `layup bootstrap` -- "
+                    f"the cached list may predate it; otherwise the code may be invalid. "
+                    f"(epoch et={et})"
+                )
 
             # Check if the coordinates are in a reference frame that we support.
             if data["sys"] not in ["ICRF_KM", "ICRF_AU"]:

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -305,6 +305,33 @@ def test_moving_observatory_coordinate_cache():
             observatory.populate_observatory(obscode, et, row_inconsistent)
 
 
+def test_unknown_obscode_gives_actionable_error():
+    """An obscode absent from the local ObsCodes.json with no observation-supplied
+    position -- typically a ground station added to the MPC list after the cached
+    codes file -- must raise a clear, actionable error pointing at `layup bootstrap`
+    rather than the misleading "invalid coordinates" (issue #404)."""
+    observatory = LayupObservatory()
+    obscode = "ZZZ"  # not a real MPC code -> guaranteed absent from ObservatoryXYZ
+    et = 2451545.0
+    row_dtype = [
+        ("sys", "U7"),
+        ("ctr", "i4"),
+        ("pos1", "<f8"),
+        ("pos2", "<f8"),
+        ("pos3", "<f8"),
+    ]
+    # A normal ground observation: the position columns exist (obs80 always emits
+    # them) but are NaN because there is no embedded observer position.
+    row = np.array(("", 399, np.nan, np.nan, np.nan), dtype=row_dtype)
+    with pytest.raises(ValueError, match="bootstrap"):
+        observatory.populate_observatory(obscode, et, row)
+    # and the message should not be the old misleading wording
+    with pytest.raises(ValueError) as exc:
+        observatory.populate_observatory(obscode, et, row)
+    assert "invalid coordinates" not in str(exc.value)
+    assert obscode in str(exc.value)
+
+
 def test_fixed_observatory_with_zero_parallax_constant():
     """Regression test for issue #286.
 


### PR DESCRIPTION
## Summary

An observatory code absent from the local `ObsCodes.json` — most often a **ground station added to the MPC list after the cached file** — has no parallax constants, so `populate_observatory` fell into the *moving-observatory* branch, read NaN `pos1/pos2/pos3`, and raised the misleading `Observatory X has invalid coordinates`. The code is valid; only the cached codes file is stale.

## Fix

A **genuine** non-fixed observatory (satellite/roving) carries a real `pos1/pos2/pos3`; NaN there instead means an **unrecognized fixed station**. So on the NaN case, raise a clear, actionable error that names the code and points at `layup bootstrap` to refresh `ObsCodes.json`:

```
Observatory code 'R67' is not in the local observatory-codes file (ObsCodes.json)
and no position was supplied with the observation. If it is a ground station,
refresh the codes with `layup bootstrap` -- the cached list may predate it;
otherwise the code may be invalid.
```

This resolves #404's core complaint (a misleading hard-crash) and makes the staleness obvious and fixable — one of the remedies the issue proposed.

## Scope

This is the clear-degradation fix. Fully *fitting* an object through an unknown code (on-demand obscode refresh, or skip-with-warning) is a larger enhancement; at batch scale the per-object failure bucket now carries an actionable message instead of a misleading one.

## Tests

Adds a regression test: an unknown code with no supplied position raises an error that mentions the code and `bootstrap`, and is not the old "invalid coordinates". All 51 `test_data_processing_utilities` tests pass.

Closes #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)