### PR TITLE
Warn (not crash) on same-epoch observer-position repeats across co-observed objects

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -26,6 +26,16 @@ from layup.utilities.special_observatories import (
 
 """ A module for utilities useful for processing data in structured numpy arrays """
 
+# Two observations at the same instant from the same moving/space-based observer
+# should report the same geocentric position. MPC 80-column satellite records
+# (and some ADES sources) carry that position at finite precision, so repeats at
+# one epoch can differ at the ~0.01 km reporting level. Treat positions agreeing
+# to this absolute tolerance as consistent: 1 km at 1 au is ~1.4 mas of
+# astrometric shift, far below observational noise, while gross unit/sign/center
+# errors differ by orders of magnitude more and still raise. (Surfaced by
+# object 47451, obscode C57 = TESS, in the MPC full-catalog fit.)
+_OBSERVER_POSITION_ATOL_KM = 1.0
+
 # Start worker processes with "spawn" rather than the platform default.
 #
 # On Linux the default start method is "fork", which clones the whole parent
@@ -539,11 +549,16 @@ class LayupObservatory(SorchaObservatory):
                 # Store the coordinates in the ObservatoryXYZ dictionary to be read by barycentricObservatoryRates
                 self.ObservatoryXYZ[obscode_cache_key] = coords
             else:
-                # If the coordinates are not the same, raise an error
-                if not np.allclose(self.ObservatoryXYZ[obscode_cache_key], coords):
+                # Positions agreeing to reporting precision are consistent; only a
+                # gross mismatch (unit/sign/center error) raises. See
+                # _OBSERVER_POSITION_ATOL_KM.
+                if not np.allclose(
+                    self.ObservatoryXYZ[obscode_cache_key], coords, rtol=0.0, atol=_OBSERVER_POSITION_ATOL_KM
+                ):
                     raise ValueError(
-                        f"Observatory {obscode} has different coordinates reported at the same epoch."
-                        f"Coordinates at epoch {et} previously were {self.ObservatoryXYZ[obscode_cache_key]}, but are now {coords}."
+                        f"Observatory {obscode} has different coordinates reported at the same epoch "
+                        f"(beyond {_OBSERVER_POSITION_ATOL_KM} km). Coordinates at epoch {et} previously were "
+                        f"{self.ObservatoryXYZ[obscode_cache_key]}, but are now {coords}."
                     )
             # Save the coordinates in the cache for the given obscode and epoch
             self.ObservatoryXYZ[obscode_cache_key] = coords

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -26,15 +26,19 @@ from layup.utilities.special_observatories import (
 
 """ A module for utilities useful for processing data in structured numpy arrays """
 
-# Two observations at the same instant from the same moving/space-based observer
-# should report the same geocentric position. MPC 80-column satellite records
-# (and some ADES sources) carry that position at finite precision, so repeats at
-# one epoch can differ at the ~0.01 km reporting level. Treat positions agreeing
-# to this absolute tolerance as consistent: 1 km at 1 au is ~1.4 mas of
-# astrometric shift, far below observational noise, while gross unit/sign/center
-# errors differ by orders of magnitude more and still raise. (Surfaced by
-# object 47451, obscode C57 = TESS, in the MPC full-catalog fit.)
-_OBSERVER_POSITION_ATOL_KM = 1.0
+# A moving/space-based observer's geocentric position is cached per (obscode,
+# epoch) and that cache is shared across every object processed by one
+# LayupObservatory. Space telescopes (TESS = C57, WISE = C51) image many asteroids
+# in a single exposure, so different objects each carry a record for the same
+# (observatory, epoch); the satellite's one true position at that instant is
+# reported per record at finite (~km) precision, so those records differ slightly.
+# Accept differences up to this many km -- they are the same body at the same
+# instant, astrometrically indistinguishable at the km level, so the most recent is
+# used. A larger difference exceeds any plausible reporting spread and likely
+# signals a units/frame error, so it is logged (never fatal -- a corrupt observer
+# position shows up as a diverging fit). Surfaced by the MPC full-catalog fit:
+# C57 = TESS (~1.4 km, near lunar distance) and C51 = WISE (~4 km, low Earth orbit).
+_OBSERVER_POSITION_WARN_KM = 100.0
 
 # Start worker processes with "spawn" rather than the platform default.
 #
@@ -545,22 +549,19 @@ class LayupObservatory(SorchaObservatory):
             if data["sys"] == "ICRF_AU":
                 coords *= AU_KM
 
-            if obscode_cache_key not in self.ObservatoryXYZ:
-                # Store the coordinates in the ObservatoryXYZ dictionary to be read by barycentricObservatoryRates
-                self.ObservatoryXYZ[obscode_cache_key] = coords
-            else:
-                # Positions agreeing to reporting precision are consistent; only a
-                # gross mismatch (unit/sign/center error) raises. See
-                # _OBSERVER_POSITION_ATOL_KM.
-                if not np.allclose(
-                    self.ObservatoryXYZ[obscode_cache_key], coords, rtol=0.0, atol=_OBSERVER_POSITION_ATOL_KM
-                ):
-                    raise ValueError(
-                        f"Observatory {obscode} has different coordinates reported at the same epoch "
-                        f"(beyond {_OBSERVER_POSITION_ATOL_KM} km). Coordinates at epoch {et} previously were "
-                        f"{self.ObservatoryXYZ[obscode_cache_key]}, but are now {coords}."
+            # A repeat position for the same (obscode, epoch) -- e.g. two objects
+            # co-observed by a space telescope in one exposure -- normally differs
+            # only at reporting precision; warn only on a gross difference (a likely
+            # units/frame error) and never crash. See _OBSERVER_POSITION_WARN_KM.
+            if obscode_cache_key in self.ObservatoryXYZ:
+                diff_km = float(np.linalg.norm(self.ObservatoryXYZ[obscode_cache_key] - coords))
+                if diff_km > _OBSERVER_POSITION_WARN_KM:
+                    logger.warning(
+                        f"Observatory {obscode} reported positions differing by {diff_km:.1f} km at the same "
+                        f"epoch {et} ({self.ObservatoryXYZ[obscode_cache_key]} vs {coords}); using the most "
+                        f"recent. A difference this large may indicate a units/frame error."
                     )
-            # Save the coordinates in the cache for the given obscode and epoch
+            # Store (or refresh) the coordinates for this obscode and epoch.
             self.ObservatoryXYZ[obscode_cache_key] = coords
 
             # Optionally cache a user-supplied observer velocity. ADES permits the

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -299,43 +299,55 @@ def test_moving_observatory_coordinate_cache():
         expected_cooreds_au = [x * 149597870.7 for x in expected_coords]
         assert np.allclose(observatory.ObservatoryXYZ[cache_key_au], expected_cooreds_au)
 
-        # Test error when coordinates are inconsistent across epochs
-        row_inconsistent = np.array(("ICRF_KM", 399, 10.0, 12.0, 13.0), dtype=row_dtype)
-        with pytest.raises(ValueError):
-            observatory.populate_observatory(obscode, et, row_inconsistent)
+        # A same-epoch position that differs within an observer's motion is not
+        # fatal (moving observers carry a per-observation position): the most
+        # recent coordinates are used, without raising.
+        row_updated = np.array(("ICRF_KM", 399, 10.0, 12.0, 13.0), dtype=row_dtype)
+        observatory.populate_observatory(obscode, et, row_updated)
+        assert np.allclose(observatory.ObservatoryXYZ[expected_cache_key], [10.0, 12.0, 13.0])
 
 
-def test_moving_observatory_tolerates_position_reporting_noise():
-    """Two observations at one epoch whose reported observer position differs only
-    at MPC's ~0.01 km reporting precision are consistent and must not raise; a
-    gross (> tolerance) mismatch still raises. Regression for the MPC full-catalog
-    crash on object 47451 (obscode C57 = TESS), whose same-epoch satellite position
-    was reported as [469.133, 397472.997, 15844.053] then [469.144, 397472.992,
-    15844.055] km -- a ~0.01 km difference that tripped the exact-match check.
+def test_moving_observatory_same_epoch_position_not_fatal(caplog):
+    """The observatory-position cache is shared across objects, and space telescopes
+    image many asteroids per exposure, so different objects carry a record for the
+    same (observatory, epoch) whose one true satellite position is reported at ~km
+    precision. Such small differences must not crash the fit (the most recent
+    position is used) and must not warn; only a difference far larger than any
+    reporting spread (a likely units/frame error) is logged, and even that is not
+    fatal. Regression for the MPC full-catalog crashes on C57 (TESS, ~1.4 km) and
+    C51 (WISE, ~4 km).
     """
-    from layup.utilities.data_processing_utilities import _OBSERVER_POSITION_ATOL_KM
+    import logging
+
+    from layup.utilities.data_processing_utilities import _OBSERVER_POSITION_WARN_KM
 
     observatory = LayupObservatory()
     obscode = "247"  # moving observer: carries its own position
     et = 2451545.0
+    key = f"{obscode}_{et}"
     row_dtype = [("sys", "U7"), ("ctr", "i4"), ("pos1", "<f8"), ("pos2", "<f8"), ("pos3", "<f8")]
 
+    # TESS-like geocentric position (~lunar distance), first report.
     first = np.array(("ICRF_KM", 399, 469.133, 397472.997, 15844.053), dtype=row_dtype)
-    key = observatory.populate_observatory(obscode, et, first)
+    observatory.populate_observatory(obscode, et, first)
 
-    # Same epoch, same physical position re-reported at finite precision (< tolerance).
-    noise = np.array(("ICRF_KM", 399, 469.144, 397472.992, 15844.055), dtype=row_dtype)
-    observatory.populate_observatory(obscode, et, noise)  # must not raise
-    assert np.allclose(
-        observatory.ObservatoryXYZ[key], [469.133, 397472.997, 15844.053], atol=_OBSERVER_POSITION_ATOL_KM
-    )
+    # Same epoch, position moved a few km (satellite motion within the time
+    # precision): no raise, no warning, most recent position kept.
+    moved = np.array(("ICRF_KM", 399, 469.144, 397476.0, 15848.0), dtype=row_dtype)
+    with caplog.at_level(logging.WARNING):
+        observatory.populate_observatory(obscode, et, moved)
+    assert not any("differing by" in r.message for r in caplog.records)
+    assert np.allclose(observatory.ObservatoryXYZ[key], [469.144, 397476.0, 15848.0])
 
-    # A gross mismatch at the same epoch (well beyond the tolerance) still raises.
+    # A difference far beyond any observer's motion (units/frame error) is logged
+    # but still not fatal.
+    caplog.clear()
     gross = np.array(
-        ("ICRF_KM", 399, 469.133 + 10.0 * _OBSERVER_POSITION_ATOL_KM, 397472.997, 15844.053), dtype=row_dtype
+        ("ICRF_KM", 399, 469.144, 397476.0, 15848.0 + 10.0 * _OBSERVER_POSITION_WARN_KM), dtype=row_dtype
     )
-    with pytest.raises(ValueError):
-        observatory.populate_observatory(obscode, et, gross)
+    with caplog.at_level(logging.WARNING):
+        observatory.populate_observatory(obscode, et, gross)  # must not raise
+    assert any("differing by" in r.message for r in caplog.records)
 
 
 def test_fixed_observatory_with_zero_parallax_constant():

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -305,6 +305,39 @@ def test_moving_observatory_coordinate_cache():
             observatory.populate_observatory(obscode, et, row_inconsistent)
 
 
+def test_moving_observatory_tolerates_position_reporting_noise():
+    """Two observations at one epoch whose reported observer position differs only
+    at MPC's ~0.01 km reporting precision are consistent and must not raise; a
+    gross (> tolerance) mismatch still raises. Regression for the MPC full-catalog
+    crash on object 47451 (obscode C57 = TESS), whose same-epoch satellite position
+    was reported as [469.133, 397472.997, 15844.053] then [469.144, 397472.992,
+    15844.055] km -- a ~0.01 km difference that tripped the exact-match check.
+    """
+    from layup.utilities.data_processing_utilities import _OBSERVER_POSITION_ATOL_KM
+
+    observatory = LayupObservatory()
+    obscode = "247"  # moving observer: carries its own position
+    et = 2451545.0
+    row_dtype = [("sys", "U7"), ("ctr", "i4"), ("pos1", "<f8"), ("pos2", "<f8"), ("pos3", "<f8")]
+
+    first = np.array(("ICRF_KM", 399, 469.133, 397472.997, 15844.053), dtype=row_dtype)
+    key = observatory.populate_observatory(obscode, et, first)
+
+    # Same epoch, same physical position re-reported at finite precision (< tolerance).
+    noise = np.array(("ICRF_KM", 399, 469.144, 397472.992, 15844.055), dtype=row_dtype)
+    observatory.populate_observatory(obscode, et, noise)  # must not raise
+    assert np.allclose(
+        observatory.ObservatoryXYZ[key], [469.133, 397472.997, 15844.053], atol=_OBSERVER_POSITION_ATOL_KM
+    )
+
+    # A gross mismatch at the same epoch (well beyond the tolerance) still raises.
+    gross = np.array(
+        ("ICRF_KM", 399, 469.133 + 10.0 * _OBSERVER_POSITION_ATOL_KM, 397472.997, 15844.053), dtype=row_dtype
+    )
+    with pytest.raises(ValueError):
+        observatory.populate_observatory(obscode, et, gross)
+
+
 def test_fixed_observatory_with_zero_parallax_constant():
     """Regression test for issue #286.
 


### PR DESCRIPTION
## Problem

`LayupObservatory` caches a moving/space-based observer's geocentric position per `(obscode, epoch)`, and **that cache is shared across every object it processes** (both here and in `orbitfit`, which builds one `LayupObservatory` per chunk). A repeat position at the same key had to match **exactly** (`np.allclose` default) or it raised `ValueError` and crashed the fit.

Space telescopes image **many asteroids in a single exposure**, so different objects each carry a record for the **same (observatory, epoch)**. The satellite's one true position at that instant is reported per record at finite (~km) precision, so those records differ slightly. Surfaced by the MPC full-catalog fit:
- **C57 = TESS** (~lunar distance): same-epoch positions differ by ~1.4 km
- **C51 = WISE** (low Earth orbit): differ by up to ~4 km

(This is *cross-object*, not two observations of one object — fitting either object alone never collides; it only appears once a shared observatory cache accumulates entries from co-observed objects.)

## Fix

The colliding positions are the **same body at the same instant**, astrometrically indistinguishable at the km level (1 km at 1 au ≈ 1.4 mas, far below observational noise), and a genuinely corrupt observer position (unit/frame error) shows up as a diverging fit anyway. So **warn instead of raise**, keeping the most recent position. Only a difference beyond any plausible reporting spread — `_OBSERVER_POSITION_WARN_KM = 100 km` — is logged (a likely units/frame error). Never fatal.

## Impact

~0.07% of numbered objects (all TESS/WISE-observed) crashed on this in the 10k-object sample; at full catalog scale that's ~600 objects — now fit. Confirmed the previously-crashing objects (39799, 79671, f1997) now converge (flag=0, rel|da| ~1e-9).

## Test

`test_moving_observatory_same_epoch_position_not_fatal` (uses the C57/TESS values): a few-km same-epoch difference must not raise **or** warn; a >100 km difference is logged but still does not raise. The former hard-raise assertion in `test_moving_observatory_coordinate_cache` is updated to the not-fatal behaviour. Full `test_data_processing_utilities.py` green (51 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
