### PR TITLE
Fit piecewise per-apparition non-gravitational amplitudes (per_arc)

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -252,14 +252,24 @@ def _select_nongrav_auto(
     return res_grav  # no non-grav model is warranted
 
 
-def _get_result_dtypes(primary_id_column_name: str, nongrav_names=()):
+def _get_result_dtypes(primary_id_column_name: str, nongrav_names=(), per_arc=False):
     """Helper function to create the result dtype with the correct primary ID column name.
 
     For each fitted non-gravitational parameter in ``nongrav_names`` (a subset of
     ``A1``/``A2``/``A3``), two columns are appended -- e.g. ``a2`` and ``a2_unc``
     (the value and its 1-sigma uncertainty, au/day^2). With no non-grav params the
     default 6-parameter output schema is unchanged.
+
+    When ``per_arc`` is set (the two-apparition comet-linkage fit), the non-grav
+    columns above hold the *earlier* arc's amplitudes and a second block
+    ``a2_arc2``/``a2_arc2_unc`` is appended for the *later* arc. Both are opt-in,
+    so the ordinary fit schema is unaffected.
     """
+    per_arc_cols = []
+    if per_arc:
+        per_arc_cols = [
+            (col, "f8") for n in nongrav_names for col in (n.lower() + "_arc2", n.lower() + "_arc2_unc")
+        ]
     # Define a structured dtype to match the OrbfitResult fields
     return np.dtype(
         [
@@ -282,6 +292,7 @@ def _get_result_dtypes(primary_id_column_name: str, nongrav_names=()):
         + [  # non-grav params (issue #351), value + 1-sigma per fitted param
             (col, "f8") for n in nongrav_names for col in (n.lower(), n.lower() + "_unc")
         ]
+        + per_arc_cols  # later-arc non-grav amplitudes (comet linkage), when per_arc
         # Observation provenance / incremental fingerprint (issue #419): a
         # deterministic hash of the observation set this orbit was fit from, plus
         # the number of fittable observations. Kept last so the positional output
@@ -1038,6 +1049,7 @@ def _orbitfit(
     fit_nongrav: bool = False,
     nongrav_auto_thresholds=None,
     nongrav_gr=None,
+    per_arc: bool = False,
     skip_unchanged: bool = False,
 ):
     """This function will contain all of the calls to the c++ code that will
@@ -1082,7 +1094,14 @@ def _orbitfit(
         logger.warning("Non-gravitational fitting requires engine='cartesian'; overriding %r.", engine)
         engine = "cartesian"
 
-    _RESULT_DTYPES = _get_result_dtypes(primary_id_column_name, nongrav_names)
+    # Per-arc (piecewise-constant) non-grav amplitudes need an explicit non-grav
+    # mask (which params to split per apparition); it is meaningless for a
+    # gravity-only or 'auto'-selected fit. Ignore with a warning otherwise.
+    if per_arc and not nongrav_mask:
+        logger.warning("per_arc=True requires an explicit fit_nongrav mask (e.g. 'A1A2A3'); ignoring.")
+        per_arc = False
+
+    _RESULT_DTYPES = _get_result_dtypes(primary_id_column_name, nongrav_names, per_arc=per_arc)
     if len(data) == 0:
         return np.array([], dtype=_RESULT_DTYPES)
 
@@ -1283,6 +1302,7 @@ def _orbitfit(
                 observations,
                 nongrav_mask=nongrav_mask,
                 gofr=_gofr_arg(nongrav_gr),
+                per_arc=per_arc,
             )
             if res_ng.flag == 0:
                 res = res_ng
@@ -1307,6 +1327,27 @@ def _orbitfit(
                     (getattr(res, n.lower() + "_unc") if (fitted_mask & _NONGRAV_BITS[n]) else np.nan),
                 )
             )
+        # Later-arc amplitudes (comet linkage): the C++ result reports them in the
+        # _arc2 fields only when per_arc fitting was on and converged.
+        per_arc_cols = ()
+        if per_arc:
+            per_arc_on = success and getattr(res, "per_arc", False)
+            per_arc_cols = tuple(
+                v
+                for n in nongrav_names
+                for v in (
+                    (
+                        getattr(res, n.lower() + "_arc2")
+                        if (per_arc_on and fitted_mask & _NONGRAV_BITS[n])
+                        else np.nan
+                    ),
+                    (
+                        getattr(res, n.lower() + "_arc2_unc")
+                        if (per_arc_on and fitted_mask & _NONGRAV_BITS[n])
+                        else np.nan
+                    ),
+                )
+            )
         output = np.array(
             [
                 (
@@ -1324,6 +1365,7 @@ def _orbitfit(
                 )
                 + cov_matrix  # Flat covariance matrix
                 + nongrav_cols  # non-grav params + uncertainties (issue #351), when fit_nongrav
+                + per_arc_cols  # later-arc amplitudes (comet linkage), when per_arc
                 + (obs_hash, nobs_fit)  # obs fingerprint (issue #419)
             ],
             dtype=_RESULT_DTYPES,
@@ -1345,6 +1387,7 @@ def orbitfit(
     fit_nongrav=False,
     nongrav_auto_thresholds=None,
     nongrav_gr=None,
+    per_arc=False,
     skip_unchanged=False,
 ):
     """This is the function that you would call interactively. i.e. from a notebook
@@ -1396,6 +1439,14 @@ def orbitfit(
         Default (``None``) is the asteroidal inverse-square law ``(r/r0)^-2`` used by
         Yarkovsky A2 fits; pass a cometary law (e.g. Marsden water-ice) to fit a
         comet's non-gravs. Applies to any non-grav fit (explicit or ``"auto"``).
+    per_arc : bool, optional
+        Fit piecewise-constant *per-apparition* non-grav amplitudes (comet
+        linkage). The state and ``g(r)`` are shared, but observations before the
+        fit epoch (the earlier arc) and after it (the later arc) each get their own
+        ``[A1,A2,A3]``. Requires an explicit ``fit_nongrav`` mask and an
+        ``initial_guess`` whose epoch sits between the two apparitions. The output
+        adds ``a{1,2,3}_arc2`` columns for the later arc; the base ``a{1,2,3}``
+        columns then hold the earlier arc. Default False.
     skip_unchanged : bool
         Incremental / steady-state mode (issue #419). When True and ``initial_guess``
         is a prior result catalog carrying the ``obs_hash`` fingerprint columns, any
@@ -1457,6 +1508,7 @@ def orbitfit(
         fit_nongrav=fit_nongrav,
         nongrav_auto_thresholds=nongrav_auto_thresholds,
         nongrav_gr=nongrav_gr,
+        per_arc=per_arc,
         skip_unchanged=skip_unchanged,
     )
     # Re-attach objects carried forward unchanged by the #419 pre-filter.

--- a/src/lib/orbit_fit/fit_result.cpp
+++ b/src/lib/orbit_fit/fit_result.cpp
@@ -31,6 +31,15 @@ namespace orbit_fit
         int nongrav_mask = 0;
         double a1 = 0.0, a2 = 0.0, a3 = 0.0;
         double a1_unc = 0.0, a2_unc = 0.0, a3_unc = 0.0;
+        // Per-arc (piecewise-constant) non-grav amplitudes for the two-apparition
+        // comet-linkage fit. With per_arc on, a1/a2/a3 above are the EARLIER arc
+        // (arc A) and a{1,2,3}_arc2 the LATER arc (arc B); the state and g(r) are
+        // shared. per_arc=false leaves the _arc2 fields zero (unchanged 6/7-param
+        // behavior). Comparing arc A vs arc B amplitudes labels the outcome:
+        // equal -> stable, changed -> recovered, orbit+g(r)-shared/A-differs -> split.
+        bool per_arc = false;
+        double a1_arc2 = 0.0, a2_arc2 = 0.0, a3_arc2 = 0.0;
+        double a1_arc2_unc = 0.0, a2_arc2_unc = 0.0, a3_arc2_unc = 0.0;
     } FitResult;
 
     static void orbit_fit_result_bindings(py::module &m)
@@ -53,7 +62,15 @@ namespace orbit_fit
             .def_readwrite("a3", &orbit_fit::FitResult::a3, "Non-grav A3 normal term (au/day^2)")
             .def_readwrite("a1_unc", &orbit_fit::FitResult::a1_unc, "1-sigma uncertainty on A1 (au/day^2)")
             .def_readwrite("a2_unc", &orbit_fit::FitResult::a2_unc, "1-sigma uncertainty on A2 (au/day^2)")
-            .def_readwrite("a3_unc", &orbit_fit::FitResult::a3_unc, "1-sigma uncertainty on A3 (au/day^2)");
+            .def_readwrite("a3_unc", &orbit_fit::FitResult::a3_unc, "1-sigma uncertainty on A3 (au/day^2)")
+            .def_readwrite("per_arc", &orbit_fit::FitResult::per_arc,
+                           "Whether per-arc (piecewise-constant) non-grav amplitudes were fit")
+            .def_readwrite("a1_arc2", &orbit_fit::FitResult::a1_arc2, "Later-arc (arc B) A1 (au/day^2)")
+            .def_readwrite("a2_arc2", &orbit_fit::FitResult::a2_arc2, "Later-arc (arc B) A2 (au/day^2)")
+            .def_readwrite("a3_arc2", &orbit_fit::FitResult::a3_arc2, "Later-arc (arc B) A3 (au/day^2)")
+            .def_readwrite("a1_arc2_unc", &orbit_fit::FitResult::a1_arc2_unc, "1-sigma uncertainty on arc-B A1")
+            .def_readwrite("a2_arc2_unc", &orbit_fit::FitResult::a2_arc2_unc, "1-sigma uncertainty on arc-B A2")
+            .def_readwrite("a3_arc2_unc", &orbit_fit::FitResult::a3_arc2_unc, "1-sigma uncertainty on arc-B A3");
     }
 
 } // namespace orbit_fit

--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -436,10 +436,35 @@ namespace orbit_fit
         }
     }
 
