### PR TITLE
Support supplied per-observation astrometric uncertainties

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -1015,7 +1015,7 @@ def _orbitfit(
     initial_guess=None,
     bias_dict: dict = None,
     sort_array: bool = True,
-    weight_data: bool = False,
+    weight_data=False,  # bool (Veres 2017) or "supplied" (rmsRA/rmsDec columns)
     iod: str = "gauss",
     engine: str = "cartesian",
     fit_nongrav: bool = False,
@@ -1042,9 +1042,14 @@ def _orbitfit(
         A dictionary containing bias corrections for different catalogs.
     sort_array : bool
         Whether to sort the observations by obstime before processing. Default is True.
-    weight_data : bool
-        Whether to apply data weighting based on the observation code, date, catalog
-        and program. Default is False.
+    weight_data : bool or str
+        Astrometric weighting. ``False`` (default) leaves the built-in default
+        uncertainty. ``True`` applies the Veres 2017 model (observation code, date,
+        catalog, program). ``"supplied"`` uses the per-observation ``rmsRA`` /
+        ``rmsDec`` columns (arcseconds) directly -- e.g. ADES-reported
+        uncertainties, or an external weighting model such as era-based historical
+        weighting for old comet apparitions (a row with a NaN/nonpositive value
+        falls back to the default).
     iod : str
         The IOD used to generate an initial guess orbit. Supports 'gauss'
         (default) and 'auto' (Gauss with BK-IOD fallback).
@@ -1098,6 +1103,7 @@ def _orbitfit(
         program_column_present = "program" in column_names
         position_rates_columns_present = all(col in column_names for col in ["raRate", "decRate"])
         rate_unc_columns_present = all(col in column_names for col in ["rmsRArate", "rmsDecrate"])
+        astrom_unc_columns_present = all(col in column_names for col in ["rmsRA", "rmsDec"])
         radar_columns_present = any(col in column_names for col in ["delay", "doppler"])
 
         # Fingerprint the raw observation set (issue #419), before any in-place
@@ -1191,7 +1197,21 @@ def _orbitfit(
                     [d["vx"], d["vy"], d["vz"]],  # Barycentric velocity
                 )
 
-            if weight_data:
+            # Astrometric weighting. ``weight_data="supplied"`` uses the per-obs
+            # rmsRA/rmsDec columns (arcsec) directly -- e.g. ADES-reported
+            # uncertainties, or an external weighting model such as era-based
+            # historical weighting for old comet apparitions. ``weight_data=True``
+            # uses the Veres 2017 model; ``False`` leaves the C++ default. Supplied
+            # takes precedence; a NaN/nonpositive supplied value on a row falls
+            # back to the C++ default for that row.
+            if isinstance(weight_data, str) and weight_data.lower() == "supplied":
+                if not astrom_unc_columns_present:
+                    raise ValueError('weight_data="supplied" requires rmsRA and rmsDec columns (arcsec).')
+                if np.isfinite(d["rmsRA"]) and d["rmsRA"] > 0:
+                    o.ra_unc = abs(d["rmsRA"]) * np.pi / (180.0 * 3600.0)
+                if np.isfinite(d["rmsDec"]) and d["rmsDec"] > 0:
+                    o.dec_unc = abs(d["rmsDec"]) * np.pi / (180.0 * 3600.0)
+            elif weight_data:
                 # astrometric_uncertainty_Veres2017 returns the astrometric uncertainty in
                 # ARCSECONDS (per its docstring), but Observation.ra_unc /
                 # dec_unc are stored in RADIANS.  Convert at the assignment.
@@ -1339,9 +1359,14 @@ def orbitfit(
         The name of the primary identifier column for the objects. Default is "provID".
     debias : bool
         Whether to apply debiasing corrections to the observations. Default is False.
-    weight_data : bool
-        Whether to apply data weighting based on the observation code, date, catalog
-        and program. Default is False.
+    weight_data : bool or str
+        Astrometric weighting. ``False`` (default) leaves the built-in default
+        uncertainty. ``True`` applies the Veres 2017 model (observation code, date,
+        catalog, program). ``"supplied"`` uses the per-observation ``rmsRA`` /
+        ``rmsDec`` columns (arcseconds) directly -- e.g. ADES-reported
+        uncertainties, or an external weighting model such as era-based historical
+        weighting for old comet apparitions (a row with a NaN/nonpositive value
+        falls back to the default).
     iod : str
         The IOD used to generate an initial guess orbit. Supports 'gauss'
         (default) and 'auto' (Gauss with BK-IOD fallback).

--- a/tests/layup/test_weight_data.py
+++ b/tests/layup/test_weight_data.py
@@ -64,6 +64,58 @@ def test_orbitfit_weight_data_true_runs_without_crashing():
     assert "flag" in row.dtype.names
 
 
+def _fit_supplied(prov_id, sigma_arcsec):
+    """Fit with weight_data='supplied' and an explicit per-obs sigma (arcsec)."""
+    import numpy.lib.recfunctions as rfn
+
+    reader = CSVDataReader(
+        get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv"),
+        "csv",
+        primary_id_column_name="provID",
+    )
+    data = reader.read_rows()
+    data = data[data["provID"] == prov_id]
+    cols = data.dtype.names
+    sig = np.full(len(data), float(sigma_arcsec))
+    if "rmsRA" in cols:
+        data = data.copy()
+        data["rmsRA"] = sig
+        data["rmsDec"] = sig
+    else:
+        data = rfn.append_fields(data, ["rmsRA", "rmsDec"], [sig, sig.copy()], usemask=False)
+    return orbitfit(data, cache_dir=CACHE, weight_data="supplied")[0]
+
+
+def test_orbitfit_weight_data_supplied_uses_the_columns():
+    """weight_data='supplied' reads the per-obs rmsRA/rmsDec columns: a looser
+    supplied sigma yields a proportionally looser position covariance (the weights
+    are actually applied), and the fit still converges."""
+    tight = _fit_supplied("119839", 0.2)
+    loose = _fit_supplied("119839", 2.0)
+    assert tight["flag"] == 0 and loose["flag"] == 0
+    s_tight = float(np.sqrt(sum(parse_cov(tight)[i, i] for i in range(3))))
+    s_loose = float(np.sqrt(sum(parse_cov(loose)[i, i] for i in range(3))))
+    # 10x looser astrometry -> ~10x looser position sigma (linear least squares).
+    assert 5.0 < s_loose / s_tight < 20.0, f"ratio {s_loose / s_tight:.1f} (weights not applied?)"
+
+
+def test_orbitfit_weight_data_supplied_requires_columns():
+    """weight_data='supplied' without rmsRA/rmsDec columns raises a clear error."""
+    reader = CSVDataReader(
+        get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv"),
+        "csv",
+        primary_id_column_name="provID",
+    )
+    data = reader.read_rows()
+    data = data[data["provID"] == "119839"]
+    if "rmsRA" in data.dtype.names:
+        import numpy.lib.recfunctions as rfn
+
+        data = rfn.drop_fields(data, ["rmsRA", "rmsDec"])
+    with pytest.raises(ValueError, match="rmsRA"):
+        orbitfit(data, cache_dir=CACHE, weight_data="supplied")
+
+
 def test_orbitfit_weight_data_true_gives_sensible_uncertainty():
     """orbitfit(weight_data=True) must apply weights in the right units.
     Previously the returned arcsecond value was assigned directly to


### PR DESCRIPTION
## What

Adds a third astrometric-weighting mode to `orbitfit`: `weight_data="supplied"` reads the per-observation `rmsRA`/`rmsDec` columns (in arcseconds) and uses them directly as the observation uncertainties, instead of the built-in ~1-arcsecond default (`weight_data=False`) or the Veres et al. (2017) model (`weight_data=True`).

## Why

layup currently weights every observation at ~1 arcsecond by default, and the Veres 2017 model returns ~1 arcsecond for anything pre-CCD. That badly over-weights historical astrometry — 19th- and early-20th-century visual and photographic positions are really only good to several arcseconds, up to an arcminute. In the fit's reject/refit loop that then throws the orbit out entirely, so a century-old comet discovery arc simply will not fit. Letting the caller supply per-observation uncertainties — from ADES, or from an external model such as era-based historical weighting — fixes that without hard-coding any weighting policy into layup.

## Behaviour / compatibility

- `weight_data=False` (default) and `weight_data=True` (Veres 2017) are unchanged — byte-identical.
- `"supplied"` requires the `rmsRA`/`rmsDec` columns (raises a clear error otherwise); a NaN or non-positive value on a given row falls back to the default weighting for that row.

## Tests

Adds tests that a looser supplied sigma yields a proportionally looser position covariance (confirming the weights are actually applied) and that the missing-columns case raises. The existing `weight_data` regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)