### PR TITLE
Make the non-grav g(r) sublimation law configurable (comet fitting)

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -218,18 +218,35 @@ def _nongrav_warranted(csq_gravity, res_ng, names, thresholds=_AUTO_DEFAULT_THRE
     )
 
 
-def _select_nongrav_auto(assist_ephem, res_grav, observations, thresholds=_AUTO_DEFAULT_THRESHOLDS):
+def _gofr_arg(nongrav_gr):
+    """Normalize a non-grav g(r) argument to the ``[alpha, nm, nn, nk, r0]`` list the
+    C++ fit expects (empty -> the default inverse-square law)."""
+    if nongrav_gr is None:
+        return []
+    gr = list(nongrav_gr)
+    if len(gr) != 5:
+        raise ValueError("nongrav_gr must be [alpha, nm, nn, nk, r0] (5 values) or None")
+    return [float(v) for v in gr]
+
+
+def _select_nongrav_auto(
+    assist_ephem, res_grav, observations, thresholds=_AUTO_DEFAULT_THRESHOLDS, gofr=None
+):
     """Adaptive non-grav selection for ``fit_nongrav="auto"`` (issue #357).
 
     ``res_grav`` is the converged gravity-only fit. Returns the most parsimonious
     acceptable model: the gravity-only result unless a non-grav model is both
     well-conditioned (flag 0) and statistically warranted per ``thresholds``.
+    ``gofr`` selects the g(r) sublimation law (see ``orbitfit``'s ``nongrav_gr``).
     """
     if _gravity_fit_acceptable(res_grav.csq, res_grav.ndof, thresholds):
         return res_grav  # gravity-only fit is acceptable; no non-gravs needed
+    gr = _gofr_arg(gofr)
     for names in _AUTO_NONGRAV_LADDER:
         mask = sum(_NONGRAV_BITS[n] for n in names)
-        res_ng = run_from_vector_with_initial_guess(assist_ephem, res_grav, observations, nongrav_mask=mask)
+        res_ng = run_from_vector_with_initial_guess(
+            assist_ephem, res_grav, observations, nongrav_mask=mask, gofr=gr
+        )
         if res_ng.flag == 0 and _nongrav_warranted(res_grav.csq, res_ng, names, thresholds):
             return res_ng  # parsimonious, well-determined non-grav model
     return res_grav  # no non-grav model is warranted
@@ -1020,6 +1037,7 @@ def _orbitfit(
     engine: str = "cartesian",
     fit_nongrav: bool = False,
     nongrav_auto_thresholds=None,
+    nongrav_gr=None,
     skip_unchanged: bool = False,
 ):
     """This function will contain all of the calls to the c++ code that will
@@ -1256,10 +1274,15 @@ def _orbitfit(
                 res,
                 observations,
                 nongrav_auto_thresholds or _AUTO_DEFAULT_THRESHOLDS,
+                gofr=nongrav_gr,
             )
         elif nongrav_mask and res.flag == 0:
             res_ng = run_from_vector_with_initial_guess(
-                get_ephem(kernels_loc), res, observations, nongrav_mask=nongrav_mask
+                get_ephem(kernels_loc),
+                res,
+                observations,
+                nongrav_mask=nongrav_mask,
+                gofr=_gofr_arg(nongrav_gr),
             )
             if res_ng.flag == 0:
                 res = res_ng
@@ -1321,6 +1344,7 @@ def orbitfit(
     engine="cartesian",
     fit_nongrav=False,
     nongrav_auto_thresholds=None,
+    nongrav_gr=None,
     skip_unchanged=False,
 ):
     """This is the function that you would call interactively. i.e. from a notebook