+    // Remap one detection's partial vector into a wider per-arc layout. The
+    // residual functions build partials as [state(6), amp(nactive)]; the per-arc
+    // (piecewise-constant non-grav) fit needs this pass's `nactive` amplitude
+    // columns placed at `amp_col_offset` within a full-width `npar_total` row, so
+    // the earlier arc's amplitudes and the later arc's occupy disjoint columns
+    // (the other arc's columns stay zero for this detection). No-op when the
+    // source already spans npar_total (the ordinary shared-amplitude fit).
+    static void remap_amp_partials(std::vector<double> &v, int nactive,
+                                   int amp_col_offset, int npar_total)
+    {
+        if (v.empty() || (int)v.size() == npar_total)
+            return;
+        std::vector<double> out(npar_total, 0.0);
+        for (int i = 0; i < 6; i++)
+            out[i] = v[i];
+        for (int k = 0; k < nactive; k++)
+            out[amp_col_offset + k] = v[6 + k];
+        v.swap(out);
+    }
+
     // This routine requires that resid_vec and partials_vec are
     // preallocated because the indices in out_seq will be used for
     // random access of locations in those vectors.
     // Also, in_seq and out_seq must be of the same length.
+    //
+    // Per-arc (piecewise-constant non-grav) fit: when npar_total > 0 the partials
+    // are widened to npar_total columns and this pass's amplitude partials placed
+    // at amp_col_offset (see remap_amp_partials). Defaults (npar_total = -1)
+    // preserve the ordinary layout exactly.
     void compute_residuals_sequence(struct assist_ephem *ephem,
                                     struct reb_particle p0, double epoch,
                                     std::vector<Observation> &detections,
@@ -448,7 +473,8 @@ namespace orbit_fit
                                     std::vector<size_t> &in_seq,
                                     std::vector<size_t> &out_seq,
                                     int nongrav_mask = 0, const double *a123 = nullptr,
-                                    const double *gofr = nullptr)
+                                    const double *gofr = nullptr,
+                                    int amp_col_offset = 6, int npar_total = -1)
     {
 
         // Pass in this simulation stuff to keep it flexible
@@ -527,6 +553,17 @@ namespace orbit_fit
                                      resids,
                                      parts,
                                      npar);
