### PR TITLE
JOSS paper: drop the known-object attribution claim

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -152,7 +152,7 @@ Meg's review: a few sentences on capabilities beyond orbit fitting.  Facts only.
    write "barycentric" pending layup#447.
 Deferred, unrelated: the 5-parameter/energy-prior BK line -> layup#445.
 -->
-Ephemeris predictions with `Layup` are highly efficient, using ASSIST's ability to integrate once and interpolate to many epochs and observatory locations. `Layup` also includes utilities for orbital element conversions, as well as known-object attribution. Finally, `Layup` includes an extensive command-line interface and a Python API.
+Ephemeris predictions with `Layup` are highly efficient, using ASSIST's ability to integrate once and interpolate to many epochs and observatory locations. `Layup` also includes utilities for orbital element conversions. Finally, `Layup` includes an extensive command-line interface and a Python API.
 
 
 # Validation


### PR DESCRIPTION
One sentence, but a functional claim that is not true.

`paper/paper.md` Functionality section said:

> `Layup` also includes utilities for orbital element conversions, ~~as well as known-object attribution~~.

The first half is true. The second is not — checked against `main`: there is no attribution module, no attribution CLI verb, and no function in `src/` that performs known-object attribution. The verbs are bootstrap, comet, convert, demo, init, log, orbitfit, predict, unpack, visualize.

**"Have the functional claims of the software been confirmed?" is a JOSS review checklist item**, so a reviewer would go looking for that utility.

## Why dropping it rather than rewriting it

The work *has* been done — using layup, largely on the USDF side — but as a separate application built on layup's public API, not as something the package ships. That is a demonstration, and a demonstration is a stronger thing to describe than a feature list.

The AJ paper will describe it properly once the figures are settled (requested from the USDF session; two candidate results are in circulation and it is not yet settled which are current or what sample each is over). For the JOSS *capability tour*, which is a list of what the package does, dropping the clause is the accurate fix and costs nothing.

## The paper's other two mentions are correct and unchanged

> Every `Layup` fit reports a full state covariance, which it propagates through element and frame conversions and through ephemeris predictions **to support attribution and linking**.

> This enables rigorous uncertainty ellipses, which in turn **support attribution and linking**.

Both are claims about what the machinery *enables*, not about what ships. That distinction is the whole of this change.

## Checks

Frontmatter parses (18 authors, 15 affiliations), 27 citations all resolve against `paper.bib`, and the `Draft JOSS paper` workflow builds the PDF on this PR.