@@ -1366,6 +1390,12 @@ def orbitfit(
         chi-square drop and per-parameter significance must be to adopt one. Default
         (``None``) uses the standard thresholds; pass a customized
         ``NongravAutoThresholds`` to tune. Ignored unless ``fit_nongrav="auto"``.
+    nongrav_gr : sequence of float, optional
+        The non-gravitational g(r) sublimation law as ``[alpha, nm, nn, nk, r0]`` in
+        ASSIST's parameterization ``g(r) = alpha*(r/r0)^-nm*(1+(r/r0)^nn)^-nk``.
+        Default (``None``) is the asteroidal inverse-square law ``(r/r0)^-2`` used by
+        Yarkovsky A2 fits; pass a cometary law (e.g. Marsden water-ice) to fit a
+        comet's non-gravs. Applies to any non-grav fit (explicit or ``"auto"``).
     skip_unchanged : bool
         Incremental / steady-state mode (issue #419). When True and ``initial_guess``
         is a prior result catalog carrying the ``obs_hash`` fingerprint columns, any
@@ -1426,6 +1456,7 @@ def orbitfit(
         engine=engine,
         fit_nongrav=fit_nongrav,
         nongrav_auto_thresholds=nongrav_auto_thresholds,
+        nongrav_gr=nongrav_gr,
         skip_unchanged=skip_unchanged,
     )
     # Re-attach objects carried forward unchanged by the #419 pre-filter.

--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -447,7 +447,8 @@ namespace orbit_fit
                                     std::vector<partials> &partials_vec,
                                     std::vector<size_t> &in_seq,
                                     std::vector<size_t> &out_seq,
-                                    int nongrav_mask = 0, const double *a123 = nullptr)
+                                    int nongrav_mask = 0, const double *a123 = nullptr,
+                                    const double *gofr = nullptr)
     {
 
         // Pass in this simulation stuff to keep it flexible
@@ -488,7 +489,17 @@ namespace orbit_fit
         if (nactive > 0)
         {
             ax->forces = (enum ASSIST_FORCES)(ax->forces | ASSIST_FORCE_NON_GRAVITATIONAL);
-            ax->alpha = 1.0; ax->nm = 2.0; ax->nk = 0.0; ax->nn = 1.0; ax->r0 = 1.0; // g(r) = (r/r0)^-2
+            // g(r) = alpha*(r/r0)^-nm*(1+(r/r0)^nn)^-nk. Default (gofr==nullptr) is the
+            // asteroidal inverse-square law (r/r0)^-2; a comet fit passes its Marsden
+            // law as [alpha, nm, nn, nk, r0] (e.g. water-ice sublimation).
+            if (gofr)
+            {
+                ax->alpha = gofr[0]; ax->nm = gofr[1]; ax->nn = gofr[2]; ax->nk = gofr[3]; ax->r0 = gofr[4];
+            }
+            else
+            {
+                ax->alpha = 1.0; ax->nm = 2.0; ax->nk = 0.0; ax->nn = 1.0; ax->r0 = 1.0;
+            }
             int nreal = 1;
             int nvar = npar; // 6 state + nactive param particles
             pp.assign(3 * (nreal + nvar), 0.0);
@@ -535,7 +546,8 @@ namespace orbit_fit
                            std::vector<size_t> &forward_out_seq,
                            std::vector<size_t> &reverse_in_seq,
                            std::vector<size_t> &reverse_out_seq,
-                           int nongrav_mask = 0, const double *a123 = nullptr)
+                           int nongrav_mask = 0, const double *a123 = nullptr,
+                           const double *gofr = nullptr)
     {
 
         compute_residuals_sequence(ephem, p0, epoch,
@@ -544,7 +556,7 @@ namespace orbit_fit
                                    partials_vec,
                                    forward_in_seq,
                                    forward_out_seq,
-                                   nongrav_mask, a123);
+                                   nongrav_mask, a123, gofr);
 
         compute_residuals_sequence(ephem, p0, epoch,
                                    detections,
@@ -552,7 +564,7 @@ namespace orbit_fit
                                    partials_vec,
                                    reverse_in_seq,
                                    reverse_out_seq,
-                                   nongrav_mask, a123);
+                                   nongrav_mask, a123, gofr);
     }
 
     // Forward declaration: create_sequences is defined later in this translation
@@ -888,10 +900,11 @@ namespace orbit_fit
                   size_t iter_max,
                   int nongrav_mask = 0,    // bitmask of non-grav params to fit (1=A1,2=A2,4=A3)
                   double *a123io = nullptr, // [A1,A2,A3] seed in / fitted out (3 doubles)
