### PR TITLE
CI: bump the auxiliary-data cache key to v2

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -38,7 +38,7 @@ jobs:
         path: |
           ~/.cache/layup
           ~/Library/Caches/layup
-        key: layup-data-${{ runner.os }}-v1
+        key: layup-data-${{ runner.os }}-v2
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -23,14 +23,7 @@ jobs:
     # is the recurring flaky-download hang (issue #388), which escapes
     # pytest-timeout when it happens in a spawned worker. Capping keeps reruns
     # cheap instead of burning ~2 hours per hang.
-    #
-    # Raised 20 -> 40 alongside the cache-key bump below. A cold cache re-fetches
-    # the whole auxiliary set, which includes linux_p1550p2650.440 at ~600 MB, so
-    # the first run on a new key is far slower than the ~12 min a cold run
-    # normally costs. 20 minutes would have failed that run for the wrong reason.
-    # This is a ceiling, not a budget: a healthy warm leg still finishes in ~6 min,
-    # so a leg that reaches 40 is wedged, not merely slow.
-    timeout-minutes: 40
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v7
     - name: Set up - ${{ matrix.os }} - Python ${{ matrix.python-version }}

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -23,7 +23,14 @@ jobs:
     # is the recurring flaky-download hang (issue #388), which escapes
     # pytest-timeout when it happens in a spawned worker. Capping keeps reruns
     # cheap instead of burning ~2 hours per hang.
-    timeout-minutes: 20
+    #
+    # Raised 20 -> 40 alongside the cache-key bump below. A cold cache re-fetches
+    # the whole auxiliary set, which includes linux_p1550p2650.440 at ~600 MB, so
+    # the first run on a new key is far slower than the ~12 min a cold run
+    # normally costs. 20 minutes would have failed that run for the wrong reason.
+    # This is a ceiling, not a budget: a healthy warm leg still finishes in ~6 min,
+    # so a leg that reaches 40 is wedged, not merely slow.
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@v7
     - name: Set up - ${{ matrix.os }} - Python ${{ matrix.python-version }}
@@ -44,7 +51,7 @@ jobs:
         path: |
           ~/.cache/layup
           ~/Library/Caches/layup
-        key: layup-data-${{ runner.os }}-v1
+        key: layup-data-${{ runner.os }}-v2
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Bumps the auxiliary-data cache key from `v1` to `v2` in both workflows that share it.

The key is deliberately manual, and #456 replaced two of the cached files, so without a bump the stale cache is restored and the old kernels linger beside the new ones.

That staleness is not cosmetic — it is why CI never noticed the old NAIF URLs had gone 404. Runs kept restoring kernels that no longer exist upstream, so the suite stayed green while a new user's `layup bootstrap` would have failed. The evidence: `main` at an unchanged commit was green 5–8 August and red every day from the 9th, and only the tests that download into a *fresh* directory ever failed.

Expect one slow run. The first run after this merges will be the cold one; after that the `v2` cache is warm and legs return to normal.

### What changed since this PR was opened

**The `timeout-minutes` 20 → 40 raise has been removed**, and `main` has been merged in so the diff is just the two key lines.

The raise was based on a wrong diagnosis. I read the Ubuntu legs as slow and assumed a cold cache would push them past the cap. They are not slow — they wedge. Serial on Linux the suite is green in 10m14s; under `-n auto` the legs sit silent for ~10 minutes until the cap kills them.

A higher ceiling does not help a wedge, it just doubles what each hung run costs, which is the opposite of why the cap exists (#388). The real cause is nested parallelism — layup sizes its own process pool at `os.cpu_count()` inside each xdist worker, so N workers × N spawned interpreters oversubscribe a ~4-core runner. That is being fixed at the source instead, and the cap stays at 20.
