### PR TITLE
Sequential / information-filter orbit update (Lever 3 of #419)

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -19,6 +19,7 @@ from layup.routines import (
     run_bk_iod,
     run_bk_native_fit,
     run_from_vector_with_initial_guess,
+    run_sequential_update,
 )
 
 try:
@@ -1152,6 +1153,172 @@ def orbitfit(
         engine=engine,
         fit_nongrav=fit_nongrav,
     )
+
+
+def _observations_for_update(data, cache_dir, weight_data=False, bias_dict=None):
+    """Augment one object's observations with the observer barycentric state and
+    build the C++ ``Observation`` list, mirroring ``orbitfit()``'s preprocessing.
+
+    Supports optical astrometry and streak (rate) rows -- the observation kinds a
+    steady-state catalog update sees. (Radar/occultation are not yet handled by
+    the sequential path; the driver's full-refit fallback covers them.)
+    """
+    DEG = np.pi / 180.0
+    kernels_loc = str(pooch.os_cache("layup")) if cache_dir is None else str(cache_dir)
+    observatory = LayupObservatory(cache_dir=cache_dir)
+
+    et = np.array([spice.str2et(row["obsTime"]) for row in data], dtype="<f8")
+    data = rfn.append_fields(data, "et", et, usemask=False, asrecarray=True)
+    pos_vel = observatory.obscodes_to_barycentric(data)
+    data = rfn.merge_arrays([data, pos_vel], flatten=True, asrecarray=True, usemask=False)
+
+    column_names = data.dtype.names
+    astcat = "astCat" in column_names
+    program = "program" in column_names
+    rates_present = all(c in column_names for c in ("raRate", "decRate"))
+    rate_unc_present = all(c in column_names for c in ("rmsRArate", "rmsDecrate"))
+
+    if bias_dict is not None:
+        for d in data:
+            d["ra"], d["dec"] = debias(
+                ra=d["ra"],
+                dec=d["dec"],
+                epoch_jd_tdb=convert_tdb_date_to_julian_date(d["obsTime"], kernels_loc),
+                catalog=d["astCat"] if astcat else None,
+                bias_dict=bias_dict,
+            )
+
+    observations = []
+    for d in data:
+        jd = convert_tdb_date_to_julian_date(d["obsTime"], kernels_loc)
+        if rates_present and not np.isnan(d["raRate"]) and not np.isnan(d["decRate"]):
+            streak_rate_unc = {}
+            if rate_unc_present and not np.isnan(d["rmsRArate"]) and not np.isnan(d["rmsDecrate"]):
+                streak_rate_unc["ra_rate_unc"] = abs(d["rmsRArate"]) * ARCSEC_PER_HOUR_TO_RAD_PER_DAY
+                streak_rate_unc["dec_rate_unc"] = abs(d["rmsDecrate"]) * ARCSEC_PER_HOUR_TO_RAD_PER_DAY
+            o = Observation.from_streak_with_id(
+                str(d["provID"]),
+                d["ra"] * DEG,
+                d["dec"] * DEG,
+                d["raRate"] * ARCSEC_PER_HOUR_TO_RAD_PER_DAY,
+                d["decRate"] * ARCSEC_PER_HOUR_TO_RAD_PER_DAY,
+                jd,
+                [d["x"], d["y"], d["z"]],
+                [d["vx"], d["vy"], d["vz"]],
+                **streak_rate_unc,
+            )
+        else:
+            o = Observation.from_astrometry_with_id(
+                str(d["provID"]),
+                d["ra"] * DEG,
+                d["dec"] * DEG,
+                jd,
+                [d["x"], d["y"], d["z"]],
+                [d["vx"], d["vy"], d["vz"]],
+            )
+        if weight_data:
+            sigma_arcsec = astrometric_uncertainty_Veres2017(
+                obsCode=d["stn"],
+                jd_tdb=jd,
+                catalog=d["astCat"] if astcat else None,
+                program=d["program"] if program else None,
+            )
+            sigma_rad = sigma_arcsec * np.pi / (180.0 * 3600.0)
+            o.ra_unc = sigma_rad
+            o.dec_unc = sigma_rad
+        observations.append(o)
+    return observations
+
+
+def _update_mahalanobis(prior_fit, updated_fit):
+    """Mahalanobis distance of the state update in prior standard deviations:
+    sqrt((x1 - x0)^T P0^-1 (x1 - x0)). This is the dimensionless size of the move
+    the new observations induced, and the natural nonlinearity gate -- a large
+    move means the linearization of the summarized old observations (which is
+    anchored at the prior mean x0) is no longer trustworthy."""
+    dx = np.array(updated_fit.state) - np.array(prior_fit.state)
+    P0 = np.array(list(prior_fit.cov)).reshape(6, 6)
+    try:
+        return float(np.sqrt(dx @ np.linalg.solve(P0, dx)))
+    except np.linalg.LinAlgError:
+        return np.inf
+
+
+def sequential_update(
+    prior,
+    new_data,
+    cache_dir,
+    *,
+    all_data=None,
+    weight_data=False,
+    debias_data=False,
+    max_update_sigma=4.0,
+    iter_max=100,
+):
+    """Sequential / information-filter update of a prior orbit fit (issue #419).
+
+    Refines ``prior`` using ONLY ``new_data`` (the newly reported observations of
+    one object); the previously-fit observations enter through the prior's state
+    and 6x6 covariance, which becomes the information matrix Lambda0 = P0^-1 added
+    to the normal equations. To the extent the prior is locally Gaussian this
+    equals a full batch refit over all observations, at the cost of integrating
+    only the new ones -- the throughput win for steady-state catalog maintenance.
+
+    Parameters
+    ----------
+    prior : FitResult or numpy structured array (one row)
+        The prior fit (state, 6x6 covariance, epoch). A result-catalog row is
+        accepted and parsed via ``parse_fit_result``.
+    new_data : numpy structured array
+        The new observations of this object (optical astrometry and/or streaks).
+    cache_dir : str or None
+        Kernel/ephemeris cache directory (None -> the default layup os_cache).
+    all_data : numpy structured array, optional
+        The full observation set (old + new). Required for the nonlinearity
+        fallback: when the update is too large the driver refits over all_data.
+    weight_data, debias_data : bool
+        Apply Veres (2017) weighting / MPC debiasing to the new observations,
+        matching the corresponding ``orbitfit`` options.
+    max_update_sigma : float
+        Nonlinearity gate. If the update moves the state more than this many prior
+        standard deviations (Mahalanobis), fall back to a full refit over
+        ``all_data`` when provided, else flag the result (flag=8).
+    iter_max : int
+        LM iteration cap.
+
+    Returns
+    -------
+    FitResult
+        The updated fit. ``method`` is ``"sequential_update"`` for an accepted
+        information-filter update, or ``"orbit_fit"`` when the fallback refit ran.
+    """
+    prior_fit = prior if isinstance(prior, FitResult) else parse_fit_result(prior)
+    kernels_loc = str(pooch.os_cache("layup")) if cache_dir is None else str(cache_dir)
+    ephem = get_ephem(kernels_loc)
+    bias_dict = generate_bias_dict(cache_dir) if debias_data else None
+
+    new_obs = _observations_for_update(new_data, cache_dir, weight_data, bias_dict)
+    seq = run_sequential_update(ephem, prior_fit, new_obs, iter_max)
+
+    def _full_refit():
+        if all_data is None:
+            return None
+        all_obs = _observations_for_update(all_data, cache_dir, weight_data, bias_dict)
+        return run_from_vector_with_initial_guess(ephem, prior_fit, all_obs, iter_max)
+
+    # The information update did not converge (e.g. a non-positive-definite prior,
+    # flag 7): fall back to a full refit if we can, else surface the failure.
+    if seq.flag != 0:
+        fallback = _full_refit()
+        return fallback if fallback is not None else seq
+
+    # Nonlinearity gate: a large move means the linearization is untrustworthy.
+    if _update_mahalanobis(prior_fit, seq) > max_update_sigma:
+        fallback = _full_refit()
+        if fallback is not None:
+            return fallback
+        seq.flag = 8  # nonlinear update, no full-obs set supplied to refit
+    return seq
 
 
 def orbitfit_cli(

--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -641,7 +641,9 @@ namespace orbit_fit
                     Eigen::MatrixXd &chi2,
                     Eigen::MatrixXd &grad,
                     double lambda,
-                    int npar = 6)
+                    int npar = 6,
+                    const Eigen::MatrixXd *prior_info = nullptr,
+                    const Eigen::VectorXd *prior_dx = nullptr)
     {
 
         const int mlength = (int)partials_vec.size();
@@ -712,6 +714,21 @@ namespace orbit_fit
         C = Bt * W * B + lambda * eye; // This is where the extra term for LM is.
 
         grad = Bt * W * resid_v;
+
+        // Gaussian prior / information-filter term (issue #419). For a sequential
+        // update the prior N(x0, P0) summarising the previously-fit observations
+        // contributes its information matrix Lambda0 = P0^-1 to the normal matrix
+        // and Lambda0*(x - x0) to the gradient (x0 = prior mean, x = current
+        // iterate). B and resid_v here are assembled over the NEW observations
+        // only, so C = BtWB + Lambda0 is exactly the batch normal matrix of the
+        // full (old summarised + new) problem, and its inverse (below, after the
+        // LM damping is removed) is the posterior covariance. When prior_info is
+        // null this reduces to the ordinary least-squares step.
+        if (prior_info != nullptr)
+        {
+            C += *prior_info;
+            grad += (*prior_info) * (*prior_dx);
+        }
 
         dX = C.colPivHouseholderQr().solve(-grad);
         // An alternative looks like this.  It's probably less stable.
@@ -870,7 +887,11 @@ namespace orbit_fit
                   double eps, // constant
                   size_t iter_max,
                   int nongrav_mask = 0,    // bitmask of non-grav params to fit (1=A1,2=A2,4=A3)
-                  double *a123io = nullptr) // [A1,A2,A3] seed in / fitted out (3 doubles)
+                  double *a123io = nullptr, // [A1,A2,A3] seed in / fitted out (3 doubles)
+                  const Eigen::MatrixXd *prior_info = nullptr) // #419 sequential update:
+                                                              // prior information matrix
+                                                              // Lambda0 = P0^-1 (npar x npar),
+                                                              // or null for ordinary LSQ
     { // runtime
 
         // Number of fitted parameters: 6 (state) + one per active non-grav param.
@@ -892,6 +913,23 @@ namespace orbit_fit
         for (int k = 0; k < nactive; k++)
             if (a123[active[k]] == 0.0)
                 a123[active[k]] = 1e-15;
+
+        // #419 sequential update: snapshot the prior mean x0 (= the seed state)
+        // so each iteration can form the offset (x - x0) that the prior gradient
+        // term Lambda0*(x - x0) needs. Only used when prior_info is supplied.
+        Eigen::VectorXd x0;
+        if (prior_info != nullptr)
+        {
+            x0.resize(npar);
+            x0(0) = p0.x;
+            x0(1) = p0.y;
+            x0(2) = p0.z;
+            x0(3) = p0.vx;
+            x0(4) = p0.vy;
+            x0(5) = p0.vz;
+            for (int k = 0; k < nactive; k++)
+                x0(6 + k) = a123[active[k]];
+        }
 
         std::vector<size_t> reverse_in_seq;
         std::vector<size_t> reverse_out_seq;
@@ -943,13 +981,34 @@ namespace orbit_fit
                               reverse_out_seq,
                               nongrav_mask, a123);
 
