### PR TITLE
DIAGNOSTIC (do not merge): name the test that wedges the Ubuntu legs

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -14,8 +14,10 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: ['macos-latest','ubuntu-latest']
-        python-version: ['3.13', '3.14']
+        # DIAGNOSTIC BRANCH -- Linux only, one Python. macOS is green on main;
+        # this branch exists solely to name the test that wedges the Ubuntu legs.
+        os: ['ubuntu-latest']
+        python-version: ['3.13']
 
     runs-on: ${{ matrix.os }}
     # Fail a wedged leg fast instead of running to the 6-hour default. The unit
@@ -23,7 +25,9 @@ jobs:
     # is the recurring flaky-download hang (issue #388), which escapes
     # pytest-timeout when it happens in a spawned worker. Capping keeps reruns
     # cheap instead of burning ~2 hours per hang.
-    timeout-minutes: 20
+    # DIAGNOSTIC: serial runs are several times slower than -n auto, so the
+    # normal 20 would fire before we reach the hang.
+    timeout-minutes: 45
     steps:
     - uses: actions/checkout@v7
     - name: Set up - ${{ matrix.os }} - Python ${{ matrix.python-version }}
@@ -55,10 +59,24 @@ jobs:
         layup bootstrap
     - name: Run unit tests with pytest
       run: |
-        # -rs prints a summary of skipped tests and their reasons, so silently
-        # skipped suites (e.g. ephem-gated fit/validation tests) are visible in
-        # the CI log (issue #359).
-        python -m pytest -n auto -rs --cov=layup --cov-report=xml
+        # DIAGNOSTIC RUN -- do not merge. Three deliberate departures from the
+        # normal invocation, each needed to name the test that wedges Ubuntu:
+        #
+        #   -n0                     serial. Under `-n auto` the progress output is
+        #                           in completion order across workers, so a stalled
+        #                           worker cannot be tied to a test.
+        #   -v                      one line per test, so the log names what is
+        #                           running when the wedge happens.
+        #   --timeout-method=thread the configured "signal" method cannot interrupt
+        #                           a blocking C call, which is why the 300 s
+        #                           timeout never fires today. The thread method
+        #                           dumps every thread's stack and kills the
+        #                           process. It is rejected in pyproject because it
+        #                           crashes xdist workers -- with -n0 there are
+        #                           none, so it is safe here.
+        #   --timeout=180           the observed stall exceeds 9 minutes, so 3 is
+        #                           ample and keeps the run short.
+        python -m pytest -n0 -v -rs --timeout=180 --timeout-method=thread
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v7
       with:


### PR DESCRIPTION
🔴 **Diagnostic only — do not merge.** Opened to make CI name a test it currently cannot. I will close it once we have the answer.

### What we are chasing

Since #456 and #459 landed, **both macOS legs on `main` pass** in ~13 minutes. Both **Ubuntu** legs stall dead — 9 minutes 41 seconds with no log output whatsoever — until the 20-minute cap kills them. Same behaviour on three legs across two days, so it is not a one-off.

### Why the normal run cannot tell us which test

- CI runs `pytest -n auto`, so progress output is in *completion* order across workers. A stalled worker cannot be tied back to a test. The two Ubuntu legs failing at different progress positions is scheduling noise, not two different tests. (I misread this earlier and named the wrong tests — disregard any names from before.)
- `pytest-timeout` is configured at 300 s and never fires. It uses `timeout_method = "signal"`, chosen deliberately because the thread method crashes xdist workers — and `SIGALRM` cannot interrupt a blocking C call. The stall runs 581 s, so whatever is stuck is not returning to the interpreter.

### What this branch changes

Linux only, one Python, and:

| flag | why |
|---|---|
| `-n0` | serial, so progress order is collection order |
| `-v` | one line per test, so the log names what was running when it wedged |
| `--timeout-method=thread` | *can* interrupt a blocking C call; dumps every thread's stack and kills the process. Rejected in `pyproject.toml` because it crashes xdist workers — with `-n0` there are none |
| `--timeout=180` | the stall exceeds 9 minutes, so 3 is ample and keeps the run short |

`timeout-minutes` goes to 45 because a serial run is several times slower than `-n auto`.

### Also still unexplained

There is a genuine test failure on the Ubuntu legs, separate from the hang, and it is unnamed for the same reason. This run should surface both.

Related: #457 (the macOS build fix that unblocked all this), #460 (cache key). Note #460's `timeout-minutes` 20 → 40 now looks like the wrong instinct — this is a wedge, not slowness, so a higher cap only doubles the cost of a hung run.