-                  const Eigen::MatrixXd *prior_info = nullptr) // #419 sequential update:
+                  const Eigen::MatrixXd *prior_info = nullptr, // #419 sequential update:
                                                               // prior information matrix
                                                               // Lambda0 = P0^-1 (npar x npar),
                                                               // or null for ordinary LSQ
+                  const double *gofr = nullptr) // [alpha,nm,nn,nk,r0] Marsden g(r); null -> r^-2
     { // runtime
 
         // Number of fitted parameters: 6 (state) + one per active non-grav param.
@@ -979,7 +992,7 @@ namespace orbit_fit
                               forward_out_seq,
                               reverse_in_seq,
                               reverse_out_seq,
-                              nongrav_mask, a123);
+                              nongrav_mask, a123, gofr);
 
             // #419 sequential update: offset of the current iterate from the
             // prior mean, for the prior gradient term Lambda0*(x - x0). Empty and
@@ -1218,12 +1231,18 @@ namespace orbit_fit
                                                   FitResult initial_guess,
                                                   std::vector<Observation> &detections,
                                                   size_t iter_max = 100,
-                                                  int nongrav_mask = 0)
+                                                  int nongrav_mask = 0,
+                                                  std::vector<double> gofr = {})
     {
         int success = 1;
         size_t iters;
         double chi2_final;
         size_t dof;
+
+        // Non-grav g(r) law [alpha,nm,nn,nk,r0]; empty -> the default inverse-square.
+        if (!gofr.empty() && gofr.size() != 5)
+            throw std::invalid_argument("gofr must have 5 elements [alpha, nm, nn, nk, r0]");
+        const double *gofr_ptr = gofr.empty() ? nullptr : gofr.data();
 
         std::vector<residuals> resid_vec(detections.size());
         std::vector<partials> partials_vec(detections.size());
@@ -1259,7 +1278,9 @@ namespace orbit_fit
             eps,
             iter_max,
             nongrav_mask,
-            a123);
+            a123,
+            nullptr, // prior_info (ordinary LSQ)
+            gofr_ptr);
 
         int nactive = 0;
         std::vector<int> active;
@@ -1432,6 +1453,7 @@ namespace orbit_fit
               py::arg("ephem"), py::arg("initial_guess"),
               py::arg("detections"), py::arg("iter_max") = 100,
               py::arg("nongrav_mask") = 0,
+              py::arg("gofr") = std::vector<double>{},
               R"pbdoc(
                 Takes an assist_ephem object, a vector of observations, an
                 initial guess, and (optionally) a cap on LM iterations

--- a/tests/layup/test_nongrav_a2.py
+++ b/tests/layup/test_nongrav_a2.py
@@ -300,6 +300,33 @@ def test_orbitfit_driver_fits_a2():
     assert row["csq"] < 1e-5
 
 
+def test_orbitfit_nongrav_gr_default_and_configurable():
+    """The non-grav g(r) defaults to the asteroidal inverse-square law -- passing it
+    explicitly (``[1, 2, 1, 0, 1]``) is byte-identical -- and a different law
+    (Marsden water-ice) changes the fit, so cometary sublimation laws can be fit.
+    A malformed g(r) raises."""
+    data, guess = _build_arc_array()
+
+    def a2(gr):
+        fit = orbitfit(data, cache_dir=CACHE, initial_guess=guess, fit_nongrav="A2", nongrav_gr=gr)
+        assert fit[0]["flag"] == 0
+        return float(fit[0]["a2"]), float(fit[0]["csq"])
+
+    a2_default, csq_default = a2(None)
+    a2_asteroid, csq_asteroid = a2([1.0, 2.0, 1.0, 0.0, 1.0])
+    a2_water, _ = a2([0.1113, 2.15, 5.093, 4.6142, 2.808])
+
+    # The default is exactly the inverse-square law -- unchanged and byte-identical.
+    assert (a2_default, csq_default) == (a2_asteroid, csq_asteroid)
+    # The arc was generated with r^-2, so it recovers the true A2 there, and a
+    # different g(r) is genuinely used (yielding a different amplitude).
+    assert abs(a2_asteroid - _TRUE_A2) / abs(_TRUE_A2) < 1e-2
+    assert a2_water != a2_asteroid
+    # A malformed g(r) (not 5 values) is rejected.
+    with pytest.raises(ValueError):
+        orbitfit(data, cache_dir=CACHE, initial_guess=guess, fit_nongrav="A2", nongrav_gr=[1.0, 2.0])
+
+
 def test_orbitfit_default_schema_unchanged():
     """Without fit_nongrav the result schema has no a2 columns and the 6-parameter
     fit still succeeds (no regression)."""