+            // Per-arc fit: widen this pass's partials into the shared layout so
+            // the earlier/later arc amplitudes land in disjoint columns.
+            if (npar_total > 0)
+            {
+                remap_amp_partials(parts.x_partials, nactive, amp_col_offset, npar_total);
+                remap_amp_partials(parts.y_partials, nactive, amp_col_offset, npar_total);
+                remap_amp_partials(parts.ra_rate_partials, nactive, amp_col_offset, npar_total);
+                remap_amp_partials(parts.dec_rate_partials, nactive, amp_col_offset, npar_total);
+                remap_amp_partials(parts.delay_partials, nactive, amp_col_offset, npar_total);
+                remap_amp_partials(parts.doppler_partials, nactive, amp_col_offset, npar_total);
+            }
             resid_vec[k] = resids;
             partials_vec[k] = parts;
         }
@@ -547,24 +584,43 @@ namespace orbit_fit
                            std::vector<size_t> &reverse_in_seq,
                            std::vector<size_t> &reverse_out_seq,
                            int nongrav_mask = 0, const double *a123 = nullptr,
-                           const double *gofr = nullptr)
+                           const double *gofr = nullptr,
+                           const double *a123_fwd = nullptr)
     {
+        // Per-arc (piecewise-constant non-grav) switch: the presence of a123_fwd
+        // means the forward march (later apparition, arc B) carries its own
+        // amplitude triple in columns [6+nactive .. 6+2*nactive), while the
+        // reverse march (earlier apparition, arc A) uses a123 in columns
+        // [6 .. 6+nactive). The fit epoch must sit between the two apparitions so
+        // forward=arc B and reverse=arc A. With a123_fwd null this is the ordinary
+        // shared-amplitude fit (npar_total = -1 -> no remap, byte-identical).
+        bool per_arc = (a123_fwd != nullptr);
+        int nactive = 0;
+        for (int i = 0; i < 3; i++)
+            if (nongrav_mask & (1 << i))
+                nactive++;
+        int npar_total = per_arc ? 6 + 2 * nactive : -1;
+        int off_fwd = per_arc ? 6 + nactive : 6;
 
+        // Forward march = later arc (arc B).
         compute_residuals_sequence(ephem, p0, epoch,
                                    detections,
                                    resid_vec,
                                    partials_vec,
                                    forward_in_seq,
                                    forward_out_seq,
-                                   nongrav_mask, a123, gofr);
+                                   nongrav_mask, per_arc ? a123_fwd : a123, gofr,
+                                   off_fwd, npar_total);
 
