### PR TITLE
Arm four dead assertions, and stop CI hiding its own failures

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -23,6 +23,11 @@ jobs:
         python-version: ['3.11', '3.12']
 
     runs-on: ${{ matrix.os }}
+    # Cap the job so a hung network fetch cannot burn hours (issue #388). Run
+    # 32624442399 on 2026-08-23 ran 2h21m before failing on a ConnectTimeout to
+    # ssd.jpl.nasa.gov; testing-and-coverage.yml already had this cap, this
+    # workflow did not.
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@v7
     - name: Set up - ${{ matrix.os }} - Python ${{ matrix.python-version }}
@@ -51,5 +56,7 @@ jobs:
         pip list
     - name: Run unit tests with pytest
       run: |
-        # -rs surfaces skipped tests + reasons in the CI log (issue #359).
-        python -m pytest -n auto -rs
+        # -rsfE surfaces skipped tests + reasons (issue #359) while KEEPING pytest's
+        # default failure/error listing. Plain -rs replaces -rfE rather than adding
+        # to it, so failures never appeared in the log.
+        python -m pytest -n auto -rsfE

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -55,10 +55,13 @@ jobs:
         layup bootstrap
     - name: Run unit tests with pytest
       run: |
-        # -rs prints a summary of skipped tests and their reasons, so silently
+        # -rsfE prints a summary of skipped tests and their reasons, so silently
         # skipped suites (e.g. ephem-gated fit/validation tests) are visible in
-        # the CI log (issue #359).
-        python -m pytest -n auto -rs --cov=layup --cov-report=xml
+        # the CI log (issue #359) -- while KEEPING pytest's default failure/error
+        # listing. Plain -rs REPLACES the default -rfE rather than adding to it,
+        # which removed the FAILED lines from the log: a red run then gave no
+        # indication of what had failed.
+        python -m pytest -n auto -rsfE --cov=layup --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v7
       with:

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -336,10 +336,15 @@ def test_layup_get_residual_vectors():
     vectors = np.array([[1, 2, 3], [4, 5, 6], [0.7, 0.8, 0.9]])
     output_A, output_D = layup_get_residual_vectors(vectors)
 
+    # layup_get_residual_vectors is the vectorised form: it takes the (3, N) array
+    # whose COLUMNS are the input vectors and returns A and D in the same layout, so
+    # the i-th result is output_A[:, i]. Comparing output_A[i] (a row) silently
+    # compared unrelated quantities -- and, before these assertions were armed, did
+    # not compare anything at all.
     for i in range(len(vectors[0])):
         sorcha_A, sorcha_D = get_residual_vectors(vectors.T[i])
-        np.allclose(output_A[i], sorcha_A)
-        np.allclose(output_D[i], sorcha_D)
+        assert np.allclose(output_A[:, i], sorcha_A), f"A vector differs from sorcha at i={i}"
+        assert np.allclose(output_D[:, i], sorcha_D), f"D vector differs from sorcha at i={i}"
 
 
 def test_layup_calculate_rates_and_geometry():
@@ -398,11 +403,11 @@ def test_layup_calculate_rates_and_geometry():
         geom_param.rho_mag = ephem_geom_params.rho_mag.T[i]
         geom_param.r_ast = ephem_geom_params.r_ast.T[i]
         geom_param.v_ast = ephem_geom_params.v_ast.T[i]
-        print()
         sorcha_output = calculate_rates_and_geometry(pointing, geom_param)
         for j in range(3, len(sorcha_output)):
-            print(output[j][i], sorcha_output[j])
-            np.allclose(output[j][i], sorcha_output[j])
+            assert np.allclose(output[j][i], sorcha_output[j]), (
+                f"field {j} differs from sorcha at pointing {i}: " f"{output[j][i]} != {sorcha_output[j]}"
+            )
 
 
 def test_get_onsky_data_output(tmpdir):
@@ -448,7 +453,9 @@ def test_get_onsky_data_output(tmpdir):
         "Obj_Sun_vz_LTC_km_s",
         "phase_deg",
     ]:
-        np.allclose(results[column], expected[column])
+        assert np.allclose(
+            results[column], expected[column]
+        ), f"column {column} differs from the expected output"
 
 
 def test_residuals_at_state_matches_predict_sequence():


### PR DESCRIPTION
Two independent problems, both found while running a mock JOSS review against `main`. No changes to `src/`.

## 1. Four assertions in `test_predict.py` did nothing

Lines 341, 342, 405 and 451 called `np.allclose(...)` as a bare expression and discarded the result:

```python
np.allclose(output_A[i], sorcha_A)              # 341
np.allclose(output_D[i], sorcha_D)              # 342
np.allclose(output[j][i], sorcha_output[j])     # 405
np.allclose(results[column], expected[column])  # 451
```

These were the **only** four bare occurrences in the suite — everything else uses `assert` or `np.testing.assert_*` — so this was an isolated slip, not a pattern. But of all the places for it:

- **341/342/405 are the only comparisons anywhere in the package against Sorcha**, i.e. our only cross-implementation validation.
- **451** voided the entire 12-column comparison against `onsky_expected.csv`.

`test_layup_get_residual_vectors`, `test_layup_calculate_rates_and_geometry` and `test_get_onsky_data_output` passed unconditionally and would have passed if the functions under test returned zeros.

### Arming them exposed a second bug — in the test, not the code

`test_layup_get_residual_vectors` failed as soon as the assertion was live. The cause is the indexing: `layup_get_residual_vectors` is the vectorised form, taking a `(3, N)` array whose **columns** are the input vectors and returning `A`/`D` in the same layout, so the i-th result is `output_A[:, i]`. The test compared `output_A[i]` — a row — against Sorcha's i-th vector, which are unrelated quantities.

With the indexing corrected, the two implementations **agree exactly**:

```
max |layup - sorcha| over A and D:  0.0
```

So the vectorised implementation was right all along; only the comparison was wrong. A real validation is restored and no science code changes.

### One I could not verify locally

`test_get_onsky_data_output` still fails on my machine — but **identically on unmodified `main`** (verified by stashing). It subprocesses to whichever `layup` is on `PATH`, which here resolves to a different conda environment, so it fails at the return-code check before reaching the assertion. Pre-existing and environmental. The armed assertion is not exercised locally and **will run for the first time in CI on this PR** — worth watching that leg specifically.

## 2. `-rs` was hiding CI failures

Both workflows passed `-rs`. That **replaces** pytest's default `-rfE` short-summary selection rather than adding to it, so the summary listed skips and dropped failures.

Evidence — run [32624442399](https://github.com/Smithsonian/layup/actions/runs/32624442399) (2026-08-23): ran **2 h 21 min**, ended `43 failed, 424 passed, 1 skipped`, and the log contains **zero occurrences of the string `FAILED`**.

The flag was added to surface silently-skipped suites (#359) and inadvertently made every red run undiagnosable. `-rsfE` does both.

Also: `timeout-minutes` existed only in `testing-and-coverage.yml` (added for #388). `smoke-test.yml` — the workflow that burned 2 h 21 min — had none, and now has a 40-minute cap.

## Checks

- `black` clean; both workflow files validate as YAML.
- The two locally-runnable armed tests pass.
- `test_get_onsky_data_output` is unverified locally for the environmental reason above.