### PR TITLE
Fix build under scikit-build-core 1.0.0 (name the setuptools_scm version provider)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
+    "setuptools_scm>=8",
     "pybind11",
     "assist",
     "rebound"
@@ -73,6 +74,11 @@ build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
 wheel.packages = ["src/layup", "src/layup_cmdline"]
+# The project version is dynamic (see [project].dynamic) and derived from git via
+# setuptools_scm; scikit-build-core requires the provider to be named explicitly
+# (a hard error since scikit-build-core 0.11 -- it previously tolerated the
+# omission). setuptools_scm must be in [build-system].requires above.
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 write_to = "src/layup/_version.py"


### PR DESCRIPTION
## Summary

**scikit-build-core 1.0.0 (released today) broke layup's build** — every fresh `pip install` / editable install now fails at metadata generation, which takes down CI for **all** PRs (surfaced on the ubuntu-3.14 leg of #414, but it is not specific to that PR or that Python version — it is whichever job installs the new backend).

The error:
```
scikit_build_core ... AssertionError: project.version is not specified,
must be statically present or tool.scikit-build metadata.version.provider
configured when dynamic
```

## Cause

`pyproject.toml` declares `[project].dynamic = ["version"]` and has a `[tool.setuptools_scm]` section, but it never told scikit-build-core to **use** setuptools_scm as the version provider, and `setuptools_scm` was not in `[build-system].requires`. scikit-build-core < 1.0 tolerated this; 1.0.0 makes it a hard error.

## Fix

- Add `metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"` under `[tool.scikit-build]`.
- Add `setuptools_scm>=8` to `[build-system].requires`.

This is the canonical scikit-build-core + setuptools_scm dynamic-version wiring and matches the intent already present in `[tool.setuptools_scm]`.

## Validation

Reproduced locally with **scikit-build-core 1.0.0** by running the exact failing hook (`prepare_metadata_for_build_editable`):

- **old `pyproject.toml`** → `AssertionError: project.version is not specified ...` (the CI error)
- **this branch** → metadata generates cleanly: `layup-0.1.dev...+g<sha>.dist-info` (version resolved via setuptools_scm)

Once this merges, the other open PRs need a rebuild against it (a rebase/merge of `main`) to get green CI again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)