### PR TITLE
fixed CLI duplicate bug

### DIFF
--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -784,6 +784,7 @@ def convert_cli(
 
     sample_data = sample_reader.read_rows(block_start=0, block_size=1)
 
+    logger.info(f"Reading the first line of {input_file} as header:\n{sample_data.dtype.names}\n")
     # Check orbit format in the file
     input_format = get_format(sample_data)
 

--- a/src/layup/utilities/file_io/CSVReader.py
+++ b/src/layup/utilities/file_io/CSVReader.py
@@ -133,7 +133,6 @@ class CSVDataReader(ObjectDataReader):
                     # Skip comment lines
                     self.num_pre_header_lines += 1
                 else:
-                    logger.info(f"Reading the first line of {self.filename} as header:\n{line}")
                     self._check_header_line(line)
                     # Note - header row INDEX is 0-indexed.
                     self.header_row_index = self.num_pre_header_lines

--- a/src/layup/utilities/layup_logging.py
+++ b/src/layup/utilities/layup_logging.py
@@ -94,7 +94,7 @@ class LayupLogger:
         """
 
         logger = logging.getLogger("layup")
-
+        logger.propagate = False
         # This logger handles all messages >= DEBUG
         logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
Fixes #434  .

CSVReader had a log output that none of the other logs had. This caused duplicate CLI prints when the sample reader and full reader were called. I've moved this log to convert.py so it only occurs once.

logger. propagate was set to False to avoid other duplicate logs, such as in the output file log.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x]  Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
