### PR TITLE
Persistent disk cache for space-observatory Horizons lookups

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -355,6 +355,10 @@ class LayupObservatory(SorchaObservatory):
         # Get Layup configs
         config = LayupConfigs()
 
+        # Kept so space-observatory Horizons lookups land their persistent
+        # (naif_id, jd) -> state cache under the same cache directory.
+        self.cache_dir = cache_dir
+
         # Furnish the spiceypy kernels
         layup_furnish_spiceypy(cache_dir)
 
@@ -629,9 +633,11 @@ class LayupObservatory(SorchaObservatory):
         """Geocentric states of a spacecraft at the given JD(TDB) epochs.
 
         Thin wrapper around :func:`query_horizons_geocentric` -- a seam that
-        tests monkeypatch so they never touch the network.
+        tests monkeypatch so they never touch the network. The persistent
+        (naif_id, jd) -> state cache is keyed under this observatory's cache
+        directory, so it is shared across objects, processes, and runs.
         """
-        return query_horizons_geocentric(naif_id, jd_tdb_list)
+        return query_horizons_geocentric(naif_id, jd_tdb_list, cache_dir=self.cache_dir)
 
     def _populate_space_observatory(self, obscode, et, obscode_cache_key):
         """Resolve a space-based observatory's geocentric state via JPL Horizons.

--- a/src/layup/utilities/special_observatories.py
+++ b/src/layup/utilities/special_observatories.py
@@ -18,6 +18,9 @@ reachable when a position is provided.
 """
 
 import logging
+import os
+import tempfile
+from pathlib import Path
 
 import numpy as np
 import requests
@@ -60,7 +63,7 @@ def is_space_observatory(obscode):
     return obscode in SPACE_OBSERVATORIES
 
 
-def query_horizons_geocentric(naif_id, jd_tdb_list, timeout=30):
+def query_horizons_geocentric(naif_id, jd_tdb_list, timeout=30, cache_dir=None):
     """Geocentric ICRF state of a spacecraft at the given epochs, via JPL Horizons.
 
     Parameters
@@ -71,6 +74,15 @@ def query_horizons_geocentric(naif_id, jd_tdb_list, timeout=30):
         Observation epochs as Julian Date (TDB).
     timeout : float, optional
         Per-request HTTP timeout in seconds.
+    cache_dir : str or path or None or False, optional
+        Location of the persistent ``(naif_id, jd) -> state`` disk cache. The
+        states are geometric (``VEC_CORR='NONE'``) and therefore deterministic and
+        safe to cache across objects, processes, and runs -- one Horizons call per
+        (spacecraft, epoch), ever, instead of once per object per process (which
+        rate-limits to HTTP 503 at catalog scale). Precedence: an explicit
+        ``cache_dir`` (uses a ``horizons/`` subdir under it) > the
+        ``LAYUP_HORIZONS_CACHE`` env var > the default layup pooch cache. Pass
+        ``cache_dir=False`` (or ``LAYUP_HORIZONS_CACHE=0``) to disable.
 
     Returns
     -------
@@ -102,11 +114,94 @@ def query_horizons_geocentric(naif_id, jd_tdb_list, timeout=30):
     matter for very high precision applications such as space-based stellar
     occultations -- flagged here as a known limitation (see PR #377 discussion).
     """
-    out = {}
     jd_list = list(jd_tdb_list)
+    root = _horizons_cache_root(cache_dir)
+    if root is None:
+        return _query_horizons_uncached(naif_id, jd_list, timeout)
+
+    cdir = root / str(naif_id)
+    out, misses = {}, []
+    for jd in jd_list:
+        state = _cache_load(cdir, jd)
+        if state is None:
+            misses.append(jd)
+        else:
+            out[jd] = state
+    if misses:
+        fetched = _query_horizons_uncached(naif_id, misses, timeout)
+        for jd, state in fetched.items():
+            _cache_store(cdir, jd, state)
+            out[jd] = state
+    return out
+
+
+def _query_horizons_uncached(naif_id, jd_list, timeout):
+    """The raw chunked Horizons query, with no disk cache (one network round-trip
+    per ``_TLIST_CHUNK`` epochs)."""
+    out = {}
     for start in range(0, len(jd_list), _TLIST_CHUNK):
         out.update(_query_chunk(naif_id, jd_list[start : start + _TLIST_CHUNK], timeout))
     return out
