### PR TITLE
Add the four community files required for the JOSS release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to Layup are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Versions are set from git tags via `setuptools_scm`; there is no version string in
+the source tree to edit.
+
+## [Unreleased]
+
+First public release. Layup determines orbits of solar system objects at the scale
+of the Rubin Observatory's Legacy Survey of Space and Time, and reports a full state
+covariance with every fit.
+
+### Observation types
+
+- Optical astrometry, read from the MPC 80-column format and from ADES in four
+  serializations (CSV, PSV, XML, HDF5).
+- Shift-and-stack measurements: sky position together with sky-motion rates, fit as
+  data rather than converted into synthetic tracklets.
+- Radar range and Doppler, with a two-leg light-time model (the station taken at the
+  transmit time on the up leg).
+- Observations from space-based platforms, with spacecraft positions resolved through
+  JPL Horizons and cached.
+
+All four share the same fitting machinery: they differ in the number and kind of
+residual rows they contribute, not in the code path they take.
+
+### Orbit determination
+
+- Initial orbit determination by Gauss's method and by a Bernstein-Khushalani linear
+  fit for distant objects, with automatic selection (`iod="auto"`) and a multi-root
+  picker that screens Gauss's candidate roots before committing to one.
+- Differential correction by Levenberg-Marquardt in either of two six-parameter
+  parameterizations: a barycentric equatorial Cartesian state, or a
+  Bernstein-Khushalani basis with a bound-orbit energy prior.
+- Non-gravitational accelerations via the Marsden A1/A2/A3 model, with a configurable
+  radial dependence spanning asteroidal and cometary laws, and amplitudes fittable per
+  apparition.
+- Incremental (sequential) orbit determination, folding new observations into existing
+  solutions at full-fit accuracy for roughly an order of magnitude less cost.
+
+### Covariance
+
+- Every fit returns a full state covariance, propagated consistently through element
+  and frame conversions (by JAX automatic differentiation) and through ephemeris
+  predictions (by variational particles integrated in REBOUND/ASSIST).
+
+### Ephemerides and prediction
+
+- Ephemeris-quality integrations through ASSIST and REBOUND, using the IAS15
+  integrator.
+- Predictions that integrate once and interpolate to many epochs and observatory
+  locations.
+
+### Interfaces
+
+- A command-line interface and a Python API, with parallel execution across objects.
+- `layup bootstrap` to fetch the required ephemeris and reference data, and a bundled
+  demo dataset (`layup demo`).
+
+### Validation
+
+- Cross-validated against JPL Horizons across main-belt asteroids, trans-Neptunian
+  objects, interstellar (hyperbolic) objects, and radar-observed near-Earth objects.
+- Demonstrated at scale by re-fitting the full Minor Planet Center catalog.
+
+[Unreleased]: https://github.com/Smithsonian/layup/commits/main

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,82 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "Layup: Orbit Fitting at LSST Scale"
+abstract: >-
+  Layup is an open-source Python and C++ package for orbit determination at
+  the scale of the Vera C. Rubin Observatory's Legacy Survey of Space and Time.
+  It ingests optical astrometry, shift-and-stack (position and rate)
+  measurements, radar range and Doppler observations, and observations from
+  space-based platforms; fits both gravitational and non-gravitational orbits
+  in Cartesian and Bernstein-Khushalani parameterizations; and reports a full
+  state covariance with every fit, propagated consistently through element and
+  frame conversions and through ephemeris predictions.
+type: software
+license: MIT
+repository-code: "https://github.com/Smithsonian/layup"
+url: "https://layup.readthedocs.io"
+keywords:
+  - orbit determination
+  - asteroids
+  - solar system
+  - astronomy
+  - LSST
+authors:
+  - family-names: Holman
+    given-names: Matthew J.
+    orcid: "https://orcid.org/0000-0002-1139-4880"
+  - family-names: Schwamb
+    given-names: Megan E.
+    orcid: "https://orcid.org/0000-0003-4365-1455"
+  - family-names: Napier
+    given-names: Kevin J.
+    orcid: "https://orcid.org/0000-0003-4827-5049"
+  - family-names: Bernardinelli
+    given-names: Pedro H.
+    orcid: "https://orcid.org/0000-0003-0743-9422"
+  - family-names: Lyttle
+    given-names: Ryan R.
+    orcid: "https://orcid.org/0009-0007-8602-2954"
+  - family-names: Murtagh
+    given-names: Joseph
+    orcid: "https://orcid.org/0000-0001-9505-1131"
+  - family-names: Wilson
+    given-names: Adam
+    orcid: "https://orcid.org/0009-0001-2321-3784"
+  - family-names: Rein
+    given-names: Hanno
+    orcid: "https://orcid.org/0000-0003-1927-731X"
+  - family-names: Oldag
+    given-names: Drew
+    orcid: "https://orcid.org/0000-0001-6984-8411"
+  - family-names: West
+    given-names: Maxine
+    orcid: "https://orcid.org/0009-0003-3171-3118"
+  - family-names: Beebe
+    given-names: Wilson
+    orcid: "https://orcid.org/0009-0003-1791-8707"
+  - family-names: Jurić
+    given-names: Mario
+    orcid: "https://orcid.org/0000-0003-1996-9252"
+  - family-names: Eggl
+    given-names: Siegfried
+    orcid: "https://orcid.org/0000-0002-1398-6302"
+  - family-names: Makadia
+    given-names: Rahil
+    orcid: "https://orcid.org/0000-0001-9265-2230"
+  - family-names: Moeyens
+    given-names: Joachim
+    orcid: "https://orcid.org/0000-0001-5820-3925"
+  - family-names: Chandler
+    given-names: Colin Orion
+    orcid: "https://orcid.org/0000-0001-7335-1715"
+  - family-names: Ruch
+    given-names: Thomas R.
+    orcid: "https://orcid.org/0000-0003-0403-0891"
+  - family-names: Holt
+    given-names: Carrie E.
+    orcid: "https://orcid.org/0000-0002-4043-6445"
+
+# TODO before the v1.0.0 release, per RELEASE_CHECKLIST.md Phase 4:
+#   version: 1.0.0
+#   date-released: YYYY-MM-DD
+#   doi: <Zenodo version DOI, minted when the GitHub Release is published>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**mholman@cfa.harvard.edu**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to Layup
+
+Thanks for your interest in Layup. Contributions are welcome — bug reports, fixes,
+documentation, and new capability alike.
+
+Layup is an orbit-determination package for the Rubin Observatory era, so a good
+fraction of contributions involve orbital dynamics as much as software. Both kinds of
+expertise are useful, and you do not need both.
+
+## Reporting a bug
+
+Open an issue at https://github.com/Smithsonian/layup/issues. The most useful reports
+include:
+
+- what you ran (the command line or the Python call, with the arguments);
+- the input data, or enough of it to reproduce — a handful of observations is usually
+  plenty, and a designation plus the observatory codes and epochs is often enough;
+- what you expected and what you got, including the `flag` value if a fit returned one;
+- your platform, Python version, and the versions of `layup`, `assist`, `rebound` and
+  `sorcha`.
+
+If a fit is slow or fails to converge rather than crashing, say so explicitly — those
+are usually a different class of problem from an exception, and the orbital geometry
+(heliocentric distance, arc length, number of observations) is the part we will ask
+about first.
+
+## Asking a question
+
+Questions about how to use Layup are welcome as issues. If something was hard to work
+out, that is usually a documentation bug and worth reporting as one.
+
+## Contributing code
+
+1. **Open an issue first** for anything beyond a small fix, so the approach can be
+   discussed before you spend time on it.
+2. **Fork and branch.** Branch from `main`.
+3. **Install for development**, following the README:
+   ```
+   git clone --recursive https://github.com/Smithsonian/layup.git
+   cd layup
+   pip install -e ".[dev]"
+   ```
+   Layup builds a C++ extension, so a compiler is required; the `--recursive` clone
+   brings in the `assist`, `eigen` and `rebound` submodules.
+4. **Run the tests**: `pytest`. Please add tests for what you change.
+5. **Run the formatter**: the project uses `black` (pinned in the `dev` extra) via
+   `pre-commit`. Install the hooks once with `pre-commit install`.
+6. **Open a pull request** against `main`, describing what changed and why.
+
+### A note on numerical changes
+
+Layup is a numerical package, and changes to the fitting, covariance, or observation
+models need evidence, not just passing tests — the existing tests will happily pass
+against a subtly wrong Jacobian. If you change a partial derivative, a covariance
+propagation, or an observation model, please say in the pull request how you checked
+it: a finite-difference comparison against the analytic form, a cross-check against
+JPL Horizons, or a Monte-Carlo test are all good. Several real bugs in Layup's history
+were found exactly this way, and the tests did not catch any of them.
+
+### Review
+
+Pull requests need a review from someone other than the author before merging. Once a
+pull request is approved, the submitter merges it.
+
+## Code of Conduct
+
+By participating you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+Contributions are licensed under the MIT License, the same terms as the rest of the
+project. See [LICENSE](LICENSE).


