### PR TITLE
Added 80 column fix from Sorcha code

### DIFF
--- a/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
+++ b/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
@@ -27,8 +27,8 @@ from layup.utilities.layup_configs import AuxiliaryConfigs
 
 
 def _split_kernel_path_str(abspath: str, split=77):
-    """If abspath string is longer than 79 chars, split it up in the meta kernel by inserting "+' '".
-    79 is the default because the character limit in SPICE is 80 before the string needs split.
+    """If abspath string is longer than 77 chars, split it up in the meta kernel by inserting "+',\n'".
+    77 is the default because the character limit in SPICE is 80 before the string needs split.
 
     Parameters
     ----------

--- a/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
+++ b/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
@@ -26,6 +26,28 @@ from layup.utilities.layup_configs import AuxiliaryConfigs
 """
 
 
+def _split_kernel_path_str(abspath: str, split=77):
+    """If abspath string is longer than 79 chars, split it up in the meta kernel by inserting "+' '".
+    79 is the default because the character limit in SPICE is 80 before the string needs split.
+
+    Parameters
+    ----------
+    abspath: str
+        The filepath string that needs split.
+    Split : int
+        The maximum size each part of the filepath can be before it needs split.
+    Returns
+    ---------
+    abspath : str
+    The filepath string split into chunks of required size.
+    """
+
+    n_iter = int(len(str(abspath)) / split)  # Number of splits required
+    for n in range(n_iter, 0, -1):  # Goes backwards to not change the character count of the string before it
+        abspath = abspath[: split * n] + "+',\n'" + abspath[split * n :]
+    return abspath
+
+
 def build_meta_kernel_file(auxconfigs: AuxiliaryConfigs, retriever: pooch.Pooch, downloader=None) -> None:
     """Builds a specific text file that will be fed into `spiceypy` that defines
     the list of spice kernel to load, as well as the order to load them.
@@ -47,11 +69,12 @@ def build_meta_kernel_file(auxconfigs: AuxiliaryConfigs, retriever: pooch.Pooch,
     """
     # build meta_kernel file path
     meta_kernel_file_path = os.path.join(retriever.abspath, auxconfigs.meta_kernel)
+    abspath = _split_kernel_path_str(str(retriever.abspath))
 
     # build a meta_kernel.txt file
     with open(meta_kernel_file_path, "w") as meta_file:
         meta_file.write("\\begindata\n\n")
-        meta_file.write(f"PATH_VALUES = ('{retriever.abspath}')\n\n")
+        meta_file.write(f"PATH_VALUES = ('{abspath}')\n\n")
         meta_file.write("PATH_SYMBOLS = ('A')\n\n")
         meta_file.write("KERNELS_TO_LOAD=(\n")
         for file_name in auxconfigs.ordered_kernel_files:

--- a/src/layup/utilities/file_io/Obs80Reader.py
+++ b/src/layup/utilities/file_io/Obs80Reader.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from layup.utilities.file_io.ObjectDataReader import ObjectDataReader
 
-
 # Column 15 (0-indexed 14) is the MPC "note 2" / observation-type code. The
 # codes S (satellite), R (radar) and V (roving observer) each emit a SECOND
 # line carrying the observer position/data; that continuation line repeats the

--- a/tests/layup/test_create_meta_kernal.py
+++ b/tests/layup/test_create_meta_kernal.py
@@ -1,4 +1,6 @@
 # This file tests if the function _split_kernel_path_str() returns the right string
+import os
+import spiceypy
 from layup.utilities.bootstrap_utilties.create_meta_kernel import _split_kernel_path_str
 
 
@@ -22,3 +24,30 @@ def test_kernel_str_length():
     for test_data in test_strings:
         output = _split_kernel_path_str(test_data[0], split=test_data[2])
         assert output == test_data[1]
+
+
+def test_meta_kernel_loads_under_long_path(tmp_path):
+    # A cache path long enough to trip the SPICE 80-char string limit.
+    deep = tmp_path
+    while len(str(deep)) < 160:
+        deep = deep / "12345678"
+    deep.mkdir(parents=True, exist_ok=True)
+
+    # A tiny kernel we can check actually loaded.
+    (deep / "tiny.tls").write_text("\\begindata\nDELTET/DELTA_T_A = 99.5\n\\begintext\n")
+
+    mk = deep / "meta_kernel.txt"
+    mk.write_text(
+        "\\begindata\n\n"
+        f"PATH_VALUES = ('{_split_kernel_path_str(str(deep))}')\n\n"
+        "PATH_SYMBOLS = ('A')\n\n"
+        "KERNELS_TO_LOAD = ( '$A/tiny.tls' )\n\n"
+        "\\begintext\n"
+    )
+
+    spiceypy.kclear()
+    try:
+        spiceypy.furnsh(str(mk))  # would raise TYPEMISMATCH before the fix
+        assert spiceypy.gdpool("DELTET/DELTA_T_A", 0, 1)[0] == 99.5
+    finally:
+        spiceypy.kclear()

--- a/tests/layup/test_create_meta_kernal.py
+++ b/tests/layup/test_create_meta_kernal.py
@@ -1,0 +1,24 @@
+# This file tests if the function _split_kernel_path_str() returns the right string
+from layup.utilities.bootstrap_utilties.create_meta_kernel import _split_kernel_path_str
+
+
+def test_kernel_str_length():
+
+    # Each list in the tuple is a test containing the input, expected output and split value for the function, respectively
+    test_strings = (
+        ["this is a test string", "this is a test +',\n'string", 15],
+        [
+            "this is another test string which is slightly larger",
+            "this is another+',\n' test string wh+',\n'ich is slightly+',\n' larger",
+            15,
+        ],
+        ["small string", "small string", 79],
+        [
+            "split will be the length of this string to see what happens",
+            "split will be the length of this string to see what happens+',\n'",
+            59,
+        ],
+    )
+    for test_data in test_strings:
+        output = _split_kernel_path_str(test_data[0], split=test_data[2])
+        assert output == test_data[1]


### PR DESCRIPTION
Added _split_kernel_path_str and its unit test from Sorcha to avoid 80 column bug

Fixes #433  .

Describe your changes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