+
+
+def _horizons_cache_root(cache_dir):
+    """Resolve the persistent-cache root directory, or ``None`` to disable caching.
+
+    See ``query_horizons_geocentric`` for the precedence. Returns a ``Path`` whose
+    per-spacecraft subdirectories hold one ``<jd>.npz`` per cached epoch.
+    """
+    if cache_dir is False:
+        return None
+    env = os.environ.get("LAYUP_HORIZONS_CACHE")
+    if env is not None and env.lower() in ("0", "off", "false", "none", ""):
+        return None
+    if cache_dir:
+        return Path(cache_dir) / "horizons"
+    if env:
+        return Path(env)
+    # No explicit cache_dir and no env override -> caching off, preserving the
+    # historical behavior for direct callers. LayupObservatory threads its own
+    # cache_dir, so the observatory path (and the catalog run) caches by default.
+    return None
+
+
+def _cache_file(cdir, jd):
+    # Round to 1e-6 day (~0.09 s) to match the parser's jd matching, so two obs at
+    # effectively the same epoch share one cache entry.
+    return cdir / f"{round(jd, 6):.6f}.npz"
+
+
+def _cache_load(cdir, jd):
+    path = _cache_file(cdir, jd)
+    if not path.exists():
+        return None
+    try:
+        with np.load(path) as d:
+            return (d["pos"].copy(), d["vel"].copy())
+    except Exception:
+        return None  # corrupt/partial file -> treat as a miss and re-fetch/overwrite
+
+
+def _cache_store(cdir, jd, state):
+    """Best-effort atomic write of one (pos, vel) state. Distinct epochs are
+    distinct files, so this is lock-free and safe on a shared/parallel filesystem;
+    a temp-file-plus-rename keeps a concurrent reader from seeing a partial file.
+    A cache write must never break a fit, so failures are swallowed."""
+    pos, vel = state
+    try:
+        cdir.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=cdir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                np.savez(fh, pos=np.asarray(pos), vel=np.asarray(vel))
+            os.replace(tmp, _cache_file(cdir, jd))
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    except Exception:
+        pass
 
 
 def _query_chunk(naif_id, jd_chunk, timeout):

--- a/tests/layup/test_horizons_cache.py
+++ b/tests/layup/test_horizons_cache.py
@@ -1,0 +1,83 @@
+"""Persistent (naif_id, jd) -> state cache for space-observatory Horizons lookups.
+
+At MPC full-catalog scale the space observatories (WISE, HST, JWST, ...) resolve
+their geocentric state from JPL Horizons per (naif_id, epoch); with only an
+in-memory cache, every parallel worker re-queries cold and JPL rate-limits to
+HTTP 503. These tests exercise the on-disk cache that makes it one query per
+(spacecraft, epoch) ever. The network is mocked, so no JPL calls are made.
+"""
+
+import numpy as np
+import pytest
+
+import layup.utilities.special_observatories as so
+
+
+@pytest.fixture
+def fake_horizons(monkeypatch):
+    """Replace the network chunk-query with a deterministic stub that records the
+    epochs it was asked for."""
+    calls = []
+
+    def _fake_chunk(naif_id, jd_chunk, timeout):
+        calls.append(list(jd_chunk))
+        return {jd: (np.array([jd, 2.0, 3.0]), np.array([0.1, 0.2, 0.3])) for jd in jd_chunk}
+
+    monkeypatch.setattr(so, "_query_chunk", _fake_chunk)
+    return calls
+
+
+def test_cache_writes_then_serves_from_disk(tmp_path, fake_horizons):
+    jds = [2459000.5, 2459001.5]
+
+    out1 = so.query_horizons_geocentric("-48", jds, cache_dir=str(tmp_path))
+    assert len(fake_horizons) == 1 and sorted(fake_horizons[0]) == jds
+    assert (tmp_path / "horizons" / "-48").is_dir()
+
+    # Second identical call: served entirely from disk, no new network query.
+    out2 = so.query_horizons_geocentric("-48", jds, cache_dir=str(tmp_path))
+    assert len(fake_horizons) == 1
+    for jd in jds:
+        assert np.allclose(out2[jd][0], out1[jd][0])
+        assert np.allclose(out2[jd][1], out1[jd][1])
+
+
+def test_partial_overlap_fetches_only_misses(tmp_path, fake_horizons):
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=str(tmp_path))
+    assert len(fake_horizons) == 1
+
+    # One cached epoch + one new one -> only the new epoch is queried.
+    out = so.query_horizons_geocentric("-48", [2459000.5, 2459002.5], cache_dir=str(tmp_path))
+    assert len(fake_horizons) == 2 and fake_horizons[1] == [2459002.5]
+    assert set(out) == {2459000.5, 2459002.5}
+
+
+def test_cache_is_per_spacecraft(tmp_path, fake_horizons):
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=str(tmp_path))
+    # Same epoch, different spacecraft -> a real query (not a cross-craft cache hit).
+    so.query_horizons_geocentric("-163", [2459000.5], cache_dir=str(tmp_path))
+    assert len(fake_horizons) == 2
+    assert (tmp_path / "horizons" / "-48").is_dir()
+    assert (tmp_path / "horizons" / "-163").is_dir()
+
+
+def test_cache_disabled_always_queries(tmp_path, fake_horizons):
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=False)
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=False)
+    assert len(fake_horizons) == 2  # no caching -> queried both times
+
+
+def test_env_var_disables_cache(tmp_path, fake_horizons, monkeypatch):
+    monkeypatch.setenv("LAYUP_HORIZONS_CACHE", "0")
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=str(tmp_path))
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=str(tmp_path))
+    assert len(fake_horizons) == 2
+
+
+def test_corrupt_cache_file_is_refetched(tmp_path, fake_horizons):
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=str(tmp_path))
+    # Corrupt the cached file; the next call must treat it as a miss and re-fetch.
+    cache_file = next((tmp_path / "horizons" / "-48").glob("*.npz"))
+    cache_file.write_bytes(b"not an npz")
+    so.query_horizons_geocentric("-48", [2459000.5], cache_dir=str(tmp_path))
+    assert len(fake_horizons) == 2