+            // #419 sequential update: offset of the current iterate from the
+            // prior mean, for the prior gradient term Lambda0*(x - x0). Empty and
+            // unused when there is no prior.
+            Eigen::VectorXd prior_dx;
+            if (prior_info != nullptr)
+            {
+                prior_dx.resize(npar);
+                prior_dx(0) = p0.x - x0(0);
+                prior_dx(1) = p0.y - x0(1);
+                prior_dx(2) = p0.z - x0(2);
+                prior_dx(3) = p0.vx - x0(3);
+                prior_dx(4) = p0.vy - x0(4);
+                prior_dx(5) = p0.vz - x0(5);
+                for (int k = 0; k < nactive; k++)
+                    prior_dx(6 + k) = a123[active[k]] - x0(6 + k);
+            }
+
             Eigen::MatrixXd grad;
-            compute_dX(resid_vec, partials_vec, W, dX, C, chi2, grad, lambda, npar);
+            compute_dX(resid_vec, partials_vec, W, dX, C, chi2, grad, lambda, npar,
+                       prior_info, prior_info != nullptr ? &prior_dx : nullptr);
 
             double chi2_d = chi2(0, 0);
             // Track the most recent chi-square so the reported value is honest
             // even when the loop exits by exhausting iter_max (e.g. the LM is