+        // Reverse march = earlier arc (arc A).
         compute_residuals_sequence(ephem, p0, epoch,
                                    detections,
                                    resid_vec,
                                    partials_vec,
                                    reverse_in_seq,
                                    reverse_out_seq,
-                                   nongrav_mask, a123, gofr);
+                                   nongrav_mask, a123, gofr,
+                                   6, npar_total);
     }
 
     // Forward declaration: create_sequences is defined later in this translation
@@ -904,7 +960,9 @@ namespace orbit_fit
                                                               // prior information matrix
                                                               // Lambda0 = P0^-1 (npar x npar),
                                                               // or null for ordinary LSQ
-                  const double *gofr = nullptr) // [alpha,nm,nn,nk,r0] Marsden g(r); null -> r^-2
+                  const double *gofr = nullptr, // [alpha,nm,nn,nk,r0] Marsden g(r); null -> r^-2
+                  bool per_arc = false,     // piecewise-constant per-arc non-grav amplitudes
+                  double *a123_fwd_io = nullptr) // arc-B [A1,A2,A3] seed in / fitted out (per_arc)
     { // runtime
 
         // Number of fitted parameters: 6 (state) + one per active non-grav param.
@@ -918,14 +976,29 @@ namespace orbit_fit
             if (nongrav_mask & (1 << i))
                 active.push_back(i);
         int nactive = (int)active.size();
-        int npar = 6 + nactive;
+        // Per-arc (piecewise-constant non-grav) fit doubles the amplitude block:
+        // 6 shared state + nactive arc-A amplitudes (cols 6..) + nactive arc-B
+        // amplitudes (cols 6+nactive..). a123 holds arc A (earlier), a123b arc B
+        // (later). Off, a123b is unused and the layout is the ordinary 6+nactive.
+        int npar = per_arc ? 6 + 2 * nactive : 6 + nactive;
         double a123[3] = {0.0, 0.0, 0.0};
+        double a123b[3] = {0.0, 0.0, 0.0};
         if (a123io)
             for (int i = 0; i < 3; i++)
                 a123[i] = a123io[i];
+        if (per_arc)
+        {
+            // Seed arc B from its own input if given, else from arc A.
+            for (int i = 0; i < 3; i++)
+                a123b[i] = (a123_fwd_io != nullptr) ? a123_fwd_io[i] : a123[i];
+        }
         for (int k = 0; k < nactive; k++)
+        {
             if (a123[active[k]] == 0.0)
                 a123[active[k]] = 1e-15;
+            if (per_arc && a123b[active[k]] == 0.0)
+                a123b[active[k]] = 1e-15;
+        }
 
         // #419 sequential update: snapshot the prior mean x0 (= the seed state)
         // so each iteration can form the offset (x - x0) that the prior gradient
@@ -992,7 +1065,8 @@ namespace orbit_fit
                               forward_out_seq,
                               reverse_in_seq,
                               reverse_out_seq,
-                              nongrav_mask, a123, gofr);
+                              nongrav_mask, a123, gofr,
+                              per_arc ? a123b : nullptr);
 
             // #419 sequential update: offset of the current iterate from the
             // prior mean, for the prior gradient term Lambda0*(x - x0). Empty and