--- a/tests/layup/test_nongrav_auto.py
+++ b/tests/layup/test_nongrav_auto.py
@@ -67,7 +67,7 @@ def test_select_auto_keeps_gravity_when_acceptable(monkeypatch):
 def test_select_auto_adopts_most_parsimonious(monkeypatch):
     grav = _res(csq=1000.0, ndof=100)  # reduced chi2 10 -> try non-gravs
 
-    def fake_fit(ephem, res, obs, nongrav_mask=0):
+    def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
         # A2-only already resolves it well and A2 is significant.
         return _res(csq=10.0, flag=0, nongrav_mask=nongrav_mask, a2=1e-13, a2_unc=1e-15)
 
@@ -80,7 +80,7 @@ def test_select_auto_adopts_most_parsimonious(monkeypatch):
 def test_select_auto_escalates_when_a2_alone_insufficient(monkeypatch):
     grav = _res(csq=1000.0, ndof=100)
 
-    def fake_fit(ephem, res, obs, nongrav_mask=0):
+    def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
         # A2 alone is insignificant; A1+A2 both land significant with a big drop.
         if nongrav_mask == O._NONGRAV_BITS["A2"]:
             return _res(csq=995.0, flag=0, nongrav_mask=nongrav_mask, a2=1e-15, a2_unc=1e-15)
@@ -132,7 +132,7 @@ def test_select_auto_threshold_suppresses_nongrav(monkeypatch):
     # A case that adopts A2 under the default thresholds...
     grav = _res(csq=1000.0, ndof=100)  # reduced chi2 10 -> non-grav tried by default
 
-    def fake_fit(ephem, res, obs, nongrav_mask=0):
+    def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
         return _res(csq=10.0, flag=0, nongrav_mask=nongrav_mask, a2=1e-13, a2_unc=1e-15)
 
     monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)


### PR DESCRIPTION
## Summary

The non-gravitational fit **hardcoded the asteroidal inverse-square law** `g(r) = (r/r0)^-2` (`orbit_fit.cpp`), so only Yarkovsky-style A2 could be fit. **Comets** — whose acceleration follows a Marsden water-ice (or other volatile) sublimation law — could not. ASSIST already evaluates the full Marsden form `g(r) = alpha·(r/r0)^-nm·(1+(r/r0)^nn)^-nk` (`forces.c`); this PR just exposes its parameters.

## Change

Thread an optional `gofr = [alpha, nm, nn, nk, r0]` **alongside the existing `a123`** through the fit chain — `compute_residuals_sequence` → `compute_residuals` → `orbit_fit` → `run_from_vector_with_initial_guess` (new pybind arg `gofr`, default empty) — and up to Python `orbitfit(nongrav_gr=...)` and the `fit_nongrav="auto"` selection path.

A `null`/empty `gofr` uses the inverse-square law, so **every existing non-grav fit is unchanged**.

## Backward compatibility

The default (and an explicit `[1, 2, 1, 0, 1]`) reproduce the previous fit **byte-for-byte**:

```
default    a2 = -2.757526e-06   csq = 9.2796
asteroid   a2 = -2.757526e-06   csq = 9.2796   (identical)
water-ice  a2 = -2.900889e-04   csq = 9.2620   (g(r) is used: A and g(r) trade off)
```

## Tests

`test_orbitfit_nongrav_gr_default_and_configurable`: the default equals an explicit inverse-square law byte-for-byte and still recovers the true A2; a Marsden water-ice `g(r)` changes the fitted amplitude; a malformed `g(r)` raises. The existing non-grav suites pass (the `fit_nongrav="auto"` test fakes were updated to accept the new `gofr` kwarg).

## Motivation

Enables cometary non-grav fitting — the foundation for comet linkage (joint-fitting two apparitions with a shared g(r) sublimation law), and generally useful for any comet orbit fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)