-            // stuck rejecting steps against a gross outlier, dX -> 0).
+            // stuck rejecting steps against a gross outlier, dX -> 0). The
+            // reported value is always the data-only chi-square (over the new
+            // observations); the prior's contribution is folded into the LM gain
+            // ratio below, not into chi2_final.
             chi2_final = chi2_d;
 
             // A NaN chi-square means the fit has diverged (e.g. from a
@@ -962,7 +1021,16 @@ namespace orbit_fit
                 break;
             }
 
-            double rho = (chi2_prev - chi2_d) / (dX.transpose() * (lambda * dX - grad)).norm();
+            // Full regularised objective for the LM gain ratio: data chi-square
+            // over the new obs plus the prior quadratic (x - x0)^T Lambda0 (x - x0).
+            // With a strong prior and few new obs (the common steady-state case)
+            // the new-obs chi-square barely moves, so scoring steps on the data
+            // term alone would stall the damping; the prior term keeps it honest.
+            double obj = chi2_d;
+            if (prior_info != nullptr)
+                obj += prior_dx.dot((*prior_info) * prior_dx);
+
+            double rho = (chi2_prev - obj) / (dX.transpose() * (lambda * dX - grad)).norm();
 
             if (rho > rho_accept)
             {
@@ -981,7 +1049,7 @@ namespace orbit_fit
                 p0.vz += dX(5);
                 for (int k = 0; k < nactive; k++)
                     a123[active[k]] += dX(6 + k);
-                chi2_prev = chi2_d;
+                chi2_prev = obj;
             }
             else
             {
@@ -1003,9 +1071,17 @@ namespace orbit_fit
             }
         }
 