@@ -1062,6 +1136,11 @@ namespace orbit_fit
                 p0.vz += dX(5);
                 for (int k = 0; k < nactive; k++)
                     a123[active[k]] += dX(6 + k);
+                // Arc-B amplitudes occupy the second amplitude block (cols
+                // 6+nactive..) in the per-arc fit.
+                if (per_arc)
+                    for (int k = 0; k < nactive; k++)
+                        a123b[active[k]] += dX(6 + nactive + k);
                 chi2_prev = obj;
             }
             else
@@ -1135,6 +1214,9 @@ namespace orbit_fit
         if (nactive > 0 && a123io)
             for (int i = 0; i < 3; i++)
                 a123io[i] = a123[i];
+        if (per_arc && nactive > 0 && a123_fwd_io)
+            for (int i = 0; i < 3; i++)
+                a123_fwd_io[i] = a123b[i];
 
         return flag;
     }
@@ -1232,7 +1314,8 @@ namespace orbit_fit
                                                   std::vector<Observation> &detections,
                                                   size_t iter_max = 100,
                                                   int nongrav_mask = 0,
-                                                  std::vector<double> gofr = {})
+                                                  std::vector<double> gofr = {},
+                                                  bool per_arc = false)
     {
         int success = 1;
         size_t iters;
@@ -1264,6 +1347,11 @@ namespace orbit_fit
 
         // Seed [A1,A2,A3] from the initial guess for the params being fit (#351).
         double a123[3] = {initial_guess.a1, initial_guess.a2, initial_guess.a3};
+        // Per-arc (piecewise-constant) fit: arc-B amplitudes seeded from the
+        // guess's _arc2 fields (or from arc A when those are zero, handled inside
+        // orbit_fit). The fit epoch is expected to sit between the two apparitions.
+        double a123b[3] = {initial_guess.a1_arc2, initial_guess.a2_arc2,
+                           initial_guess.a3_arc2};
 
         flag = orbit_fit(
             ephem,
@@ -1280,7 +1368,9 @@ namespace orbit_fit
             nongrav_mask,
             a123,
             nullptr, // prior_info (ordinary LSQ)
-            gofr_ptr);
+            gofr_ptr,
+            per_arc,
+            per_arc ? a123b : nullptr);
 
         int nactive = 0;
         std::vector<int> active;
@@ -1290,7 +1380,7 @@ namespace orbit_fit
                 active.push_back(i);
                 nactive++;
             }
-        int npar = 6 + nactive;
+        int npar = per_arc ? 6 + 2 * nactive : 6 + nactive;
         dof = total_residual_rows(detections) - npar;
 
         FitResult result;
@@ -1327,6 +1417,7 @@ namespace orbit_fit
         // from the corresponding diagonal entries of the joint covariance. Active
         // params are column 6+k for the k-th active param; inactive stay at zero.
         result.nongrav_mask = nongrav_mask;
+        result.per_arc = per_arc;
         result.a1 = a123[0];
         result.a2 = a123[1];
         result.a3 = a123[2];
@@ -1334,6 +1425,22 @@ namespace orbit_fit
         for (int k = 0; k < nactive; k++)
             *unc[active[k]] =
                 (flag == 0 && cov.rows() >= npar) ? std::sqrt(cov(6 + k, 6 + k)) : NAN;
