### PR TITLE
Don't size a worker pool as though we own the whole machine

### DIFF
--- a/src/layup/comet.py
+++ b/src/layup/comet.py
@@ -13,6 +13,7 @@ from layup.utilities.file_io.file_output import write_csv, write_hdf5
 from layup.utilities.data_processing_utilities import (
     get_format,
     process_data,
+    resolve_num_workers,
 )
 
 # These are the maximum and minimum dates that the ASSIST ephemeris file allows for
@@ -349,8 +350,7 @@ def comet_cli(
 
     primary_id_column_name = cli_args.primary_id_column_name if cli_args else "ObjID"
 
-    if num_workers < 0:
-        num_workers = os.cpu_count()
+    num_workers = resolve_num_workers(num_workers)
 
     # Open the input file and read the first line
     reader_class = INPUT_READERS.get(file_format)

--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -15,6 +15,7 @@ from layup.utilities.data_processing_utilities import (
     get_format,
     has_cov_columns,
     process_data,
+    resolve_num_workers,
 )
 from layup.utilities.file_io import CSVDataReader, HDF5DataReader
 from layup.utilities.file_io.file_output import write_csv, write_hdf5
@@ -767,8 +768,7 @@ def convert_cli(
 
     primary_id_column_name = cli_args.primary_id_column_name if cli_args else "ObjID"
 
-    if num_workers < 0:
-        num_workers = os.cpu_count()
+    num_workers = resolve_num_workers(num_workers)
 
     # Open the input file and read the first line
     reader_class = INPUT_READERS.get(file_format)

--- a/src/layup/log.py
+++ b/src/layup/log.py
@@ -4,7 +4,11 @@ It has a corresponding layup_cmdline verb, `log` as well."""
 # These imports are needed only for the demo
 import os
 import numpy as np
-from layup.utilities.data_processing_utilities import process_data, process_data_by_id
+from layup.utilities.data_processing_utilities import (
+    process_data,
+    process_data_by_id,
+    resolve_num_workers,
+)
 
 # NOTE - The following is the "configuration" required to log from this module.
 import logging
@@ -60,7 +64,7 @@ def log_cli():
     logger.info(f"In `log_cli` function.")
 
     samples = 25
-    num_workers = os.cpu_count()
+    num_workers = resolve_num_workers(-1)
 
     result = log_by_chunk(samples, num_workers)
     logger.debug(f"Processed data with this length: {len(result)}")

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -46,6 +46,7 @@ from layup.utilities.data_processing_utilities import (
     get_format,
     parse_fit_result,
     process_data_by_id,
+    resolve_num_workers,
 )
 from layup.utilities.datetime_conversions import convert_tdb_date_to_julian_date
 from layup.utilities.debiasing import debias, generate_bias_dict
@@ -1974,8 +1975,7 @@ def orbitfit_cli(
                 else Path(f"{output_file_stem_flagged}.h5")
             )
 
-    if num_workers < 0:
-        num_workers = os.cpu_count()
+    num_workers = resolve_num_workers(num_workers)
 
     # Check that input file exists
     if not input_file.exists():

--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -28,6 +28,7 @@ from layup.utilities.data_processing_utilities import (
     process_data,
     process_data_by_id,
     skyplane_cov_to_radec_cov,
+    resolve_num_workers,
 )
 from layup.utilities.file_io import CSVDataReader
 from layup.utilities.file_io.file_output import write_csv
@@ -420,7 +421,10 @@ def predict(
     primary_id_column_name : str
         The name of the primary ID column.
     num_workers : int
-        The number of workers to use for parallelization. If -1, use all available cores.
+        The number of workers to use for parallelization. Negative means decide
+        automatically: the CPUs available to this process, or 1 when layup is
+        already running inside someone else's worker, or ``LAYUP_NUM_WORKERS``
+        when set. See ``resolve_num_workers``.
     cache_dir : str or None
         The directory to the cached kernels. If None, use the default cache directory.
     args : argparse
@@ -432,8 +436,7 @@ def predict(
     -------
     numpy structured array with the flattened results
     """
-    if num_workers < 0:
-        num_workers = os.cpu_count()
+    num_workers = resolve_num_workers(num_workers)
 
     layup_observatory = LayupObservatory(cache_dir=cache_dir)
 
@@ -535,8 +538,7 @@ def predict_cli(
 
     num_workers = cli_args.n
 
-    if num_workers < 0:
-        num_workers = os.cpu_count()
+    num_workers = resolve_num_workers(num_workers)
 
     times = np.arange(start_date, end_date + timestep_day, step=timestep_day)
 

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -57,7 +57,87 @@ _OBSERVER_POSITION_WARN_KM = 100.0
 # cheaper, but "spawn" is the most portable and matches the macOS default.)
 _MP_CONTEXT = multiprocessing.get_context("spawn")
 
+# Environment override for the automatic worker count, mirroring OMP_NUM_THREADS
+# and friends: a caller that already knows how much of the machine it owns can
+# say so without threading the value through every layup call.
+_NUM_WORKERS_ENV = "LAYUP_NUM_WORKERS"
+
 logger = logging.getLogger(__name__)
+
+
+def _running_inside_a_worker():
+    """Whether this process is already one of several running in parallel.
+
+    Two ways that happens:
+
+    * ``multiprocessing.parent_process()`` is set -- we are a child of a process
+      pool, either layup's own (a fit that calls ``convert``, say) or the
+      caller's.
+    * ``PYTEST_XDIST_WORKER`` is set -- pytest-xdist has given this process one
+      slice of the machine. xdist workers are started by execnet, not by
+      multiprocessing, so the first check does not see them.
+
+    Both mean the same thing operationally: this process does not own the whole
+    machine and must not size a pool as though it did.
+    """
+    if multiprocessing.parent_process() is not None:
+        return True
+    return bool(os.environ.get("PYTEST_XDIST_WORKER"))
+
+
+def resolve_num_workers(num_workers):
+    """Resolve a requested worker count to the number of processes to start.
+
+    ``num_workers >= 0`` is honoured as given -- an explicit request always wins.
+    A negative value means "decide for me", and that decision is the point of
+    this function: **the automatic answer must account for parallelism we are
+    already inside of.**
+
+    ``os.cpu_count()`` reports the size of the machine, not the share of it this
+    process owns. When several layup processes run at once -- N pytest-xdist
+    workers, a SLURM array task per core, a caller's own pool -- each one sizing
+    its pool at ``os.cpu_count()`` oversubscribes the machine by a factor of N.
+    On a small runner that is enough to wedge it: N x N spawned interpreters,
+    each re-importing layup and JAX, thrashing a handful of cores. The same
+    mistake one level down (N workers x N OpenBLAS threads) is what
+    ``tests/layup/conftest.py`` pins the threadpool variables to avoid.
+
+    So, for a negative request, in order:
+
+    1. ``LAYUP_NUM_WORKERS`` if set -- an explicit statement of our share.
+    2. 1, if we are already inside a worker process (see
+       :func:`_running_inside_a_worker`).
+    3. The number of CPUs actually available to us. On Linux that is the
+       affinity mask, which respects cgroup/taskset limits; ``os.cpu_count()``
+       does not.
+
+    Parameters
+    ----------
+    num_workers : int
+        Requested worker count. Negative means automatic.
+
+    Returns
+    -------
+    int
+        Worker count to use, always >= 1 for the automatic path.
+    """
+    if num_workers is not None and num_workers >= 0:
+        return num_workers
+
+    override = os.environ.get(_NUM_WORKERS_ENV)
+    if override:
+        try:
+            return max(1, int(override))
+        except ValueError:
+            raise ValueError(f"{_NUM_WORKERS_ENV} must be an integer; got {override!r}.") from None
+
+    if _running_inside_a_worker():
+        return 1
+
+    try:
+        return max(1, len(os.sched_getaffinity(0)))
+    except AttributeError:  # not Linux
+        return max(1, os.cpu_count() or 1)
 
 
 def write_fallback_obscodes():

--- a/tests/layup/test_data_processing_utilities.py
+++ b/tests/layup/test_data_processing_utilities.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import pytest
 import spiceypy as spice
@@ -5,6 +6,7 @@ from numpy.lib import recfunctions as rfn
 from numpy.testing import assert_array_equal, assert_equal
 
 from layup.utilities.data_processing_utilities import (
+    resolve_num_workers,
     AU_KM,
     LayupObservatory,
     get_cov_columns,
@@ -955,3 +957,45 @@ def test_layup_observatory_falls_back_on_corrupt_obscodes(monkeypatch):
     assert calls[0] is None and calls[1] is not None
     assert "X05" in observatory.ObservatoryXYZ
     assert len(observatory.ObservatoryXYZ) > 2000
+
+
+def test_resolve_num_workers_honours_an_explicit_request():
+    """An explicit count always wins, including 0 and 1."""
+    for n in (0, 1, 3, 64):
+        assert resolve_num_workers(n) == n
+
+
+def test_resolve_num_workers_auto_is_positive_and_bounded_by_the_machine():
+    """The automatic path returns a usable count, never 0 or None."""
+    n = resolve_num_workers(-1)
+    assert n >= 1
+    assert n <= (os.cpu_count() or 1)
+
+
+def test_resolve_num_workers_env_override(monkeypatch):
+    """LAYUP_NUM_WORKERS states this process's share of the machine."""
+    monkeypatch.setenv("LAYUP_NUM_WORKERS", "2")
+    assert resolve_num_workers(-1) == 2
+    # ...but it only applies to the automatic path.
+    assert resolve_num_workers(5) == 5
+
+
+def test_resolve_num_workers_env_override_rejects_nonsense(monkeypatch):
+    monkeypatch.setenv("LAYUP_NUM_WORKERS", "all-of-them")
+    with pytest.raises(ValueError, match="LAYUP_NUM_WORKERS"):
+        resolve_num_workers(-1)
+
+
+def test_resolve_num_workers_is_one_inside_a_pool_worker(monkeypatch):
+    """A layup pool child must not size a pool of its own (nested parallelism)."""
+    monkeypatch.setattr(
+        "layup.utilities.data_processing_utilities.multiprocessing.parent_process",
+        lambda: object(),
+    )
+    assert resolve_num_workers(-1) == 1
+
+
+def test_resolve_num_workers_is_one_under_pytest_xdist(monkeypatch):
+    """N xdist workers x N spawned children is what wedges a small CI runner."""
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    assert resolve_num_workers(-1) == 1


### PR DESCRIPTION
Fixes the Ubuntu CI wedge, and a real footgun for anyone running layup in parallel.

### The problem

`os.cpu_count()` reports the size of the machine, not the share of it this process owns. `predict`, `convert`, `orbitfit` and `comet` all sized their process pool at `os.cpu_count()` whenever `num_workers` was negative. So N concurrent layup processes each start N children and oversubscribe the machine N-fold.

Under `pytest -n auto` on a ~4-core runner that means 4 xdist workers each spawning up to 4 more interpreters — 16 processes on 4 cores, each re-importing layup and JAX, since the start method is `spawn`.

Measured:

| run | result |
|---|---|
| Linux, serial (`-n0`) | 460 passed, 1 skipped, **10m14s — green** |
| Linux, `-n auto` | silent for ~10 min, killed at the 20-minute cap. Three legs, two days |
| macOS, `-n auto` | green |

There is no single bad test. The wedge is a property of running in parallel.

`tests/layup/conftest.py` already fixes exactly this one level down — it pins `OMP_NUM_THREADS` and friends to 1 because "N workers x N threads oversubscribes a small CI runner (~4 cores) and hangs the Linux test step." The *process* level was never capped.

### The change

`resolve_num_workers()`, with all five automatic sites routed through it. An explicit `num_workers >= 0` is honoured exactly as before. A negative value now resolves, in order, to:

1. `LAYUP_NUM_WORKERS` if set — an explicit statement of our share, mirroring `OMP_NUM_THREADS`.
2. `1`, if we are already inside a worker process: a multiprocessing child, or a pytest-xdist worker (execnet starts those, so `parent_process()` cannot see them).
3. The CPUs actually available to us — `os.sched_getaffinity` on Linux, which respects cgroup and taskset limits that `os.cpu_count()` ignores.

Six unit tests cover the explicit path, the environment override and its validation, and both nesting cases.

### Beyond CI

Anyone running layup from their own pool, or as a SLURM array task pinned to one core, was getting the same oversubscription with no way to say otherwise short of threading `num_workers` through every call. `LAYUP_NUM_WORKERS` gives them one.

### What this does not fix

The ASSIST adaptive-step grind on degenerate distant orbits — see the skip reason on `test_iod_auto.py:119` — is real and still upstream. Oversubscription made it much worse (an 80-minute leg beside a 12-minute twin is what a grind looks like when fighting 15 other processes for 4 cores), but it is a separate problem and this PR does not close it.

Suite green under the CI invocation locally: 466 passed, 1 skipped, 105s.