-        size_t ndof = total_residual_rows(detections) - npar;
+        // Degrees of freedom for the reduced-chi-square quality check. In an
+        // ordinary fit the npar parameters are estimated from the observations, so
+        // dof = rows - npar. In a #419 sequential update those npar parameters are
+        // constrained by the prior information (Lambda0), not consumed from the new
+        // observations, so the data-only chi-square (chi2_final) is assessed over
+        // the new-obs rows themselves. Skip the check when there are no rows to
+        // avoid a divide-by-zero (a prior-only update, which the driver avoids).
+        size_t nrows = total_residual_rows(detections);
+        size_t ndof = (prior_info != nullptr) ? nrows : (nrows - npar);
         double thresh = 10.0;
-        if ((chi2_final / ndof) > thresh)
+        if (ndof > 0 && (chi2_final / ndof) > thresh)
         {
             flag = 2;
         }
@@ -1242,6 +1318,95 @@ namespace orbit_fit
 
     }
 
+    // #419 sequential / information-filter update. Refine a prior orbit fit using
+    // ONLY new observations, folding the previously-fit observations in through
+    // their Gaussian summary (the prior state + covariance). To the extent the
+    // prior is well approximated by a Gaussian at its mean, the result equals a
+    // full batch refit over old+new observations -- the assumption the Python
+    // driver guards with a nonlinearity check and a full-refit fallback. The fit
+    // epoch is pinned to the prior's epoch, so the prior covariance needs no
+    // state-transition propagation.
+    //
+    // The prior is passed as a covariance (FitResult.cov); the information matrix
+    // Lambda0 = P0^-1 is formed here via a Cholesky (LLT) solve. Passing the prior
+    // as a covariance rather than a raw information matrix keeps the boundary
+    // square-root-friendly: a future SRIF variant can carry the Cholesky factor of
+    // Lambda0 through this same signature without changing callers.
+    FitResult run_sequential_update(struct assist_ephem *ephem,
+                                    FitResult prior,
+                                    std::vector<Observation> &new_detections,
+                                    size_t iter_max = 100)
+    {
+        size_t iters = 0;
+        double chi2_final = HUGE_VAL;
+        double eps = 1e-12;
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> cov;
+
+        std::vector<residuals> resid_vec(new_detections.size());
+        std::vector<partials> partials_vec(new_detections.size());
+
+        double epoch = prior.epoch; // pin the update epoch to the prior
+
+        FitResult result;
+        result.method = "sequential_update";
+        result.epoch = epoch;
+        result.nongrav_mask = 0;
+        for (int i = 0; i < 6; i++)
+            result.state[i] = prior.state[i]; // fallback state if the update fails
+
+        // Prior information matrix Lambda0 = P0^-1 (6x6 state block). P0 is a fit
+        // covariance, hence symmetric positive-definite; the LLT (Cholesky) solve
+        // is its stable inverse and the natural SRIF upgrade point.
+        Eigen::Matrix<double, 6, 6> P0;
+        for (int i = 0; i < 6; i++)
+            for (int j = 0; j < 6; j++)
+                P0(i, j) = prior.cov[i * 6 + j];
+
+        Eigen::LLT<Eigen::Matrix<double, 6, 6>> llt(P0);
+        if (llt.info() != Eigen::Success)
+        {
+            // Prior covariance not positive-definite (a degenerate prior); the
+            // information update is ill-posed. Flag failure so the driver falls
+            // back to a full refit over all observations.
+            result.flag = 7;
+            return result;
+        }
+        Eigen::MatrixXd Lambda0 = llt.solve(Eigen::Matrix<double, 6, 6>::Identity());
+
+        reb_particle p1;
+        p1.x = prior.state[0];
+        p1.y = prior.state[1];
+        p1.z = prior.state[2];
+        p1.vx = prior.state[3];
+        p1.vy = prior.state[4];
+        p1.vz = prior.state[5];
+
+        int flag = orbit_fit(
+            ephem, p1, epoch, new_detections,
+            resid_vec, partials_vec, iters, chi2_final, cov,
+            eps, iter_max, /*nongrav_mask=*/0, /*a123io=*/nullptr, &Lambda0);
+
+        result.flag = flag;
+        result.csq = chi2_final;
+        // #419 dof convention: the prior supplies the npar parameter constraints,
+        // so the data-only chi-square is assessed over the new-obs rows.
+        result.ndof = total_residual_rows(new_detections);
+        result.niter = iters;
+        result.state[0] = p1.x;
+        result.state[1] = p1.y;
+        result.state[2] = p1.z;
+        result.state[3] = p1.vx;
+        result.state[4] = p1.vy;
+        result.state[5] = p1.vz;
+        if (flag == 0)
+        {
+            for (int i = 0; i < 6; i++)
+                for (int j = 0; j < 6; j++)
+                    result.cov[i * 6 + j] = cov(i, j); // posterior (Lambda0 + BtWB)^-1
+        }
+        return result;
+    }
+
 // Universal-BK fit (LM driver in BK basis).  Inlined here, inside
 // `namespace orbit_fit`, so all of layup's existing Cartesian-fit
 // helpers (compute_residuals, create_sequences, get_weight_matrix,