+
+        // Per-arc fit: arc B (later apparition) amplitudes live in the second
+        // amplitude block (cov columns 6+nactive..). a1/a2/a3 above are arc A.
+        if (per_arc)
+        {
+            result.a1_arc2 = a123b[0];
+            result.a2_arc2 = a123b[1];
+            result.a3_arc2 = a123b[2];
+            double *uncb[3] = {&result.a1_arc2_unc, &result.a2_arc2_unc,
+                               &result.a3_arc2_unc};
+            for (int k = 0; k < nactive; k++)
+                *uncb[active[k]] =
+                    (flag == 0 && cov.rows() >= npar)
+                        ? std::sqrt(cov(6 + nactive + k, 6 + nactive + k))
+                        : NAN;
+        }
 
 	return result;
 
@@ -1454,12 +1561,19 @@ namespace orbit_fit
               py::arg("detections"), py::arg("iter_max") = 100,
               py::arg("nongrav_mask") = 0,
               py::arg("gofr") = std::vector<double>{},
+              py::arg("per_arc") = false,
               R"pbdoc(
                 Takes an assist_ephem object, a vector of observations, an
                 initial guess, and (optionally) a cap on LM iterations
                 (`iter_max`, default 100), and runs orbit fit. Reducing
                 iter_max gives a cheap screening pass for use in
                 multi-candidate IOD picker loops.
