### PR TITLE
Adaptive non-grav inclusion: fit_nongrav="auto" (issue #357)

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -157,6 +157,58 @@ def _parse_nongrav(fit_nongrav):
     return sum(_NONGRAV_BITS[n] for n in names), names
 
 
+# fit_nongrav="auto" decision thresholds (issue #357). Non-grav models are tried
+# only when the gravity-only reduced chi-square exceeds _AUTO_ACCEPT_REDUCED_CHI2,
+# in increasing complexity (_AUTO_NONGRAV_LADDER); the first model that converges
+# and is well-conditioned (flag 0), drops chi-square by more than
+# _AUTO_DELTA_CHI2_PER_PARAM per added parameter, and whose every added parameter
+# is individually significant (|A| > _AUTO_NSIGMA * sigma) is adopted. Otherwise
+# the gravity-only fit is kept. Standard practice: introduce a non-grav only when
+# gravity is unacceptable and the parameter is statistically warranted.
+_AUTO_NONGRAV_LADDER = (("A2",), ("A1", "A2"), ("A1", "A2", "A3"))
+_AUTO_ACCEPT_REDUCED_CHI2 = 1.5
+_AUTO_DELTA_CHI2_PER_PARAM = 9.0  # ~3-sigma chi-square drop per added parameter
+_AUTO_NSIGMA = 3.0
+
+
+def _gravity_fit_acceptable(csq, ndof):
+    """Whether a gravity-only fit is good enough that no non-grav is warranted.
+
+    True when the reduced chi-square is at or below the acceptance threshold (or
+    there are no degrees of freedom to judge it by).
+    """
+    return ndof <= 0 or csq / ndof <= _AUTO_ACCEPT_REDUCED_CHI2
+
+
+def _nongrav_warranted(csq_gravity, res_ng, names):
+    """Whether adopting the (converged, well-conditioned) non-grav fit ``res_ng``
+    for parameters ``names`` over the gravity-only fit is statistically warranted:
+    a significant chi-square drop AND every added parameter individually significant.
+    """
+    if (csq_gravity - res_ng.csq) <= _AUTO_DELTA_CHI2_PER_PARAM * len(names):
+        return False  # chi-square improvement not significant for the added parameter(s)
+    return all(
+        abs(getattr(res_ng, n.lower())) > _AUTO_NSIGMA * getattr(res_ng, n.lower() + "_unc") for n in names
+    )
+
+
+def _select_nongrav_auto(assist_ephem, res_grav, observations):
+    """Adaptive non-grav selection for ``fit_nongrav="auto"`` (issue #357).
+
+    ``res_grav`` is the converged gravity-only fit. Returns the most parsimonious
+    acceptable model: the gravity-only result unless a non-grav model is both
+    well-conditioned (flag 0) and statistically warranted (see the thresholds above).
+    """
+    if _gravity_fit_acceptable(res_grav.csq, res_grav.ndof):
+        return res_grav  # gravity-only fit is acceptable; no non-gravs needed
+    for names in _AUTO_NONGRAV_LADDER:
+        mask = sum(_NONGRAV_BITS[n] for n in names)
+        res_ng = run_from_vector_with_initial_guess(assist_ephem, res_grav, observations, nongrav_mask=mask)
+        if res_ng.flag == 0 and _nongrav_warranted(res_grav.csq, res_ng, names):
+            return res_ng  # parsimonious, well-determined non-grav model
+    return res_grav  # no non-grav model is warranted
+
+
 def _get_result_dtypes(primary_id_column_name: str, nongrav_names=()):
     """Helper function to create the result dtype with the correct primary ID column name.
 
@@ -855,8 +907,14 @@ def _orbitfit(
     # Fitting non-gravitational params (issue #351) uses the joint state+nongrav
     # LM, which only the Cartesian engine supports; the BK-native engine assumes a
     # 6D state. Override with a warning, mirroring the radar path.
-    nongrav_mask, nongrav_names = _parse_nongrav(fit_nongrav)
-    if nongrav_mask and engine != "cartesian":
+    auto_nongrav = isinstance(fit_nongrav, str) and fit_nongrav.strip().lower() == "auto"
+    if auto_nongrav:
+        # 'auto' selects the non-grav model per object (issue #357); the schema
+        # carries all of A1/A2/A3 and each row reports only the adopted params.
+        nongrav_mask, nongrav_names = 0, ["A1", "A2", "A3"]
+    else:
+        nongrav_mask, nongrav_names = _parse_nongrav(fit_nongrav)
+    if (nongrav_mask or auto_nongrav) and engine != "cartesian":
         logger.warning("Non-gravitational fitting requires engine='cartesian'; overriding %r.", engine)
         engine = "cartesian"
 
@@ -1024,7 +1082,11 @@ def _orbitfit(
         # from that solution. They are weakly constrained on short arcs, so if the
         # joint fit is degenerate (flag 6) or fails to converge we keep the
         # 6-parameter result and report the params as NaN (graceful guard).
-        if nongrav_mask and res.flag == 0:
+        if auto_nongrav and res.flag == 0:
+            # Adopt the most parsimonious statistically-warranted non-grav model,
+            # or keep the gravity-only fit (issue #357).
+            res = _select_nongrav_auto(get_ephem(kernels_loc), res, observations)
+        elif nongrav_mask and res.flag == 0:
             res_ng = run_from_vector_with_initial_guess(
                 get_ephem(kernels_loc), res, observations, nongrav_mask=nongrav_mask
             )
@@ -1040,13 +1102,15 @@ def _orbitfit(
         cov_matrix = tuple(res.cov[i] for i in range(36)) if success else (np.nan,) * 36
         nongrav_cols = ()
         if nongrav_names:
-            fitted = success and getattr(res, "nongrav_mask", 0) != 0
+            # Report each parameter only if it was actually adopted (its bit is set
+            # in the fit's nongrav_mask); for 'auto' that is the selected subset.
+            fitted_mask = getattr(res, "nongrav_mask", 0) if success else 0
             nongrav_cols = tuple(
                 v
                 for n in nongrav_names
                 for v in (
-                    (getattr(res, n.lower()) if fitted else np.nan),
-                    (getattr(res, n.lower() + "_unc") if fitted else np.nan),
+                    (getattr(res, n.lower()) if (fitted_mask & _NONGRAV_BITS[n]) else np.nan),
+                    (getattr(res, n.lower() + "_unc") if (fitted_mask & _NONGRAV_BITS[n]) else np.nan),
                 )
             )
         output = np.array(
@@ -1113,10 +1177,15 @@ def orbitfit(
         orbit converges. ``False`` (default) fits none; ``True`` fits A2 (the
         transverse Yarkovsky term, the common asteroid case); a string or iterable
         naming params -- e.g. ``"A2"``, ``"A1A2A3"``, ``["A1", "A3"]`` -- selects a
-        subset of A1 (radial), A2 (transverse), A3 (normal). For each fitted param
-        an ``a{n}`` value and ``a{n}_unc`` 1-sigma column (au/day^2) are added to
-        the result. Cartesian engine only; params weakly constrained on short arcs
-        are reported as NaN (issue #351).
+        subset of A1 (radial), A2 (transverse), A3 (normal). ``"auto"`` selects the
+        model adaptively per object (issue #357): the gravity-only fit is kept
+        unless its reduced chi-square is unacceptable, in which case the most
+        parsimonious non-grav model that is well-conditioned and statistically
+        significant is adopted (the A1/A2/A3 columns are all present, with only the
+        adopted params filled and the rest NaN). For each fitted param an ``a{n}``
+        value and ``a{n}_unc`` 1-sigma column (au/day^2) are added to the result.
+        Cartesian engine only; params weakly constrained on short arcs are reported
+        as NaN (issue #351).
     """
 
     layup_observatory = LayupObservatory(cache_dir=cache_dir)

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from argparse import Namespace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional
 
@@ -157,54 +158,77 @@ def _parse_nongrav(fit_nongrav):
     return sum(_NONGRAV_BITS[n] for n in names), names
 
 
-# fit_nongrav="auto" decision thresholds (issue #357). Non-grav models are tried
-# only when the gravity-only reduced chi-square exceeds _AUTO_ACCEPT_REDUCED_CHI2,
-# in increasing complexity (_AUTO_NONGRAV_LADDER); the first model that converges
-# and is well-conditioned (flag 0), drops chi-square by more than
-# _AUTO_DELTA_CHI2_PER_PARAM per added parameter, and whose every added parameter
-# is individually significant (|A| > _AUTO_NSIGMA * sigma) is adopted. Otherwise
-# the gravity-only fit is kept. Standard practice: introduce a non-grav only when
-# gravity is unacceptable and the parameter is statistically warranted.
+# fit_nongrav="auto" model ladder (issue #357): non-grav models are tried in
+# increasing complexity, and the first that converges, is well-conditioned
+# (flag 0), and is statistically warranted (see NongravAutoThresholds) is adopted;
+# otherwise the gravity-only fit is kept.
 _AUTO_NONGRAV_LADDER = (("A2",), ("A1", "A2"), ("A1", "A2", "A3"))
-_AUTO_ACCEPT_REDUCED_CHI2 = 1.5
-_AUTO_DELTA_CHI2_PER_PARAM = 9.0  # ~3-sigma chi-square drop per added parameter
-_AUTO_NSIGMA = 3.0
 
 
-def _gravity_fit_acceptable(csq, ndof):
+@dataclass(frozen=True)
+class NongravAutoThresholds:
+    """Decision thresholds for adaptive non-grav selection (``fit_nongrav="auto"``,
+    issue #357). Pass a customized instance to ``orbitfit`` to tune how readily a
+    non-gravitational model is adopted; the defaults reproduce the standard
+    "introduce a non-grav only when gravity is unacceptable and the parameter is
+    statistically warranted" behavior.
+
+    Parameters
+    ----------
+    accept_reduced_chi2 : float
+        A gravity-only fit whose reduced chi-square is at or below this is kept
+        as-is; non-grav models are tried only above it. Default 1.5.
+    delta_chi2_per_param : float
+        Minimum chi-square drop required per added non-grav parameter to adopt a
+        model (9.0 ~ 3-sigma). Default 9.0.
+    nsigma : float
+        Each added non-grav parameter must exceed this many times its 1-sigma
+        uncertainty to be adopted. Default 3.0.
+    """
+
+    accept_reduced_chi2: float = 1.5
+    delta_chi2_per_param: float = 9.0
+    nsigma: float = 3.0
+
+
+_AUTO_DEFAULT_THRESHOLDS = NongravAutoThresholds()
+
+
+def _gravity_fit_acceptable(csq, ndof, thresholds=_AUTO_DEFAULT_THRESHOLDS):
     """Whether a gravity-only fit is good enough that no non-grav is warranted.
 
     True when the reduced chi-square is at or below the acceptance threshold (or
     there are no degrees of freedom to judge it by).
     """
-    return ndof <= 0 or csq / ndof <= _AUTO_ACCEPT_REDUCED_CHI2
+    return ndof <= 0 or csq / ndof <= thresholds.accept_reduced_chi2
 
 
-def _nongrav_warranted(csq_gravity, res_ng, names):
+def _nongrav_warranted(csq_gravity, res_ng, names, thresholds=_AUTO_DEFAULT_THRESHOLDS):
     """Whether adopting the (converged, well-conditioned) non-grav fit ``res_ng``
     for parameters ``names`` over the gravity-only fit is statistically warranted:
     a significant chi-square drop AND every added parameter individually significant.
     """
-    if (csq_gravity - res_ng.csq) <= _AUTO_DELTA_CHI2_PER_PARAM * len(names):
+    if (csq_gravity - res_ng.csq) <= thresholds.delta_chi2_per_param * len(names):
         return False  # chi-square improvement not significant for the added parameter(s)
     return all(
-        abs(getattr(res_ng, n.lower())) > _AUTO_NSIGMA * getattr(res_ng, n.lower() + "_unc") for n in names
+        abs(getattr(res_ng, n.lower())) > thresholds.nsigma * getattr(res_ng, n.lower() + "_unc")
+        for n in names
     )
 
 
-def _select_nongrav_auto(assist_ephem, res_grav, observations):
+def _select_nongrav_auto(assist_ephem, res_grav, observations, thresholds=_AUTO_DEFAULT_THRESHOLDS):
     """Adaptive non-grav selection for ``fit_nongrav="auto"`` (issue #357).
 
     ``res_grav`` is the converged gravity-only fit. Returns the most parsimonious
     acceptable model: the gravity-only result unless a non-grav model is both
-    well-conditioned (flag 0) and statistically warranted (see the thresholds above).
+    well-conditioned (flag 0) and statistically warranted per ``thresholds``.
     """
-    if _gravity_fit_acceptable(res_grav.csq, res_grav.ndof):
+    if _gravity_fit_acceptable(res_grav.csq, res_grav.ndof, thresholds):
         return res_grav  # gravity-only fit is acceptable; no non-gravs needed
     for names in _AUTO_NONGRAV_LADDER:
         mask = sum(_NONGRAV_BITS[n] for n in names)
         res_ng = run_from_vector_with_initial_guess(assist_ephem, res_grav, observations, nongrav_mask=mask)
-        if res_ng.flag == 0 and _nongrav_warranted(res_grav.csq, res_ng, names):
+        if res_ng.flag == 0 and _nongrav_warranted(res_grav.csq, res_ng, names, thresholds):
             return res_ng  # parsimonious, well-determined non-grav model
     return res_grav  # no non-grav model is warranted
 
@@ -875,6 +899,7 @@ def _orbitfit(
     iod: str = "gauss",
     engine: str = "cartesian",
     fit_nongrav: bool = False,
+    nongrav_auto_thresholds=None,
 ):
     """This function will contain all of the calls to the c++ code that will
     calculate an orbit given a set of observations. Note that all observations
@@ -1085,7 +1110,12 @@ def _orbitfit(
         if auto_nongrav and res.flag == 0:
             # Adopt the most parsimonious statistically-warranted non-grav model,
             # or keep the gravity-only fit (issue #357).
-            res = _select_nongrav_auto(get_ephem(kernels_loc), res, observations)
+            res = _select_nongrav_auto(
+                get_ephem(kernels_loc),
+                res,
+                observations,
+                nongrav_auto_thresholds or _AUTO_DEFAULT_THRESHOLDS,
+            )
         elif nongrav_mask and res.flag == 0:
             res_ng = run_from_vector_with_initial_guess(
                 get_ephem(kernels_loc), res, observations, nongrav_mask=nongrav_mask
@@ -1148,6 +1178,7 @@ def orbitfit(
     iod="gauss",
     engine="cartesian",
     fit_nongrav=False,
+    nongrav_auto_thresholds=None,
 ):
     """This is the function that you would call interactively. i.e. from a notebook
 
@@ -1186,6 +1217,12 @@ def orbitfit(
         value and ``a{n}_unc`` 1-sigma column (au/day^2) are added to the result.
         Cartesian engine only; params weakly constrained on short arcs are reported
         as NaN (issue #351).
+    nongrav_auto_thresholds : NongravAutoThresholds, optional
+        Decision thresholds used when ``fit_nongrav="auto"`` -- how unacceptable the
+        gravity-only fit must be before a non-grav is tried, and how large the
+        chi-square drop and per-parameter significance must be to adopt one. Default
+        (``None``) uses the standard thresholds; pass a customized
+        ``NongravAutoThresholds`` to tune. Ignored unless ``fit_nongrav="auto"``.
     """
 
     layup_observatory = LayupObservatory(cache_dir=cache_dir)
@@ -1220,6 +1257,7 @@ def orbitfit(
         iod=iod,
         engine=engine,
         fit_nongrav=fit_nongrav,
+        nongrav_auto_thresholds=nongrav_auto_thresholds,
     )
 
 

--- a/tests/layup/test_nongrav_a2.py
+++ b/tests/layup/test_nongrav_a2.py
@@ -338,3 +338,21 @@ def test_orbitfit_driver_fits_a1a2a3():
     assert abs(row["a1"] - _TRUE_A1) / abs(_TRUE_A1) < 1e-2
     assert abs(row["a2"] - _TRUE_A2) / abs(_TRUE_A2) < 1e-2
     assert abs(row["a3"] - _TRUE_A3) / abs(_TRUE_A3) < 1e-2
+
+
+def test_orbitfit_auto_schema_and_keeps_gravity_when_not_warranted():
+    """fit_nongrav='auto' on a purely gravitational arc: the gravity-only fit is
+    already acceptable, so no non-grav parameter is introduced -- a1/a2/a3 are all
+    NaN and the 6-parameter solution is returned (issue #357)."""
+    data, guess = _build_arc_array(a123=(0.0, 0.0, 0.0))  # no non-grav
+    fit = orbitfit(data, cache_dir=CACHE, initial_guess=guess, fit_nongrav="auto")
+    # 'auto' always carries the A1/A2/A3 columns (only adopted params are filled).
+    for col in ("a1", "a1_unc", "a2", "a2_unc", "a3", "a3_unc"):
+        assert col in fit.dtype.names, f"missing column {col}"
+    row = fit[0]
+    assert row["flag"] == 0
+    assert row["ndof"] == 2 * len(data) - 6  # gravity-only (6 parameters)
+    assert np.isnan(row["a1"]) and np.isnan(row["a2"]) and np.isnan(row["a3"])
+    state = np.array([row["x"], row["y"], row["z"], row["xdot"], row["ydot"], row["zdot"]])
+    pos_rel = np.linalg.norm(state[:3] - _STATE[:3]) / np.linalg.norm(_STATE[:3])
+    assert pos_rel < 1e-6

--- a/tests/layup/test_nongrav_auto.py
+++ b/tests/layup/test_nongrav_auto.py
@@ -1,0 +1,101 @@
+"""Adaptive non-grav selection logic for fit_nongrav="auto" (issue #357).
+
+These unit-test the decision layer directly with crafted fit results, so they run
+without the ASSIST ephemeris: the gravity-acceptance gate, the chi-square +
+per-parameter significance test, and the parsimony ladder in _select_nongrav_auto.
+The end-to-end orbitfit() paths are covered in test_nongrav_a2.py.
+"""
+
+import types
+
+from layup import orbitfit as O
+
+
+def _res(**kw):
+    """A minimal stand-in for a C++ FitResult (only the fields the auto logic reads)."""
+    d = dict(
+        csq=0.0,
+        ndof=100,
+        flag=0,
+        nongrav_mask=0,
+        a1=0.0,
+        a1_unc=1.0,
+        a2=0.0,
+        a2_unc=1.0,
+        a3=0.0,
+        a3_unc=1.0,
+    )
+    d.update(kw)
+    return types.SimpleNamespace(**d)
+
+
+def test_gravity_acceptable_gate():
+    assert O._gravity_fit_acceptable(csq=50.0, ndof=100)  # reduced chi2 0.5 -> acceptable
+    assert not O._gravity_fit_acceptable(csq=300.0, ndof=100)  # reduced chi2 3.0 -> not
+    assert O._gravity_fit_acceptable(csq=1e9, ndof=0)  # no dof to judge -> acceptable
+
+
+def test_nongrav_warranted_requires_chi2_drop_and_significance():
+    # Big chi2 drop and a strongly-determined A2 -> warranted.
+    good = _res(csq=10.0, a2=1e-13, a2_unc=1e-15)  # |A2|/sigma = 100
+    assert O._nongrav_warranted(csq_gravity=1000.0, res_ng=good, names=("A2",))
+
+    # Chi2 drop below the per-parameter threshold -> not warranted.
+    small_drop = _res(csq=995.0, a2=1e-13, a2_unc=1e-15)  # drop 5 < 9
+    assert not O._nongrav_warranted(1000.0, small_drop, ("A2",))
+
+    # Large chi2 drop but the parameter itself is not significant -> not warranted.
+    insignificant = _res(csq=10.0, a2=1e-15, a2_unc=1e-15)  # |A2|/sigma = 1
+    assert not O._nongrav_warranted(1000.0, insignificant, ("A2",))
+
+
+def test_nongrav_warranted_multiparam_needs_every_param_significant():
+    both = _res(csq=10.0, a1=1e-13, a1_unc=1e-15, a2=1e-13, a2_unc=1e-15)
+    assert O._nongrav_warranted(1000.0, both, ("A1", "A2"))  # drop 990 > 18, both sig
+    a1_weak = _res(csq=10.0, a1=1e-15, a1_unc=1e-15, a2=1e-13, a2_unc=1e-15)
+    assert not O._nongrav_warranted(1000.0, a1_weak, ("A1", "A2"))  # A1 not significant
+
+
+def test_select_auto_keeps_gravity_when_acceptable(monkeypatch):
+    tried = []
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", lambda *a, **k: tried.append(k))
+    grav = _res(csq=50.0, ndof=100)  # reduced chi2 0.5
+    out = O._select_nongrav_auto(assist_ephem=None, res_grav=grav, observations=None)
+    assert out is grav and not tried  # never attempted a non-grav fit
+
+
+def test_select_auto_adopts_most_parsimonious(monkeypatch):
+    grav = _res(csq=1000.0, ndof=100)  # reduced chi2 10 -> try non-gravs
+
+    def fake_fit(ephem, res, obs, nongrav_mask=0):
+        # A2-only already resolves it well and A2 is significant.
+        return _res(csq=10.0, flag=0, nongrav_mask=nongrav_mask, a2=1e-13, a2_unc=1e-15)
+
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)
+    out = O._select_nongrav_auto(None, grav, None)
+    assert out.csq == 10.0
+    assert out.nongrav_mask == O._NONGRAV_BITS["A2"]  # stopped at the parsimonious A2 rung
+
+
+def test_select_auto_escalates_when_a2_alone_insufficient(monkeypatch):
+    grav = _res(csq=1000.0, ndof=100)
+
+    def fake_fit(ephem, res, obs, nongrav_mask=0):
+        # A2 alone is insignificant; A1+A2 both land significant with a big drop.
+        if nongrav_mask == O._NONGRAV_BITS["A2"]:
+            return _res(csq=995.0, flag=0, nongrav_mask=nongrav_mask, a2=1e-15, a2_unc=1e-15)
+        return _res(
+            csq=10.0, flag=0, nongrav_mask=nongrav_mask, a1=1e-13, a1_unc=1e-15, a2=1e-13, a2_unc=1e-15
+        )
+
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)
+    out = O._select_nongrav_auto(None, grav, None)
+    assert out.nongrav_mask == (O._NONGRAV_BITS["A1"] | O._NONGRAV_BITS["A2"])
+
+
+def test_select_auto_falls_back_when_all_illconditioned(monkeypatch):
+    grav = _res(csq=1000.0, ndof=100)
+    # Every non-grav fit trips the weak-constraint / conditioning guard (flag 6).
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", lambda *a, **k: _res(flag=6, csq=1.0))
+    out = O._select_nongrav_auto(None, grav, None)
+    assert out is grav  # keep the gravity-only fit

--- a/tests/layup/test_nongrav_auto.py
+++ b/tests/layup/test_nongrav_auto.py
@@ -99,3 +99,47 @@ def test_select_auto_falls_back_when_all_illconditioned(monkeypatch):
     monkeypatch.setattr(O, "run_from_vector_with_initial_guess", lambda *a, **k: _res(flag=6, csq=1.0))
     out = O._select_nongrav_auto(None, grav, None)
     assert out is grav  # keep the gravity-only fit
+
+
+def test_thresholds_default_values():
+    t = O.NongravAutoThresholds()
+    assert (t.accept_reduced_chi2, t.delta_chi2_per_param, t.nsigma) == (1.5, 9.0, 3.0)
+
+
+def test_gravity_acceptable_gate_is_tunable():
+    # reduced chi2 = 2.0: acceptable under the default 1.5? no. Under a raised 3.0? yes.
+    assert not O._gravity_fit_acceptable(csq=200.0, ndof=100)
+    lenient = O.NongravAutoThresholds(accept_reduced_chi2=3.0)
+    assert O._gravity_fit_acceptable(csq=200.0, ndof=100, thresholds=lenient)
+    strict = O.NongravAutoThresholds(accept_reduced_chi2=0.1)
+    assert not O._gravity_fit_acceptable(csq=50.0, ndof=100, thresholds=strict)  # 0.5 > 0.1
+
+
+def test_nongrav_warranted_is_tunable():
+    # chi2 drop 5 per one param: not warranted at default 9.0, warranted at 4.0.
+    res_ng = _res(csq=995.0, a2=1e-13, a2_unc=1e-15)  # drop 5, A2 strongly significant
+    assert not O._nongrav_warranted(1000.0, res_ng, ("A2",))
+    assert O._nongrav_warranted(
+        1000.0, res_ng, ("A2",), thresholds=O.NongravAutoThresholds(delta_chi2_per_param=4.0)
+    )
+    # |A2|/sigma = 5: significant at nsigma=3 (default), not at nsigma=10.
+    res_sig = _res(csq=10.0, a2=5e-15, a2_unc=1e-15)
+    assert O._nongrav_warranted(1000.0, res_sig, ("A2",))
+    assert not O._nongrav_warranted(1000.0, res_sig, ("A2",), thresholds=O.NongravAutoThresholds(nsigma=10.0))
+
+
+def test_select_auto_threshold_suppresses_nongrav(monkeypatch):
+    # A case that adopts A2 under the default thresholds...
+    grav = _res(csq=1000.0, ndof=100)  # reduced chi2 10 -> non-grav tried by default
+
+    def fake_fit(ephem, res, obs, nongrav_mask=0):
+        return _res(csq=10.0, flag=0, nongrav_mask=nongrav_mask, a2=1e-13, a2_unc=1e-15)
+
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)
+    assert O._select_nongrav_auto(None, grav, None).nongrav_mask == O._NONGRAV_BITS["A2"]
+    # ...is kept gravity-only when the acceptance threshold is raised above its reduced chi2.
+    tried = []
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", lambda *a, **k: tried.append(k))
+    lenient = O.NongravAutoThresholds(accept_reduced_chi2=20.0)
+    out = O._select_nongrav_auto(None, grav, None, thresholds=lenient)
+    assert out is grav and not tried


### PR DESCRIPTION
Closes #357.

Follow-up to #351/#356 (which added the ability to *fit* non-grav A1/A2/A3). Adds an adaptive `fit_nongrav="auto"` mode, mirroring `iod="auto"`: introduce a non-grav parameter only when a gravity-only fit is unacceptable **and** the parameter is statistically warranted.

## Behaviour

`orbitfit(..., fit_nongrav="auto")`:
1. Keep the gravity-only fit if its reduced chi-square is acceptable (`_gravity_fit_acceptable`, ≤ 1.5).
2. Otherwise try non-grav models of increasing complexity — **A2; A1+A2; A1+A2+A3** — and adopt the first that:
   - converges and is well-conditioned (`flag == 0`, i.e. passes the #356 weak-constraint guard),
   - drops chi-square by more than ~3σ per added parameter (Δχ² > 9·k), **and**
   - has every added parameter individually significant (`|A| > 3·σ_A`).
3. Return the **most parsimonious** acceptable model.

The result schema always carries `a1/a2/a3` (+ `_unc`); each row reports only the adopted params, the rest `NaN`. Reuses the existing joint fit, conditioning guard, and formal uncertainties — this PR is just the decision layer on top.

## Tests

The decision layer is factored into pure helpers (`_gravity_fit_acceptable`, `_nongrav_warranted`, `_select_nongrav_auto`) and unit-tested with crafted fit results in **`test_nongrav_auto.py`** (7 tests, no ephemeris needed): the acceptance gate, the χ²-drop + per-parameter significance test, the parsimony ladder (adopt A2 / escalate to A1+A2), and the ill-conditioned fallback. `test_nongrav_a2.py` adds the end-to-end `orbitfit()` 'auto' schema + keep-gravity-when-not-warranted path.

*Note on test design:* the existing synthetic arcs are noise-free, where a gravity fit already has ~0 χ² and so is (correctly) statistically acceptable — adopting a param there would be over-fitting. The adopt/escalate logic is therefore validated with realistic crafted χ²/σ values in the unit tests rather than noise-free arcs.

## Catalog relevance

Non-gravs matter for the NEO tail of the MPC full-catalog fit; `auto` lets a bulk run apply them only where warranted, without a per-object manual flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