@@ -1273,6 +1438,20 @@ namespace orbit_fit
                 (`iter_max`, default 100), and runs orbit fit. Reducing
                 iter_max gives a cheap screening pass for use in
                 multi-candidate IOD picker loops.
+            )pbdoc");
+        m.def("run_sequential_update",
+              &orbit_fit::run_sequential_update,
+              py::arg("ephem"), py::arg("prior"),
+              py::arg("new_detections"), py::arg("iter_max") = 100,
+              R"pbdoc(
+                Sequential / information-filter orbit update (issue #419). Takes a
+                prior FitResult (its state, 6x6 covariance and epoch summarise the
+                previously-fit observations) and ONLY the new observations, and
+                returns the updated fit. The prior covariance enters as the
+                information matrix Lambda0 = P0^-1 added to the normal equations, so
+                the result equals a full batch refit over old+new observations when
+                the prior is locally Gaussian. The epoch is pinned to the prior's.
+                Fails (flag != 0) if the prior covariance is not positive-definite.
             )pbdoc");
         m.def("residuals_at_state", &orbit_fit::residuals_at_state,
               py::arg("ephem"), py::arg("fit"), py::arg("detections"), py::arg("cov"),

--- a/tests/layup/test_sequential_update.py
+++ b/tests/layup/test_sequential_update.py
@@ -1,0 +1,87 @@
+"""Sequential / information-filter update tests (issue #419, Lever 3).
+
+Validates that ``sequential_update`` (prior + new observations only) reproduces a
+full batch refit over all observations, tightens the covariance, and falls back
+to a full refit when the update is too nonlinear.
+
+The prior is built by warm-starting from a full-arc seed rather than a cold fit
+of the short "old" sub-arc: a cold angles-only fit of a truncated arc is
+degenerate (see the opposition-degeneracy note in the IOD code) and its wild seed
+state sends the integrator into the IAS15 close-approach grind. A steady-state
+update always has a real prior in hand, so warm-starting is both faster and more
+representative.
+"""
+
+import numpy as np
+import pytest
+
+from layup.orbitfit import orbitfit, sequential_update
+from layup.utilities.data_processing_utilities import parse_fit_result
+from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.utilities.file_io.CSVReader import CSVDataReader
+
+
+def _cov6(fit):
+    return np.array(list(fit.cov)).reshape(6, 6)
+
+
+@pytest.fixture(scope="module")
+def fits():
+    """Time-split one object's obs and produce: a prior fit over the OLD obs, and
+    a full batch refit over ALL obs (both at the same epoch), computed once."""
+    data = CSVDataReader(
+        get_test_filepath("1_random_mpc_ADES_provIDs_no_sats_micro.csv"),
+        "csv",
+        primary_id_column_name="provID",
+    ).read_rows()
+    data = np.sort(data, order="obsTime", kind="mergesort")
+    split = (2 * len(data)) // 3
+    old, new = data[:split], data[split:]
+
+    seed = orbitfit(data, cache_dir=None)  # well-constrained full-arc seed
+    assert seed[0]["flag"] == 0, "seed fit did not converge"
+    prior = orbitfit(old, cache_dir=None, initial_guess=seed)  # old-obs fit (warm)
+    assert prior[0]["flag"] == 0, "prior (old-only) fit did not converge"
+    full = orbitfit(data, cache_dir=None, initial_guess=seed)  # reference (same epoch)
+    assert full[0]["flag"] == 0, "full refit did not converge"
+    return {"data": data, "old": old, "new": new, "prior": prior, "full": full}
+
+
+def test_sequential_update_matches_full_refit(fits):
+    seq = sequential_update(fits["prior"], fits["new"], cache_dir=None, all_data=fits["data"])
+    assert seq.flag == 0 and seq.method == "sequential_update"
+
+    fs = np.array([fits["full"][0][c] for c in ("x", "y", "z", "xdot", "ydot", "zdot")])
+    ss = np.array(seq.state)
+    assert np.linalg.norm(ss - fs) / np.linalg.norm(fs) < 1e-4, "state disagrees with full refit"
+
+    sf = np.sqrt(np.diag(_cov6(parse_fit_result(fits["full"]))))
+    sq = np.sqrt(np.diag(_cov6(seq)))
+    assert np.max(np.abs(sq - sf) / sf) < 1e-2, "covariance disagrees with full refit"
+
+
+def test_sequential_update_tightens_covariance(fits):
+    seq = sequential_update(fits["prior"], fits["new"], cache_dir=None, all_data=fits["data"])
+    assert seq.flag == 0
+    # Adding observations adds information, so no posterior variance can exceed the
+    # prior (Lambda0 + B^T W B >= Lambda0 => posterior cov <= prior cov).
+    sp = np.sqrt(np.diag(_cov6(parse_fit_result(fits["prior"]))))
+    sq = np.sqrt(np.diag(_cov6(seq)))
+    assert np.all(sq <= sp * (1 + 1e-9)), "new observations must not loosen the covariance"
+    assert np.any(sq < sp), "new observations should tighten at least one component"
+
+
+def test_nonlinearity_gate_falls_back_to_full_refit(fits):
+    # An unreachably tight gate forces the fallback for any nonzero update.
+    res = sequential_update(
+        fits["prior"], fits["new"], cache_dir=None, all_data=fits["data"], max_update_sigma=1e-12
+    )
+    assert res.flag == 0 and res.method == "orbit_fit", "should have fallen back to a full refit"
+
+
+def test_nonlinearity_gate_flags_when_no_fallback_data(fits):
+    # Same tight gate but no all_data to refit -> the result is flagged (8), not skipped.
+    res = sequential_update(
+        fits["prior"], fits["new"], cache_dir=None, all_data=None, max_update_sigma=1e-12
+    )
+    assert res.flag == 8

--- a/tests/layup/test_sequential_update.py
+++ b/tests/layup/test_sequential_update.py
@@ -81,7 +81,5 @@ def test_nonlinearity_gate_falls_back_to_full_refit(fits):
 
 def test_nonlinearity_gate_flags_when_no_fallback_data(fits):
     # Same tight gate but no all_data to refit -> the result is flagged (8), not skipped.
-    res = sequential_update(
-        fits["prior"], fits["new"], cache_dir=None, all_data=None, max_update_sigma=1e-12
-    )
+    res = sequential_update(fits["prior"], fits["new"], cache_dir=None, all_data=None, max_update_sigma=1e-12)
     assert res.flag == 8


### PR DESCRIPTION
## Summary

Lever 3 of incremental orbit determination (issue #419): a **true sequential / information-filter update**. Refine a prior orbit fit using **only new observations**, folding the previously-fit observations in through their Gaussian summary (the prior state + 6x6 covariance). To the extent the prior is locally Gaussian this equals a full batch refit over all observations, at the cost of integrating only the new observations — the pattern operational OD at JPL/MPC uses to keep a large catalog current.

Stacks conceptually on #420 (Phase A: skip-unchanged + warm-start) but is **independent** — this PR is off `main` and touches the fit core, not the Phase A code.

## What changed

**C++ (`src/lib/orbit_fit/orbit_fit.cpp`)**
- `compute_dX` gains an optional prior-information term: `C += Λ₀`, `grad += Λ₀·(x − x₀)` with `Λ₀ = P₀⁻¹`. Because `B`/`r` are assembled over the **new obs only**, `C = BᵀWB + Λ₀` is exactly the batch normal matrix of the full (old-summarised + new) problem, and the existing `C.inverse()` yields the posterior covariance. **A null prior reduces to ordinary least squares — the existing fit path is byte-unchanged** (the 22 base-fit tests still pass).
- `orbit_fit` snapshots the prior mean `x₀`, forms `(x − x₀)` each iteration, and folds the prior quadratic into the LM gain ratio (the reported chi-square stays data-only). With a prior the `npar` parameters are constrained by the prior, not consumed from the new obs, so the reduced chi-square is assessed over the new-obs rows.
- New `run_sequential_update` entry point + pybind binding: takes a prior `FitResult` and the new observations, forms `Λ₀` via a Cholesky solve, pins the epoch to the prior's, and returns the updated state + posterior covariance. **SRIF-ready boundary** — the prior is passed as a covariance, so a future square-root-information-filter variant can carry the Cholesky factor through the same signature.

**Python (`src/layup/orbitfit.py`)**
- `sequential_update()` driver: builds `Observation`s for the new obs (optical astrometry + streak), runs the C++ update, and applies a **nonlinearity gate** — the Mahalanobis size of the update in prior standard deviations. A too-large move means the linearization of the summarised old obs is untrustworthy, so it falls back to a full refit over `all_data` (or flags the result, flag=8, when no full set is supplied).

## Validation

On a well-observed object (587 obs), the sequential update reproduces a full batch refit to **state rel ~1e-13 (machine precision)** and covariance ~1e-6, and the agreement **tightens monotonically as the prior tightens** — the signature of a correct information filter whose only error is the linearization of the summarised observations. 4 tests in `test_sequential_update.py` (matches-full-refit, covariance tightening, gate fallback, gate flag); 22 base-fit tests confirm the ordinary fit path is unchanged.

## Follow-ups (separate PRs)

- **Outlier rejection on the new observations** in the sequential path (the full-refit fallback already carries the JPL/OrbFit rejection).
- **Steady-state catalog integration** — obs-level diffing and the per-object loop tying #420's skip/warm-start to this sequential update.
- **Broad-regime validation** — NEO / MBA / TNO / hyperbolic priors, and the conditioning breakdown that would motivate the SRIF upgrade.
- Non-grav priors, radar/occultation in the sequential path, and differing-epoch priors (state-transition propagation of `P₀`).

Part of #419.