+
+                per_arc=True fits piecewise-constant per-apparition non-grav
+                amplitudes (comet linkage): the state and g(r) are shared, but the
+                earlier arc (observations before the fit epoch) and later arc (after)
+                each get their own [A1,A2,A3]. Place the fit epoch between the two
+                apparitions. Results: a1/a2/a3 = earlier arc, a{1,2,3}_arc2 = later.
             )pbdoc");
         m.def("run_sequential_update",
               &orbit_fit::run_sequential_update,

--- a/tests/layup/test_nongrav_per_arc.py
+++ b/tests/layup/test_nongrav_per_arc.py
@@ -1,0 +1,168 @@
+"""Per-arc (piecewise-constant) non-gravitational amplitudes -- comet linkage.
+
+The two-apparition comet-linkage fit shares one state and one g(r) but lets the
+non-grav amplitude differ between the earlier arc (observations before the fit
+epoch) and the later arc (after it). The truth here is generated to match that
+model exactly: from one shared state at the epoch, the arc *before* the epoch is
+integrated with one A2 and the arc *after* with another (the non-grav force is
+negligible far from perihelion, so a real comet's piecewise-per-apparition
+amplitude is well approximated this way).
+
+The tests check that the per-arc fit (a) recovers a single shared amplitude when
+both sides carry the same one, (b) recovers two *distinct* amplitudes when the
+sides differ (the same/recovered/split discriminator), and (c) leaves the
+ordinary shared-amplitude fit byte-identical when off.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import numpy as np
+import pooch
+import pytest
+
+from layup.orbitfit import orbitfit
+from layup.routines import FitResult, Observation, get_ephem, run_from_vector_with_initial_guess
+
+CACHE = str(pooch.os_cache("layup"))
+_EPHEM = ("linux_p1550p2650.440", "sb441-n16.bsp")
+_EPHEM_OK = all(os.path.exists(os.path.join(CACHE, f)) for f in _EPHEM)
+pytestmark = pytest.mark.skipif(
+    not _EPHEM_OK, reason="ASSIST ephemeris not in layup cache; run `layup bootstrap`"
+)
+
+# Apophis-like barycentric ICRF state (JPL Horizons, DE441), AU/day.
+_EPOCH = 2456323.5
+_STATE = np.array(
+    [
+        -6.885941010606326e-01,
+        7.853011708041518e-01,
+        2.744012411423299e-01,
+        -1.236352140633316e-02,
+        -7.926849409608376e-03,
+        -3.263604704470501e-03,
+    ]
+)
+_TRUE_A2 = -5.0e-14  # au/day^2, transverse (astrometrically the best constrained)
+_BIT = {"A1": 1, "A2": 2, "A3": 4}
+_GR = dict(alpha=1.0, nm=2.0, nk=0.0, nn=1.0, r0=1.0)
+_C = 2.99792458e8 * 86400.0 / 1.495978707e11  # au/day
+
+
+def _build_piecewise_arc(a2_before, a2_after, half_days=3 * 365.25, n=48):
+    """A noise-free ra/dec arc symmetric about ``_EPOCH``: obs before the epoch
+    follow A2=``a2_before``, obs after follow A2=``a2_after``, from one shared
+    state at the epoch. Returns a list of Observations for the low-level fitter.
+    """
+    import assist
+    import rebound
+
+    ephem = assist.Ephem(os.path.join(CACHE, _EPHEM[0]), os.path.join(CACHE, _EPHEM[1]))
+    jr = ephem.jd_ref
+
+    def ast_at(t_jd, a2):
+        sim = rebound.Simulation()
+        sim.t = _EPOCH - jr
+        sim.add(x=_STATE[0], y=_STATE[1], z=_STATE[2], vx=_STATE[3], vy=_STATE[4], vz=_STATE[5])
+        ax = assist.Extras(sim, ephem)
+        ax.forces = ["SUN", "PLANETS", "ASTEROIDS", "NON_GRAVITATIONAL", "GR_SIMPLE"]
+        for k, v in _GR.items():
+            setattr(ax, k, v)
+        ax.particle_params = np.array([0.0, a2, 0.0], dtype=float)
+        sim.integrate(t_jd - jr)
+        p = sim.particles[0]
+        return np.array([p.x, p.y, p.z])
+
+    obs = []
+    for dt in np.linspace(-half_days, half_days, n):
+        if abs(dt) < 1.0:
+            continue  # keep a small gap around the epoch (mimics between apparitions)
+        a2 = a2_before if dt < 0 else a2_after
+        t_jd = _EPOCH + dt
+        e = ephem.get_particle("Earth", t_jd - jr)
+        r_obs = np.array([e.x, e.y, e.z])
+        v_obs = np.array([e.vx, e.vy, e.vz])
+        lt = 0.0
+        for _ in range(3):
+            rho = ast_at(t_jd - lt, a2) - r_obs
+            lt = np.linalg.norm(rho) / _C
+        rho /= np.linalg.norm(rho)
+        o = Observation.from_astrometry_with_id(
+            "comet_like", np.arctan2(rho[1], rho[0]), np.arcsin(rho[2]), t_jd, list(r_obs), list(v_obs)
+        )
+        o.ra_unc = o.dec_unc = 0.1 / 206265.0
+        obs.append(o)
+    return obs
+
+
+def _seed(state=_STATE):
+    g = FitResult()
+    g.state = list(state)
+    g.epoch = _EPOCH  # the fit epoch sits between the two arcs
+    g.flag = 0
+    return g
+
+
+def _per_arc_fit(obs, mask=_BIT["A2"]):
+    return run_from_vector_with_initial_guess(get_ephem(CACHE), _seed(), obs, 100, mask, [], True)
+
+
+def test_per_arc_recovers_equal_amplitudes():
+    """Both sides carry the same A2 -> the per-arc fit recovers one shared value on
+    each arc (the 'stable comet' baseline)."""
+    obs = _build_piecewise_arc(_TRUE_A2, _TRUE_A2)
+    fit = _per_arc_fit(obs)
+    assert fit.flag == 0
+    assert fit.per_arc is True
+    # npar = 6 state + 2*1 amplitude (arc A + arc B).
+    assert fit.ndof == 2 * len(obs) - 8
+    assert abs(fit.a2 - _TRUE_A2) / abs(_TRUE_A2) < 0.05, f"arc A A2 {fit.a2:.4e}"
+    assert abs(fit.a2_arc2 - _TRUE_A2) / abs(_TRUE_A2) < 0.05, f"arc B A2 {fit.a2_arc2:.4e}"
+    # The two arcs agree to within their combined uncertainty (stable).
+    assert abs(fit.a2 - fit.a2_arc2) < 3.0 * (fit.a2_unc + fit.a2_arc2_unc)
+
+
+def test_per_arc_recovers_distinct_amplitudes():
+    """The sides carry different A2 -> the per-arc fit recovers two distinct values
+    (the same/recovered/split discriminator). A shared-amplitude fit cannot.
+
+    Splitting one amplitude into two per-arc amplitudes is ill-conditioned, so the
+    formal 1-sigma is large; the change is only *detected* (not just recovered)
+    when it is big compared to that -- i.e. a strongly-changed comet. The values
+    themselves are recovered accurately even so."""
+    a2_a, a2_b = 1.0e-12, 5.0e-12  # a large, split-scale activity change
+    obs = _build_piecewise_arc(a2_a, a2_b)
+    fit = _per_arc_fit(obs)
+    assert fit.flag == 0
+    assert abs(fit.a2 - a2_a) / abs(a2_a) < 0.05, f"arc A A2 {fit.a2:.4e} vs {a2_a:.4e}"
+    assert abs(fit.a2_arc2 - a2_b) / abs(a2_b) < 0.05, f"arc B A2 {fit.a2_arc2:.4e} vs {a2_b:.4e}"
+    # The difference is significant at >3 sigma (the classifier's own z-score),
+    # so it is flagged as a real change rather than noise.
+    z = abs(fit.a2 - fit.a2_arc2) / math.hypot(fit.a2_unc, fit.a2_arc2_unc)
+    assert z > 3.0, f"amplitude change only {z:.1f} sigma"
+
+
+def test_per_arc_off_is_shared_amplitude_fit():
+    """per_arc=False is the ordinary shared-amplitude fit: on an equal-amplitude
+    arc it recovers the same single A2, reports no arc-B fields, and has one fewer
+    parameter than the per-arc fit."""
+    obs = _build_piecewise_arc(_TRUE_A2, _TRUE_A2)
+    shared = run_from_vector_with_initial_guess(get_ephem(CACHE), _seed(), obs, 100, _BIT["A2"])
+    assert shared.flag == 0
+    assert shared.per_arc is False
+    assert shared.ndof == 2 * len(obs) - 7  # one shared amplitude, not two
+    assert abs(shared.a2 - _TRUE_A2) / abs(_TRUE_A2) < 0.05
+    assert shared.a2_arc2 == 0.0  # arc-B fields untouched when off
+
+
+def test_orbitfit_driver_per_arc_columns():
+    """Through the orbitfit() driver, per_arc=True adds a{1,2,3}_arc2 columns and
+    per_arc=False (the default) does not -- an opt-in, non-breaking schema change."""
+    from layup.orbitfit import _get_result_dtypes
+
+    off = _get_result_dtypes("provID", ["A2"], per_arc=False)
+    on = _get_result_dtypes("provID", ["A2"], per_arc=True)
+    assert "a2" in off.names and "a2_arc2" not in off.names
+    assert "a2_arc2" in on.names and "a2_arc2_unc" in on.names


### PR DESCRIPTION
## What

Adds an optional `per_arc` mode to the Cartesian non-gravitational fit. It shares one orbit (state) and one `g(r)` sublimation law across the fit, but lets the non-gravitational amplitudes A1/A2/A3 differ between the observations before the fit epoch and those after it.

## Why

A comet's non-gravitational acceleration is A·g(r). The `g(r)` shape is a property of the subliming ice, so it is shared over time; the amplitude A reflects the active surface, which can change from one apparition to the next (or differ between fragments of a split comet). Fitting two apparitions as one orbit while allowing the amplitude to differ lets you ask not just "is this the same comet?" but *how* it is the same — stable, re-activated, or split. Because the non-gravitational force is negligible far from the Sun, a piecewise-constant amplitude (one value near each apparition's perihelion) is a good approximation.

## How

Reuses the fit's existing forward/reverse integration from the fit epoch as the two arcs (so the fit epoch must sit between the two apparitions). Each pass carries its own amplitude triple and variational particles, remapped into disjoint columns of a `6 + 2*nactive` parameter block. `orbitfit(..., per_arc=True)` threads it through and adds opt-in `a{1,2,3}_arc2` result columns (the later arc); the base `a{1,2,3}` columns then hold the earlier arc.

## Behaviour / compatibility

- `per_arc=False` (the default) is byte-identical to the ordinary shared-amplitude fit.
- Tests: a piecewise-constant synthetic truth is recovered (equal amplitudes recover equal; distinct amplitudes recover distinct and clear 3 sigma); `per_arc=False` still fits a single shared amplitude; the driver adds the `a{1,2,3}_arc2` columns only when requested. Existing non-grav suites pass.

## Dependency

Stacked on #430 (the `g(r)`-configurable non-grav fit): the base of this PR is `feat/nongrav-gofr`, so it should be retargeted to `main` and merged after #430 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)