### PR DESCRIPTION
## Summary

Space-based observatories (WISE, HST, JWST, Spitzer, ...) have no fixed parallax constants, so layup resolves their geocentric observer state from **JPL Horizons per (naif_id, epoch)** — cached only *in-memory per `LayupObservatory` instance* (added in #377). At MPC full-catalog scale, every parallel worker re-queries Horizons cold, and JPL rate-limits to **HTTP 503** (~0.2% of numbered objects crash on it during the USDF run).

This adds a **persistent on-disk cache** so each `(spacecraft, epoch)` is fetched from Horizons **once, ever**, then served from disk across objects, processes, and runs.

## What changed

- `query_horizons_geocentric(naif_id, jds, cache_dir=...)` checks `<cache_dir>/horizons/<naif_id>/<jd:.6f>.npz` per epoch, queries Horizons only for the **misses**, and stores results atomically (`tempfile.mkstemp` + `os.replace`; distinct epochs are distinct files → lock-free and safe on a parallel/shared filesystem). States are geometric (`VEC_CORR='NONE'`), hence deterministic and exact to cache. Cache read/write failures (missing **or partial/corrupt** file) fall through to a refetch and never break a fit.
- `LayupObservatory` now stores its `cache_dir` and threads it into `_fetch_space_observatory_states`, so the observatory path — and the full-catalog run — cache under the same cache directory automatically.
- **Default off** for direct callers with no `cache_dir` and no `LAYUP_HORIZONS_CACHE` env, preserving existing behavior. Opt in via `cache_dir` or the env var; `cache_dir=False` / `LAYUP_HORIZONS_CACHE=0` disables.

## Tests

6 new (network mocked at `_query_chunk`): write-then-serve-from-disk, partial-overlap-fetches-only-misses, per-spacecraft isolation, disabled-via-arg, disabled-via-env, corrupt-file-refetch. The existing space-observatory + data-processing suites still pass (68 total).

## Provenance

Found and validated at MPC full-catalog scale on Rubin/USDF (the 503s were tripping ~0.2% of the numbered run). The USDF session independently built a harness-side monkeypatch cache and reconciled it to this layout (same `.6f` key, same atomic write, same corrupt-read → refetch), so cache already warmed there is reusable as-is; once this merges the monkeypatch is dropped and predict/orbitfit/nightly all benefit.

Extends #377 / issue #55. SPK kernels for the 9 spacecraft (network-free) are a sensible follow-up.