### PR TITLE
Minor changes to installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Orbit fitting at LSST scale
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
 
 ## Setup
+To install layup, all its dependencies, as well as the ephemeris and reference data, you need about 3.2G of free space.
+Before installing layup, it's a great idea to create a virtual environment with either `conda` or `venv`.
+
 You can download the source code with:
 ```
 git clone --recursive https://github.com/Smithsonian/layup.git
@@ -23,7 +26,7 @@ git submodule update --init
 ```
 to download the required submodules, `assist`, `eigen`, and `rebound`.
 
-Next, run
+Next, enter the layup directory and run
 ```
 pip install -e .
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,12 @@ create and activate a new environment.
    >> conda create env -n <env_name> python=3.11
    >> conda activate <env_name>
 
+Alternatively, you can create a virtual environment with python's `venv` module.
+
+.. code-block:: console
+
+   >> python -m venv venv
+   >> source venv/bin/activate
 
 Once you have created a new environment, you can install this project for local
 development using the following commands:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ create and activate a new environment.
 
 .. code-block:: console
 
-   >> conda create env -n <env_name> python=3.11
+   >> conda create -n <env_name> python=3.11
    >> conda activate <env_name>
 
 Alternatively, you can create a virtual environment with python's `venv` module.


### PR DESCRIPTION
I've done a fresh installation of layup and all dependencies on linux. Everything works well. I've made some small edits to the installation instructions.

One thing I noticed: On my cluster, the home directory is on a different partition than the "big" data partition. I think this is a fairly common setup. Currently, if I create a virtual environment with layup on the data partition, then it still writes almost half the data to my home partition, i.e. ~1.6G of files to `~/.cache/layup`. In my opinion it would be nice to keep all of layup's files within the directory it is installed in. But I understand that the `~/.cache` approach is kind of a standard thing to do... So I don't know. Not a big issue, I guess.