### PR TITLE
Remove the extracted archive after bootstrap untars it (#436)

### DIFF
--- a/src/layup/utilities/bootstrap_utilties/download_utilities.py
+++ b/src/layup/utilities/bootstrap_utilties/download_utilities.py
@@ -159,6 +159,15 @@ def _decompress(fname: str, action: str, pup: pooch.Pooch) -> None:  # pragma: n
     if os.path.splitext(fname)[-1] in tar_extentions:
         print(f"Trying to decompress tar file: {fname}")
         pooch.Untar(extract_dir=".").__call__(fname, action, pup)
+        # Remove the archive once its contents are extracted (issue #436).  The
+        # debiasing tarball is ~156 MB and pooch keeps it alongside the extracted
+        # data, so leaving it roughly doubles that part of the cache for no benefit
+        # -- nothing reads the archive again.  Failure to remove it is not worth
+        # aborting a bootstrap over, so this is best-effort.
+        try:
+            os.remove(fname)
+        except OSError as exc:  # pragma: no cover - filesystem-dependent
+            print(f"Could not remove the extracted archive {fname}: {exc}")
 
 
 def _remove_files(aux_config: AuxiliaryConfigs, retriever: pooch.Pooch) -> None:

--- a/tests/layup/test_download_utilities.py
+++ b/tests/layup/test_download_utilities.py
@@ -11,6 +11,7 @@ import pooch
 from layup.utilities.bootstrap_utilties.download_utilities import (
     make_retriever,
     layup_downloader,
+    _decompress,
     _RETRY_IF_FAILED,
     _CONNECT_TIMEOUT,
     _READ_TIMEOUT,
@@ -35,3 +36,59 @@ def test_layup_downloader_has_fail_fast_timeout():
 def test_layup_downloader_progressbar_flag():
     assert layup_downloader(progressbar=True).progressbar is True
     assert layup_downloader().progressbar is False
+
+
+def test_decompress_removes_the_tar_archive(tmp_path, monkeypatch):
+    """`layup bootstrap` must not leave the extracted archive behind (issue #436).
+
+    The debiasing tarball is ~156 MB and nothing reads it again after extraction,
+    so keeping it alongside the extracted data roughly doubles that part of the
+    cache. Network-free: builds a small tarball locally and runs the same
+    `_decompress` hook pooch calls.
+    """
+    import os
+    import tarfile
+
+    monkeypatch.chdir(tmp_path)
+    payload = tmp_path / "bias.dat"
+    payload.write_text("x" * 1000)
+    archive = tmp_path / "debias_hires2018.tgz"
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(payload, arcname="bias.dat")
+    payload.unlink()
+
+    _decompress(str(archive), "download", None)
+
+    assert not archive.exists(), "the .tgz archive should be removed after extraction"
+    assert (tmp_path / "bias.dat").exists(), "the extracted contents must survive"
+
+
+def test_decompress_survives_an_unremovable_archive(tmp_path, monkeypatch):
+    """Failing to delete the archive must not abort a bootstrap.
+
+    Removal is best-effort: a read-only cache or a platform that holds the handle
+    should cost disk space, not the whole download.
+    """
+    import tarfile
+
+    monkeypatch.chdir(tmp_path)
+    payload = tmp_path / "bias.dat"
+    payload.write_text("y" * 100)
+    archive = tmp_path / "debias_hires2018.tgz"
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(payload, arcname="bias.dat")
+    payload.unlink()
+
+    import os as _os
+
+    real_remove = _os.remove
+
+    def refuse(path, *a, **kw):
+        if str(path).endswith(".tgz"):
+            raise OSError("simulated read-only cache")
+        return real_remove(path, *a, **kw)
+
+    monkeypatch.setattr(_os, "remove", refuse)
+    _decompress(str(archive), "download", None)  # must not raise
+
+    assert (tmp_path / "bias.dat").exists(), "extraction must still have happened"


### PR DESCRIPTION
Addresses the second item of #436. The first item — the stale PyPI 0.0.1 stub — is downstream of the first real release and stays open; the two faults that will actually make that release fail are now filed separately as #471.

## The problem

`layup bootstrap` untars `debias_hires2018.tgz` (~156 MB) and leaves the archive sitting beside the extracted contents. Nothing reads it again, so it roughly doubles that part of the cache — on a package that already asks the user for about 3.2 GB.

## The fix

Remove it after extraction, best-effort:

```python
pooch.Untar(extract_dir=".").__call__(fname, action, pup)
try:
    os.remove(fname)
except OSError as exc:
    print(f"Could not remove the extracted archive {fname}: {exc}")
```

The `try` is deliberate. A read-only cache, or a platform still holding the handle, should cost disk space — not abort a multi-hundred-megabyte download that has already succeeded.

## Tests

Two, both network-free: they build a small tarball in a `tmp_path` and call the same `_decompress` hook pooch invokes.

- `test_decompress_removes_the_tar_archive` — asserts the archive is gone **and** the extracted contents survive. Verified to fail on the unpatched code with `AssertionError: the .tgz archive should be removed after extraction`.
- `test_decompress_survives_an_unremovable_archive` — monkeypatches `os.remove` to raise, and asserts extraction still completes. This pins the best-effort behaviour rather than leaving it to be inferred from the `try`.