### PR DESCRIPTION
Adds the four community files that `RELEASE_CHECKLIST.md` lists as Phase 0 items and that the JOSS submission bot checks for. `LICENSE` (MIT) was already present; these were the remaining four.

Closes the community-file half of the pre-release checklist. No code changes.

### What is here

| file | notes |
|---|---|
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1, verbatim. Enforcement contact set to mholman@cfa.harvard.edu. |
| `CITATION.cff` | All 18 authors with ORCIDs, taken from the AJ paper author block. YAML-validated. |
| `CHANGELOG.md` | Keep a Changelog format, with an `[Unreleased]` section. |
| `CONTRIBUTING.md` | How to report a bug, install for development, and open a pull request. |

### Two things left deliberately incomplete

**`CITATION.cff` has no `version`, `date-released` or `doi`.** These cannot be filled until the release is tagged and Zenodo mints the DOI — checklist Phase 4 wires them back afterwards. The TODO is marked in the file.

**`CHANGELOG.md` describes the initial release by capability, not by history.** There are 235 merged pull requests behind v1.0; enumerating them would not help anyone. At tag time, promote `[Unreleased]` to `[1.0.0] - <date>`.

### Worth a look when reviewing

- **The author list in `CITATION.cff`** — please check your own entry. It is taken from the AJ paper, so anyone who has corrected their ORCID or spelling there should be correct here, but it is worth each author's eye.
- **`CONTRIBUTING.md` asks for evidence with numerical changes** — a finite-difference comparison, a Horizons cross-check, or a Monte-Carlo test. That paragraph is there because the test suite passes happily against a subtly wrong Jacobian, which is how several real bugs reached `main`. Reword it if it reads as too strong a demand.
- **The Code of Conduct contact.** A personal address is the simplest thing that works, but if the project would rather route reports somewhere shared or institutional, now is the moment to change it.

### Not in this PR

The `sorcha @ git+https://...` dependency (#436) still needs fixing before PyPI will accept a build — PyPI forbids direct-URL dependencies. sorcha 1.2.0 and 1.2.1 are both on PyPI and both appear to work with layup, so the change is likely one line, but it deserves a clean-environment verification rather than being folded in here.