### PR TITLE
Make write_hdf5 idempotent; add append_hdf5 for chunked accumulation

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -52,7 +52,7 @@ from layup.utilities.file_io import (
     HDF5DataReader,
     Obs80DataReader,
 )
-from layup.utilities.file_io.file_output import write_csv, write_hdf5
+from layup.utilities.file_io.file_output import append_hdf5, write_csv, write_hdf5
 
 logger = logging.getLogger(__name__)
 
@@ -1282,6 +1282,22 @@ def orbitfit_cli(
 
     chunks = create_chunks(reader, chunk_size)
 
+    # Output is written one chunk at a time. The first write to each file
+    # overwrites any stale file left by a previous run (so re-runs are
+    # idempotent); later chunks append. Without this a re-run, or a re-merge onto
+    # an existing file, would duplicate every row.
+    _written_files = set()
+
+    def _emit(arr, path):
+        first = path not in _written_files
+        _written_files.add(path)
+        if output_file_format == "hdf5":
+            (write_hdf5 if first else append_hdf5)(arr, path, key="data")
+        else:  # csv: write_csv appends when the file already exists
+            if first and os.path.exists(path):
+                os.remove(path)
+            write_csv(arr, path)
+
     for chunk in chunks:
         data = reader.read_objects(chunk)
         initial_guess = None
@@ -1328,30 +1344,14 @@ def orbitfit_cli(
             fit_orbits_success = fit_orbits[success_mask]
             fit_orbits_failed = fit_orbits[~success_mask]
 
-            if output_file_format == "hdf5":
-                if len(fit_orbits_success) > 0:
-                    write_hdf5(fit_orbits_success, output_file, key="data")
+            if len(fit_orbits_success) > 0:
+                _emit(fit_orbits_success, output_file)
 
-                if len(fit_orbits_failed) > 0:
-                    write_hdf5(
-                        fit_orbits_failed[[_primary_id_column_name, "method", "flag"]],
-                        output_file_flagged,
-                        key="data",
-                    )
-            else:  # csv output format
-                if len(fit_orbits_success) > 0:
-                    write_csv(fit_orbits_success, output_file)
-
-                if len(fit_orbits_failed) > 0:
-                    write_csv(
-                        fit_orbits_failed[[_primary_id_column_name, "method", "flag"]], output_file_flagged
-                    )
+            if len(fit_orbits_failed) > 0:
+                _emit(fit_orbits_failed[[_primary_id_column_name, "method", "flag"]], output_file_flagged)
 
         else:  # All results go to a single output file
-            if output_file_format == "hdf5":
-                write_hdf5(fit_orbits, output_file, key="data")
-            else:
-                write_csv(fit_orbits, output_file)
+            _emit(fit_orbits, output_file)
 
     logger.info(f"Data has been written to {output_file}")
 

--- a/src/layup/utilities/file_io/file_output.py
+++ b/src/layup/utilities/file_io/file_output.py
@@ -42,8 +42,28 @@ def write_csv(data, filepath, move_columns=None):
     logging.info(f"Data written to {filepath}")
 
 
+def _store_hdf5(data, filepath, key, mode):
+    """Write ``data`` to ``filepath`` as an appendable HDF5 table.
+
+    ``mode="w"`` truncates any existing file first (a fresh write); ``mode="a"``
+    appends to it (creating it if absent).
+    """
+    df = pd.DataFrame(data)
+
+    store = pd.HDFStore(filepath, mode=mode)
+    store.append(key, df, format="t", data_columns=True)
+    store.close()
+
+    logging.info(f"Data written to {filepath}")
+
+
 def write_hdf5(data, filepath, key="data"):
-    """Write a numpy structured array to an HDF5 file.
+    """Write a numpy structured array to an HDF5 file, overwriting any existing
+    file so that repeated calls are idempotent.
+
+    To accumulate data across several calls (e.g. writing successive chunks into
+    one file), call this once for the first write and :func:`append_hdf5` for the
+    rest; otherwise a second call to a pre-existing file would duplicate rows.
 
     Parameters
     ----------
@@ -54,10 +74,24 @@ def write_hdf5(data, filepath, key="data"):
     key : str, optional
         The key to use in the HDF5 file.
     """
-    df = pd.DataFrame(data)
+    _store_hdf5(data, filepath, key, mode="w")
 
-    store = pd.HDFStore(filepath)
-    store.append(key, df, format="t", data_columns=True)
-    store.close()
 
-    logging.info(f"Data written to {filepath}")
+def append_hdf5(data, filepath, key="data"):
+    """Append a numpy structured array to an HDF5 table, creating the file if it
+    does not yet exist.
+
+    Use to accumulate chunked output after an initial :func:`write_hdf5`. On its
+    own this grows whatever is already on disk, so it is not idempotent across
+    re-runs -- start each run with :func:`write_hdf5`.
+
+    Parameters
+    ----------
+    data : numpy structured array
+        The data to append to the file.
+    filepath : str
+        The path to the file to write.
+    key : str, optional
+        The key to use in the HDF5 file.
+    """
+    _store_hdf5(data, filepath, key, mode="a")

--- a/tests/layup/test_file_output.py
+++ b/tests/layup/test_file_output.py
@@ -101,10 +101,10 @@ def test_write_hdf5(tmpdir):
     assert_equal(len(obj_data1), 1)
     assert_equal(len(obj_data2), 1)
 
-    # Create a new HDF5 file and write the data in append mode.
+    # Accumulate into a new HDF5 file: an initial write_hdf5 then append_hdf5.
     temp_append_filepath = os.path.join(tmpdir, "test_output_append.h5")
     write_hdf5(obj_data1, temp_append_filepath, key="data")
-    write_hdf5(obj_data2, temp_append_filepath, key="data")
+    append_hdf5(obj_data2, temp_append_filepath, key="data")
 
     # Read the data back in and compare it to the original data.
     hdf5_reader4 = HDF5DataReader(temp_append_filepath)
@@ -112,3 +112,33 @@ def test_write_hdf5(tmpdir):
     assert_equal(len(appended_data), 2)
     assert_equal(appended_data[0], obj_data1[0])
     assert_equal(appended_data[1], obj_data2[0])
+
+
+def test_write_hdf5_is_idempotent(tmpdir):
+    """write_hdf5 overwrites, so re-writing the same file does not duplicate rows
+    (regression: store.append silently doubled rows when a catalog was re-merged
+    onto an existing file)."""
+    data = HDF5DataReader(get_test_filepath("BCOM.h5")).read_rows()
+
+    temp_filepath = os.path.join(tmpdir, "idempotent.h5")
+    write_hdf5(data, temp_filepath)
+    write_hdf5(data, temp_filepath)  # second write must overwrite, not append
+
+    back = HDF5DataReader(temp_filepath).read_rows()
+    assert_equal(len(back), len(data))
+    assert_equal(back, data)
+
+
+def test_append_hdf5_accumulates(tmpdir):
+    """append_hdf5 grows a table; paired with an initial write_hdf5 it is how
+    chunked output accumulates into one file."""
+    data = HDF5DataReader(get_test_filepath("BCOM.h5")).read_rows()
+
+    temp_filepath = os.path.join(tmpdir, "accumulate.h5")
+    write_hdf5(data[0:2], temp_filepath)  # fresh file
+    append_hdf5(data[2:5], temp_filepath)  # +3 rows
+
+    back = HDF5DataReader(temp_filepath).read_rows()
+    assert_equal(len(back), 5)
+    assert_equal(back[0:2], data[0:2])
+    assert_equal(back[2:5], data[2:5])


### PR DESCRIPTION
## Summary

`write_hdf5` used `store.append`, so a second write to an existing file — a re-run of `orbitfit`, or re-merging a catalog onto an existing `.h5` — **silently duplicated every row**. This surfaced re-merging the full MPC catalog, where it doubled `numbered.h5` to ~1.79M rows (every object twice).

The append behavior was load-bearing, though: `orbitfit` writes its output one chunk at a time and relied on `append` to accumulate the chunks into one file. So the fix separates the two intents rather than just switching to overwrite.

## Change (Option C)

- **`write_hdf5` now overwrites** (opens the store with `mode="w"`) → repeated writes are idempotent. This is the right default for the single-write callers: `comet`, `convert`, `unpack`, and the catalog finalize/merge step.
- **New `append_hdf5`** keeps the append behavior for accumulation.
- **`orbitfit`'s chunked writer** overwrites on the first write to each output file and appends the remaining chunks (via a small `_emit` helper). The helper also gives the CSV path the same idempotent-first-write behavior, so a re-run of `orbitfit` no longer doubles its output in either format.

## Tests

- `test_write_hdf5_is_idempotent` — a second `write_hdf5` to the same file does not duplicate rows.
- `test_append_hdf5_accumulates` — `write_hdf5` then `append_hdf5` accumulates chunked output.
- The existing accumulation assertion in `test_write_hdf5` is updated to the `write_hdf5` + `append_hdf5` pattern.

Found during the full MPC-catalog run (USDF); relevant to the incremental-fit cycle, where re-writing an existing catalog is the normal case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)