### PR TITLE
Make PyPI publishing possible: submodules, sorcha dependency, and sdist-only build (#471)

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -23,7 +23,15 @@ jobs:
     permissions:
       id-token: write
     steps:
+    # submodules: recursive is load-bearing. CMakeLists.txt references include/eigen
+    # and include/autodiff, both git submodules, and scikit-build-core copies their
+    # contents into the sdist. Without this the build fails outright with a bare
+    # `fatal error: 'Eigen/Dense' file not found`, and if it did not, the sdist would
+    # ship without the headers and every `pip install layup` from source would fail
+    # the same way.
     - uses: actions/checkout@v7
+      with:
+        submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
@@ -32,7 +40,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
-    - name: Build package
-      run: python -m build
+    # sdist only, deliberately. `python -m build` would also produce a wheel, and on
+    # a plain ubuntu runner that wheel carries the `linux_x86_64` platform tag, which
+    # PyPI REJECTS -- Linux wheels must be manylinux or musllinux. Publishing binary
+    # wheels needs cibuildwheel across macOS and manylinux images; until then the
+    # sdist is the honest artifact. It is self-contained (~10 MB, submodules
+    # included), so users build locally -- which requires a C++17 compiler, as the
+    # README now states.
+    - name: Build sdist
+      run: python -m build --sdist
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "astropy",
     "pooch",
     "tqdm",
-    "sorcha @ git+https://github.com/dirac-institute/sorcha.git",
+    "sorcha>=1.2.0",
     "assist",
     "rebound",
     "pybind11",
@@ -31,7 +31,6 @@ dependencies = [
     "dash",
     "dash-daq",
     "dash-ag-grid",
-    "pytest"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Closes #471. Everything below was verified by building an sdist and installing it, not by reading config.

## 1. The publish workflow checked out without submodules

`CMakeLists.txt` references `include/eigen` and `include/autodiff`, both git submodules, so `python -m build` fails outright:

```
fatal error: 'Eigen/Dense' file not found
```

There is a second consequence I did not expect. **scikit-build-core copies submodule contents into the sdist** — I confirmed this by building one: 1,891 eigen files and 153 autodiff files are in the tarball. So a checkout without submodules would not merely fail the build; if it somehow succeeded, it would publish an sdist that **nobody could build from either**.

Now `submodules: recursive`, with that reasoning in a comment so it does not get dropped as redundant.

## 2. The sorcha dependency was a direct URL

Confirmed in the built metadata before the change:

```
Requires-Dist: sorcha @ git+https://github.com/dirac-institute/sorcha.git
```

PyPI rejects direct-URL `Requires-Dist` entries, so the upload fails at validation, after the build. Now `sorcha>=1.2.0`, and the rebuilt metadata reads `Requires-Dist: sorcha>=1.2.0`.

**Verified rather than assumed**: the scratch environment used for today's work carries **sorcha 1.2.1 from PyPI**, and the BK/IOD suites, the predict tests and the assertion tests have all been passing against it. @awilson110 separately reports 1.2.1 working with layup on both macOS and Ubuntu (#465).

## 3. A third fault, not in the issue: the wheel would also be rejected

`python -m build` produces a wheel as well as an sdist, and on a plain ubuntu runner that wheel carries the **`linux_x86_64`** platform tag. PyPI rejects it — Linux wheels must be `manylinux` or `musllinux`. So even with 1 and 2 fixed, the publish step would have failed.

**Now sdist-only, deliberately.** Binary wheels need `cibuildwheel` across macOS and manylinux images, which is a larger piece of work than a first release needs. The sdist is self-contained (~10 MB, submodules included) so users build locally — which needs a C++17 compiler, as the README states since #470. The reasoning is in a comment, and reversing it later is a small change.

## Also

Dropped `pytest` from `[project].dependencies`. It was installing a test framework for every user and is already in the `dev` extra. Confirmed in the rebuilt metadata: `pytest` now appears only as `extra == "dev"`.

## End-to-end verification

Built the sdist, installed it into a **fresh venv** (compiling the extension from source), and checked:

- `layup --help` runs and shows the corrected tagline from #470
- `sorcha 1.2.1` resolves from PyPI
- the C++ extension loads and `orbitfit` imports
- `run_bk_iod` recovers **41.9996 AU** on a 42 AU synthetic arc, flag 0 — so #446's fix survives into the installed package

That is the "clean-environment verification" #471 asked for.