### PR TITLE
Don't link the compiled extension against assist/rebound on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,19 @@ find_package(pybind11 CONFIG REQUIRED)
 # this)
 python_add_library(_core MODULE src/main.cpp WITH_SOABI)
 # link all the required libraries
-target_link_libraries(_core PRIVATE pybind11::headers ${LIBASSIST_SO} ${LIBREBOUND_SO})
+if(APPLE)
+  # assist and rebound ship their C libraries as Python extension modules, and
+  # whether those come out as dynamic libraries (MH_DYLIB, linkable) or bundles
+  # (MH_BUNDLE, loadable only) depends on the toolchain that built them. Xcode 26
+  # / AppleClang 21 produces bundles, and `ld` refuses to link against those
+  # ("unsupported mach-o filetype"), which breaks the macOS build entirely --
+  # issue #457. Do not link them here; layup.routines loads the bundled copies
+  # with RTLD_GLOBAL before importing _core, so the symbols are resolved through
+  # the flat namespace that -undefined dynamic_lookup searches.
+  target_link_libraries(_core PRIVATE pybind11::headers)
+else()
+  target_link_libraries(_core PRIVATE pybind11::headers ${LIBASSIST_SO} ${LIBREBOUND_SO})
+endif()
 
 # This is passing in the version as a define just as an example
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})

--- a/src/layup/routines/__init__.py
+++ b/src/layup/routines/__init__.py
@@ -1,7 +1,40 @@
 from __future__ import annotations
 
-# The compiled extension is linked with an RPATH (``$ORIGIN/..`` on Linux,
-# ``@loader_path/..`` on macOS, set in CMakeLists.txt) so the dynamic loader
-# finds librebound/libassist in site-packages regardless of the working
-# directory. The previous os.chdir() dance is therefore no longer needed (#75).
+import sys
+
+# On Linux the compiled extension is linked against librebound/libassist with an
+# RPATH (``$ORIGIN/..``, set in CMakeLists.txt), so the dynamic loader pulls them
+# in and the previous os.chdir() dance is not needed (#75).
+#
+# On macOS we cannot link against them at all. assist and rebound ship their C
+# libraries as Python extension modules, and whether those come out as dynamic
+# libraries (linkable) or bundles (loadable only) depends on the toolchain that
+# built them; Xcode 26 / AppleClang 21 produces bundles, which ``ld`` refuses to
+# link against ("unsupported mach-o filetype") -- issue #457. The extension is
+# therefore built unlinked on macOS, with ``-undefined dynamic_lookup``, and its
+# rebound/assist symbols are resolved from the flat namespace at load time.
+#
+# Importing ``assist`` and ``rebound`` is NOT enough to populate that namespace:
+# both load their libraries through ctypes, whose default mode is ``RTLD_LOCAL``,
+# so the symbols stay private to those handles. We reopen the very same files
+# with ``RTLD_GLOBAL``, which promotes the already-loaded images rather than
+# mapping second copies -- important, because a second copy would give the C++
+# side its own library-global state, separate from the one the Python-level
+# ``assist``/``rebound`` calls use. Order matters: libassist depends on librebound.
+if sys.platform == "darwin":
+    import ctypes
+
+    import assist
+    import rebound
+
+    for _lib in (rebound, assist):
+        _libpath = getattr(_lib, "__libpath__", "")
+        if not _libpath:
+            raise ImportError(
+                f"{_lib.__name__} does not expose __libpath__, so layup cannot promote its "
+                "library to the global symbol namespace. layup's compiled extension resolves "
+                f"its symbols there on macOS; check the installed {_lib.__name__} version."
+            )
+        ctypes.CDLL(_libpath, mode=ctypes.RTLD_GLOBAL)
+
 from _layup_cpp._core import *


### PR DESCRIPTION
Draft, opened to get the macOS CI legs to answer a question this machine cannot: **does the build succeed under AppleClang 21?**

### The problem

`CMakeLists.txt` linked `_core` directly against assist's and rebound's compiled Python extension modules. On macOS such a module is either a dynamic library (`MH_DYLIB`, linkable) or a bundle (`MH_BUNDLE`, loadable only). Xcode 26 / AppleClang 21 produces bundles, so `ld` refuses:

```
ld: unsupported mach-o filetype (only MH_OBJECT and MH_DYLIB can be linked) in
'.../site-packages/libassist.cpython-313-darwin.so'
```

Nothing in layup changed — the runner image did. Neither package promises a link type, so this was always resting on an implementation detail.

### The change

On macOS, build the extension unlinked and let the rebound/assist symbols resolve from the flat namespace at load time; the link line already carries `-undefined dynamic_lookup`. Linux keeps linking with its RPATH, unchanged.

That alone is not enough, which is the part worth reviewing. Importing `assist` and `rebound` does **not** put their symbols in the flat namespace — both load their libraries through ctypes, whose default mode is `RTLD_LOCAL`, so `import layup.routines` dies with:

```
ImportError: dlopen(..._core.cpython-312-darwin.so, 0x0002):
symbol not found in flat namespace '_assist_attach'
```

So `layup/routines/__init__.py` reopens the libraries with `RTLD_GLOBAL` before importing the extension.

It deliberately reopens the paths the packages expose as `__libpath__`, not the copies layup installs beside the extension. I checked that this promotes the already-loaded image rather than mapping a second one — `assist_init` resolves to the same address through assist's own handle and through the `RTLD_GLOBAL` handle. A second copy would have given the C++ side its own library-global state, separate from the one Python-level `assist`/`rebound` calls use.

### Testing, and its limit

macOS 15.2 / AppleClang 16: full suite 460 passed, 1 skipped, both before and after. Verified that the unlinked extension fails to import without the promotion and succeeds with it.

**This machine cannot reproduce the failure** — AppleClang 16 links the old code fine. So the local runs show the new loading path works; they cannot show that the build is fixed. That is what the macOS legs here are for.

### Note for reviewers

If the macOS legs still fail, the fallback is to ask upstream to ship a real dynamic library alongside the extension module, which would let us go back to linking on every platform.

Fixes #457.
