### PR TITLE
Adopt the 1/gamma-scaled BK dot convention (#445, #444)

### DIFF
--- a/src/lib/orbit_fit/bk_basis.cpp
+++ b/src/lib/orbit_fit/bk_basis.cpp
@@ -97,27 +97,20 @@ namespace orbit_fit
     {
         const RhoFrame f = compute_rho_frame(bk.alpha, bk.beta, fid);
         const double inv_g = 1.0 / bk.gamma;
-        const double inv_g2 = inv_g * inv_g;
 
         const Eigen::Vector3d r = inv_g * f.rho_hat;
 
-        // v is the exact time-derivative of r = rho_hat / gamma.  Using the
-        // chain rule d(rho_hat)/dt = adot*rho_hat_alpha + bdot*rho_hat_beta
-        // and d(1/gamma)/dt = -gdot/gamma^2:
+        // Under the 1/gamma-scaled convention (issue #445) the dots ARE the
+        // velocity components in the orthonormal fiducial basis, scaled by gamma:
+        //   adot = gamma (v . a),  bdot = gamma (v . b),  gdot = gamma (v . n0)
+        // so the inverse is three terms in an orthonormal basis:
+        //   v = (1/gamma) (adot a + bdot b + gdot n0)
         //
-        //   v = (1/gamma) d(rho_hat)/dt + d(1/gamma)/dt * rho_hat
-        //     = (1/gamma)(adot*rho_hat_alpha + bdot*rho_hat_beta)
-        //       - (gdot/gamma^2) rho_hat
-        //
-        // Dimensional check (lengths [L], time [T]): gamma ~ 1/[L], so
-        // 1/gamma ~ [L]; rho_hat_alpha/beta are dimensionless and adot,bdot
-        // ~ 1/[T], so term 1 ~ [L]/[T].  gdot ~ 1/([L][T]) and 1/gamma^2 ~
-        // [L]^2, so term 2 ~ [L]/[T] as well -- both are velocities.  The
-        // magnitudes look unusual only because rho_hat_alpha/beta are
-        // deliberately not unit length (see RhoFrame above), not because the
-        // units are inconsistent.
-        const Eigen::Vector3d v = inv_g * (bk.adot * f.rho_hat_alpha + bk.bdot * f.rho_hat_beta)
-                                  - bk.gdot * inv_g2 * f.rho_hat;
+        // The gnomonic tangent vectors rho_hat_alpha, rho_hat_beta -- which are
+        // deliberately not unit length and were a recurring source of confusion --
+        // drop out of the velocity path entirely.  All three dots now share units
+        // of inverse time.
+        const Eigen::Vector3d v = inv_g * (bk.adot * fid.a + bk.bdot * fid.b + bk.gdot * fid.n0);
 
         Eigen::Matrix<double, 6, 1> cart;
         cart << r, v;
@@ -139,17 +132,12 @@ namespace orbit_fit
         const double alpha = rho_hat.dot(fid.a) / u;
         const double beta = rho_hat.dot(fid.b) / u;
 
-        // gdot = d/dt (1/|r|) = -(r . v) / |r|^3 = -gamma^2 * (rho_hat . v)
-        const double gdot = -gamma * gamma * rho_hat.dot(v);
-
-        // d(rho_hat)/dt = gamma * (v - (v . rho_hat) * rho_hat)  -- v's component perp to rho_hat,
-        // scaled to a sphere tangent vector.  alpha-dot, beta-dot come from
-        // applying the quotient rule to alpha = (rho_hat . a) / (rho_hat . n0)
-        // and similarly for beta.
-        const Eigen::Vector3d rho_dot = gamma * (v - v.dot(rho_hat) * rho_hat);
-        const double rho_dot_n0 = rho_dot.dot(fid.n0);
-        const double adot = (rho_dot.dot(fid.a) - alpha * rho_dot_n0) / u;
-        const double bdot = (rho_dot.dot(fid.b) - beta * rho_dot_n0) / u;
+        // Under the 1/gamma-scaled convention (issue #445) the dots are simply the
+        // velocity components in the orthonormal fiducial basis, scaled by gamma.
+        // No quotient rule, no tangent-vector norms.
+        const double adot = gamma * v.dot(fid.a);
+        const double bdot = gamma * v.dot(fid.b);
+        const double gdot = gamma * v.dot(fid.n0);
 
         BKState bk;
         bk.alpha = alpha;
@@ -174,101 +162,81 @@ namespace orbit_fit
         const RhoFrame f = compute_rho_frame(alpha, beta, fid);
         const double inv_g = 1.0 / gamma;
         const double inv_g2 = inv_g * inv_g;
-        const double inv_g3 = inv_g2 * inv_g;
-        const double inv_s2 = 1.0 / f.s_sq;
-        const double inv_s4 = inv_s2 * inv_s2;
 
         Eigen::Matrix<double, 6, 6> J = Eigen::Matrix<double, 6, 6>::Zero();
 
-        // Top-left and bottom-right 3x3 blocks: d(r)/d(alpha,beta,gamma) and
-        // d(v)/d(adot,bdot,gdot) -- identical shape.
-        const Eigen::Vector3d dr_dalpha = inv_g * f.rho_hat_alpha;
-        const Eigen::Vector3d dr_dbeta = inv_g * f.rho_hat_beta;
-        const Eigen::Vector3d dr_dgamma = -inv_g2 * f.rho_hat;
+        // Position rows are unchanged by the convention change: r = rho_hat / gamma
+        // does not involve the dots.
+        J.block<3, 1>(0, 0) = inv_g * f.rho_hat_alpha;   // d r / d alpha
+        J.block<3, 1>(0, 1) = inv_g * f.rho_hat_beta;    // d r / d beta
+        J.block<3, 1>(0, 2) = -inv_g2 * f.rho_hat;       // d r / d gamma
 
-        J.block<3, 1>(0, 0) = dr_dalpha;
-        J.block<3, 1>(0, 1) = dr_dbeta;
-        J.block<3, 1>(0, 2) = dr_dgamma;
-
-        J.block<3, 1>(3, 3) = dr_dalpha;
-        J.block<3, 1>(3, 4) = dr_dbeta;
-        J.block<3, 1>(3, 5) = dr_dgamma;
-
-        // Bottom-left 3x3 block: d(v)/d(alpha,beta,gamma).  Needs second
-        // derivatives of rho_hat with respect to (alpha, beta):
-        //   d rho_hat_alpha / d alpha = -(1+beta^2)/s^4 * rho_hat
-        //                                - 2 alpha / s^2 * rho_hat_alpha
-        //   d rho_hat_alpha / d beta  = (alpha*beta)/s^4 * rho_hat
-        //                                - alpha/s^2 * rho_hat_beta
-        //                                - beta/s^2 * rho_hat_alpha
-        //   d rho_hat_beta  / d beta  = -(1+alpha^2)/s^4 * rho_hat
-        //                                - 2 beta / s^2 * rho_hat_beta
-        // and d rho_hat_beta / d alpha == d rho_hat_alpha / d beta by mixed-partial symmetry.
-        const Eigen::Vector3d d_rha_dalpha = -(1.0 + beta * beta) * inv_s4 * f.rho_hat
-                                             - 2.0 * alpha * inv_s2 * f.rho_hat_alpha;
-        const Eigen::Vector3d d_rha_dbeta = (alpha * beta) * inv_s4 * f.rho_hat
-                                            - alpha * inv_s2 * f.rho_hat_beta
-                                            - beta * inv_s2 * f.rho_hat_alpha;
-        const Eigen::Vector3d d_rhb_dbeta = -(1.0 + alpha * alpha) * inv_s4 * f.rho_hat
-                                            - 2.0 * beta * inv_s2 * f.rho_hat_beta;
-
-        // d v / d alpha
-        const Eigen::Vector3d dv_dalpha = inv_g * (adot * d_rha_dalpha + bdot * d_rha_dbeta)
-                                          - gdot * inv_g2 * f.rho_hat_alpha;
-        // d v / d beta
-        const Eigen::Vector3d dv_dbeta = inv_g * (adot * d_rha_dbeta + bdot * d_rhb_dbeta)
-                                         - gdot * inv_g2 * f.rho_hat_beta;
-        // d v / d gamma
-        const Eigen::Vector3d dv_dgamma = -inv_g2 * (adot * f.rho_hat_alpha + bdot * f.rho_hat_beta)
-                                          + 2.0 * gdot * inv_g3 * f.rho_hat;
-
-        J.block<3, 1>(3, 0) = dv_dalpha;
-        J.block<3, 1>(3, 1) = dv_dbeta;
-        J.block<3, 1>(3, 2) = dv_dgamma;
+        // Velocity rows.  Under the 1/gamma-scaled convention (issue #445),
+        //   v = (1/gamma) (adot a + bdot b + gdot n0)
+        // so v does NOT depend on alpha or beta at all, and the whole
+        // second-derivative block that used to live here is gone.
+        //
+        //   d v / d alpha = d v / d beta = 0
+        //   d v / d gamma = -(1/gamma^2) (adot a + bdot b + gdot n0) = -v / gamma
+        //   d v / d (adot, bdot, gdot) = (1/gamma) [a b n0]
+        const Eigen::Vector3d v_dir = adot * fid.a + bdot * fid.b + gdot * fid.n0;
+        J.block<3, 1>(3, 2) = -inv_g2 * v_dir;           // d v / d gamma
+        J.block<3, 1>(3, 3) = inv_g * fid.a;             // d v / d adot
+        J.block<3, 1>(3, 4) = inv_g * fid.b;             // d v / d bdot
+        J.block<3, 1>(3, 5) = inv_g * fid.n0;            // d v / d gdot
 
         return J;
     }
 
     double sigma_gdot_sq(const BKState &bk, double mu)
     {
-        // Bound-orbit constraint: 0.5 |v|^2 <= mu / |r| = mu * gamma.
-        // Substituting |v|^2 = gdot^2 / gamma^4 + |adot rho_hat_alpha + bdot rho_hat_beta|^2 / gamma^2
-        // (cross-terms with rho_hat vanish since rho_hat_alpha, rho_hat_beta are tangent to rho_hat),
+        // Bound-orbit constraint: |v|^2 < 2 mu / |r|.
         //
-        //   gdot^2 <= gamma^2 * (2 mu gamma^3 - |adot rho_hat_alpha + bdot rho_hat_beta|^2)
+        // Under the 1/gamma-scaled convention (issue #445) all three dots are
+        // velocity components in an ORTHONORMAL basis, so
+        //   |v|^2 = (adot^2 + bdot^2 + gdot^2) / gamma^2,   |r| = 1 / gamma
+        // and the bound reduces exactly to
+        //   gdot^2 < 2 mu gamma^3 - adot^2 - bdot^2.
         //
-        // The tangential term expands via
-        //   |rho_hat_alpha|^2 = (1+beta^2)/s^4,  |rho_hat_beta|^2 = (1+alpha^2)/s^4,
-        //   rho_hat_alpha . rho_hat_beta       = -alpha*beta/s^4,
-        // so
-        //   |adot rho_hat_alpha + bdot rho_hat_beta|^2 =
-        //       [adot^2 (1+beta^2) - 2 adot bdot alpha beta + bdot^2 (1+alpha^2)] / s^4 .
-        // At alpha = beta = 0 (the fiducial direction) this reduces to adot^2 + bdot^2.
-        const double alpha = bk.alpha;
-        const double beta = bk.beta;
-        const double gamma = bk.gamma;
-        const double adot = bk.adot;
-        const double bdot = bk.bdot;
-        const double s_sq = 1.0 + alpha * alpha + beta * beta;
-        const double s4 = s_sq * s_sq;
-        const double v_tan_sq = (adot * adot * (1.0 + beta * beta)
-                                 - 2.0 * adot * bdot * alpha * beta
-                                 + bdot * bdot * (1.0 + alpha * alpha)) / s4;
-        const double rhs = 2.0 * mu * gamma * gamma * gamma - v_tan_sq;
-        if (rhs <= 0.0)
-        {
-            // Tangential rates already exceed escape velocity for this
-            // gamma; the energy bound provides no constraint on gdot.
+        // This is the form the old header called "the familiar" one and could only
+        // claim at the fiducial direction (alpha = beta = 0).  It is now exact
+        // everywhere: the gamma^2 prefactor, the (1+alpha^2)/(1+beta^2) terms, the
+        // alpha*beta cross term and the s^4 denominator all existed only because
+        // the old gdot had different units from adot/bdot and the gnomonic tangent
+        // vectors are not unit length.
+        //
+        // Returns +infinity when the tangential rates already exceed escape, so the
+        // caller's precision 1/sigma_gdot_sq is 0 and the prior contributes nothing.
+        const double rhs = 2.0 * mu * bk.gamma * bk.gamma * bk.gamma
+                           - bk.adot * bk.adot - bk.bdot * bk.bdot;
+        if (!(rhs > 0.0))
             return std::numeric_limits<double>::infinity();
-        }
-        return gamma * gamma * rhs;
+        return rhs;
     }
 
     static void bk_basis_bindings(pybind11::module &m)
     {
         namespace py = pybind11;
 
-        py::class_<BKState>(m, "BKState")
+        py::class_<BKState>(m, "BKState",
+                            "Bernstein-Khushalani parameters at epoch, barycentric.\n\n"
+                            "(alpha, beta) are gnomonic tangent-plane coordinates of the\n"
+                            "line-of-sight direction at a fiducial direction n0, and\n"
+                            "gamma = 1/|r| with r from the barycenter.\n\n"
+                            "The dots are NOT d(alpha)/dt, d(beta)/dt, d(gamma)/dt.  They are\n"
+                            "the velocity components in the orthonormal fiducial basis,\n"
+                            "scaled by gamma:\n\n"
+                            "    adot = gamma * (v . a)\n"
+                            "    bdot = gamma * (v . b)\n"
+                            "    gdot = gamma * (v . n0)\n\n"
+                            "In particular gdot is the line-of-sight velocity -- the\n"
+                            "parameter angles-only astrometry constrains least, and the one\n"
+                            "the bound-orbit energy prior regularizes.  The coordinate rates,\n"
+                            "if you want them, are\n\n"
+                            "    d(alpha)/dt = s * (adot - alpha * gdot)\n"
+                            "    d(beta)/dt  = s * (bdot - beta  * gdot)\n"
+                            "    d(gamma)/dt = -(gamma/s) * (alpha*adot + beta*bdot + gdot)\n\n"
+                            "with s = sqrt(1 + alpha^2 + beta^2).  See issue #445.")
             .def(py::init<>())
             .def(py::init([](double alpha, double beta, double gamma,
                              double adot, double bdot, double gdot)

--- a/src/lib/orbit_fit/bk_basis.h
+++ b/src/lib/orbit_fit/bk_basis.h
@@ -9,8 +9,20 @@ namespace orbit_fit
     // Bernstein-Khushalani parameters at epoch.  Origin: barycenter.
     // (alpha, beta) are gnomonic tangent-plane coordinates of the
     // line-of-sight direction rho_hat at a fiducial direction n0,
-    // gamma = 1/|r_helio|, and (adot, bdot, gdot) are their time
-    // derivatives at the epoch.
+    // gamma = 1/|r| with r measured from the SAME origin as the struct --
+    // the barycenter (issue #444; the comment here previously said
+    // r_helio, which contradicted the line above and the implementation).
+    //
+    // (adot, bdot, gdot) are NOT the plain time derivatives of
+    // (alpha, beta, gamma).  They are the velocity components in the
+    // orthonormal fiducial basis, scaled by gamma (issue #445):
+    //
+    //     adot = gamma (v . a),  bdot = gamma (v . b),  gdot = gamma (v . n0)
+    //
+    // This is the scaling that makes all three carry the same units and the
+    // same 1/gamma weighting as the position, so the 6x6 Jacobian below has
+    // no second-derivative terms and the energy prior collapses to its
+    // familiar form.  See the derivation note accompanying issue #445.
     struct BKState
     {
         double alpha = 0.0;
@@ -40,8 +52,9 @@ namespace orbit_fit
 
     // Forward transform: BK -> barycentric Cartesian (position + velocity).
     //   r_vec = (1/gamma) * rho_hat(alpha, beta)
-    //   v_vec = (1/gamma) [adot * rho_hat_alpha + bdot * rho_hat_beta]
-    //           - (gdot/gamma^2) * rho_hat(alpha, beta)
+    //   v_vec = (1/gamma) [adot * a + bdot * b + gdot * n0]
+    // The velocity is diagonal in the fiducial basis: under the scaled
+    // convention the dots ARE its components there (issue #445).
     Eigen::Matrix<double, 6, 1> bk_to_cartesian(
         const BKState &bk, const BKFiducial &fid);
 
@@ -55,22 +68,24 @@ namespace orbit_fit
     // Block structure (each block is 3x3):
     //   [ d r / d (alpha,beta,gamma)     0                              ]
     //   [ d v / d (alpha,beta,gamma)     d v / d (adot,bdot,gdot)       ]
-    // Top-left and bottom-right blocks are identical (both arise from the
-    // (1/gamma) * tangent-vector structure).
+    // Under the scaled convention (issue #445) v depends on alpha and beta
+    // only through nothing at all -- the first two columns of the lower-left
+    // block are exactly zero, and the lower-right block is (1/gamma) times
+    // the orthonormal fiducial basis.  The second-derivative terms that the
+    // unscaled convention required are gone.
     Eigen::Matrix<double, 6, 6> dcart_dbk(
         const BKState &bk, const BKFiducial &fid);
 
     // Variance of the bound-orbit gdot prior:
-    //   sigma_gdot^2 = gamma^2 * (2 mu gamma^3 - |adot rho_hat_alpha + bdot rho_hat_beta|^2)
+    //   sigma_gdot^2 = 2 mu gamma^3 - adot^2 - bdot^2
     //
-    // The tangential-velocity term in the energy bound depends on the gnomonic
-    // tangent-vector norms at (alpha, beta), so the exact form expands to
-    //   sigma_gdot^2 = gamma^2 * (2 mu gamma^3 -
-    //                            [adot^2 (1+beta^2)
-    //                             - 2 adot bdot alpha beta
-    //                             + bdot^2 (1+alpha^2)] / s^4)
-    // where s^2 = 1 + alpha^2 + beta^2.  At the fiducial direction (alpha = beta = 0)
-    // this reduces to the familiar gamma^2 (2 mu gamma^3 - adot^2 - bdot^2).
+    // The bound-orbit condition is |v|^2 < 2 mu gamma, and under the scaled
+    // convention gamma^2 |v|^2 = adot^2 + bdot^2 + gdot^2 exactly, because
+    // (a, b, n0) is orthonormal.  So the bound becomes
+    //   gdot^2 < 2 mu gamma^3 - adot^2 - bdot^2
+    // with no dependence on (alpha, beta) at all.  The (alpha, beta)-dependent
+    // tangent-vector norms that the unscaled convention carried were an
+    // artifact of that convention, not physics (issue #445).
     //
     // Returns +infinity when the tangential rates already exceed escape (the
     // right-hand side would be non-positive), signalling "no prior."  The

--- a/src/lib/orbit_fit/bk_iod.cpp
+++ b/src/lib/orbit_fit/bk_iod.cpp
@@ -237,6 +237,29 @@ FitResult run_bk_iod(
         }
     }
 
+    // ----- Undo the s-scaling of the design matrix (issue #445) -----
+    // Under the 1/gamma-scaled convention the exact gnomonic relation carries a
+    // factor s = sqrt(1 + alpha^2 + beta^2) on three of the five columns:
+    //     x_obs = alpha + s*adot*t - gamma*s*(X - x_obs*ze) - s*gdot*(x_obs*t)
+    // The system built above is that relation with s set to 1, so its design
+    // matrix is A_true * D with D = diag(1, 1, s, s, s).  Scaling a column and
+    // dividing the matching parameter by the same factor is an exact identity
+    // for least squares -- the fit, its residuals and its chi-square are
+    // untouched -- so alpha and beta come out already correct, and with them s.
+    // No iteration is needed: one division finishes the job.
+    //
+    // This also leaves the refinement pass above correct as written.  It needs
+    // d_i = 1 - gamma*s*ze_i, and p(2) at that point IS gamma*s.
+    const double s_fac = std::sqrt(1.0 + p(0) * p(0) + p(1) * p(1));
+    Eigen::Matrix<double, 5, 1> d_inv;
+    d_inv << 1.0, 1.0, 1.0 / s_fac, 1.0 / s_fac, 1.0 / s_fac;
+    p = d_inv.asDiagonal() * p;
+    // Covariance transforms as D^-1 C D^-1; equivalently H -> D H D, which is
+    // what gets inverted below.
+    Eigen::Matrix<double, 5, 1> d_diag;
+    d_diag << 1.0, 1.0, s_fac, s_fac, s_fac;
+    H = d_diag.asDiagonal() * H * d_diag.asDiagonal();
+
     // Pack into a BKState (gdot pinned to 0).
     BKState bk;
     bk.alpha = p(0);

--- a/tests/layup/test_bk_basis.py
+++ b/tests/layup/test_bk_basis.py
@@ -140,7 +140,9 @@ def test_velocity_is_time_derivative_of_position(case):
             alpha + alpha_rate * t,
             beta + beta_rate * t,
             gamma + gamma_rate * t,
-            adot, bdot, gdot,
+            adot,
+            bdot,
+            gdot,
         )
         return np.asarray(bk_to_cartesian(state, fid)).flatten()[:3]
 

--- a/tests/layup/test_bk_basis.py
+++ b/tests/layup/test_bk_basis.py
@@ -106,24 +106,42 @@ def test_round_trip_cart_to_bk_to_cart(case):
 def test_velocity_is_time_derivative_of_position(case):
     """The Cartesian velocity from bk_to_cartesian is dr/dt along the BK motion.
 
-    Along the instantaneous BK trajectory the angular coordinates advance at
-    their rates: alpha(t) = alpha + adot*t, beta(t) = beta + bdot*t,
-    gamma(t) = gamma + gdot*t. Central-differencing the *position* part of
-    bk_to_cartesian along that motion must reproduce the *velocity* part, since
-    v is by construction d/dt of r = rho_hat(alpha, beta) / gamma.
+    Under the 1/gamma-scaled convention (issue #445) the dots are NOT the time
+    derivatives of the coordinates -- they are the velocity components in the
+    orthonormal fiducial basis, scaled by gamma. Differentiating
+    alpha = (r.a)/(r.n0), beta = (r.b)/(r.n0), gamma = 1/|r| gives the rates at
+    which the coordinates actually advance:
+
+        d(alpha)/dt = s * (adot - alpha * gdot)
+        d(beta)/dt  = s * (bdot - beta  * gdot)
+        d(gamma)/dt = -(gamma/s) * (alpha*adot + beta*bdot + gdot)
+
+    with s = sqrt(1 + alpha^2 + beta^2). Central-differencing the *position*
+    part of bk_to_cartesian along THOSE rates must reproduce the *velocity*
+    part, since v is by construction d/dt of r = rho_hat(alpha, beta) / gamma.
 
     This pins down that v is a genuine velocity (AU/day) and not a quantity
-    with anomalous units -- independent of the round-trip and Jacobian tests.
-    The unusual-looking magnitudes of the intermediate rho_hat_alpha/beta terms
-    are expected: those tangent vectors are deliberately not unit length.
+    with anomalous units -- independent of the round-trip and Jacobian tests --
+    and it independently confirms the scaling relation, since the rates above
+    are derived from the convention rather than read out of the implementation.
     """
     rng = np.random.default_rng(seed=2024)
     fid = _make_fiducial(rng)
     alpha, beta, gamma, adot, bdot, gdot = case
     v_analytic = np.asarray(bk_to_cartesian(_bk_from_tuple(case), fid)).flatten()[3:]
 
+    s = np.sqrt(1.0 + alpha * alpha + beta * beta)
+    alpha_rate = s * (adot - alpha * gdot)
+    beta_rate = s * (bdot - beta * gdot)
+    gamma_rate = -(gamma / s) * (alpha * adot + beta * bdot + gdot)
+
     def position(t):
-        state = BKState(alpha + adot * t, beta + bdot * t, gamma + gdot * t, adot, bdot, gdot)
+        state = BKState(
+            alpha + alpha_rate * t,
+            beta + beta_rate * t,
+            gamma + gamma_rate * t,
+            adot, bdot, gdot,
+        )
         return np.asarray(bk_to_cartesian(state, fid)).flatten()[:3]
 
     dt = 1e-4
@@ -168,9 +186,18 @@ def test_dcart_dbk_matches_finite_difference(case):
         cart_minus = np.asarray(bk_to_cartesian(_bk_perturb(bk, i, -eps[i]), fid)).flatten()
         J_fd[:, i] = (cart_plus - cart_minus) / (2.0 * eps[i])
 
-    # Relative tolerance covering the dynamic range of J entries.
+    # Relative tolerance covering the dynamic range of J entries.  The floor is
+    # an ABSOLUTE one, not just a guard against exact zero: entries that are
+    # numerically negligible (a fiducial basis vector with a ~1e-16 component,
+    # say) carry no information, and dividing by them turns pure round-off into
+    # a relative error of 1.  The floor is set at the central-difference noise
+    # level -- ~1e-9 of the largest entry, since differencing an O(|r|) position
+    # over a 1e-6 step loses about seven digits -- which still leaves six orders
+    # of margin below the smallest entry that carries real information (the
+    # d v / d gamma column, ~1e-2 of max here).
+    floor = 1e-9 * np.max(np.abs(J_analytic))
     scale = np.maximum(np.abs(J_analytic), np.abs(J_fd))
-    scale = np.where(scale > 0, scale, 1.0)
+    scale = np.maximum(scale, floor)
     np.testing.assert_array_less(
         np.abs(J_analytic - J_fd) / scale,
         1e-5,
@@ -272,8 +299,15 @@ def test_jacobian_at_fiducial():
     np.testing.assert_allclose(J[:3, 1], expected_col_beta, rtol=1e-13, atol=1e-15)
     np.testing.assert_allclose(J[:3, 2], expected_col_gamma, rtol=1e-13, atol=1e-15)
 
-    # Bottom-right block should equal the top-left block (same shape).
-    np.testing.assert_allclose(J[3:, 3:], J[:3, :3], rtol=1e-13, atol=1e-15)
+    # Bottom-right block d v / d(adot, bdot, gdot) is (1/gamma) times the
+    # orthonormal fiducial basis.  Under the unscaled convention this block
+    # happened to equal the top-left one; under the scaled convention (issue
+    # #445) the third column is +n0/gamma rather than -n0/gamma^2, which is
+    # exactly what removes the second-derivative terms from the Jacobian.
+    inv_g = 1.0 / gamma
+    np.testing.assert_allclose(J[3:, 3], inv_g * np.asarray(fid.a), rtol=1e-13, atol=1e-15)
+    np.testing.assert_allclose(J[3:, 4], inv_g * np.asarray(fid.b), rtol=1e-13, atol=1e-15)
+    np.testing.assert_allclose(J[3:, 5], inv_g * np.asarray(fid.n0), rtol=1e-13, atol=1e-15)
 
     # Bottom-left block should be zero when adot = bdot = gdot = 0.
     np.testing.assert_allclose(J[3:, :3], np.zeros((3, 3)), atol=1e-15)
@@ -287,10 +321,16 @@ def test_jacobian_at_fiducial():
 def test_sigma_gdot_sq_consistent_with_energy_bound():
     """sigma_gdot_sq matches the Cartesian-side bound on |gdot|^2 for a bound orbit.
 
-    Derivation: the bound-orbit energy constraint 0.5 |v|^2 <= mu / |r|
-    rearranges, in BK at fixed (alpha, beta, gamma, adot, bdot), to
-    gdot^2 <= gamma^2 * (2 * mu * gamma^3 - adot^2 - bdot^2),
-    which is exactly the formula sigma_gdot_sq returns.
+    Derivation: under the 1/gamma-scaled convention (issue #445) the fiducial
+    basis is orthonormal and the dots are gamma times the velocity components
+    in it, so gamma^2 |v|^2 = adot^2 + bdot^2 + gdot^2 exactly.  The bound-orbit
+    energy constraint 0.5 |v|^2 <= mu / |r| then rearranges, at fixed
+    (alpha, beta, gamma, adot, bdot), to
+        gdot^2 <= 2 * mu * gamma^3 - adot^2 - bdot^2,
+    which is exactly the formula sigma_gdot_sq returns -- with no residual
+    dependence on (alpha, beta).  This test is convention-agnostic: it drives
+    gdot to the stated boundary and checks the CARTESIAN two-body energy is
+    zero, so it constrains the transform and the bound together.
     """
     rng = np.random.default_rng(seed=66666)
     fid = _make_fiducial(rng)

--- a/tests/layup/test_bk_fit.py
+++ b/tests/layup/test_bk_fit.py
@@ -182,8 +182,22 @@ def test_bk_native_fit_recovers_known_state(name, state, arc_days, nobs):
         atol=1e-9,
         err_msg=f"[{name}] BK fit did not recover the truth state",
     )
-    # 2N residuals, 6 free params, noise-free obs -> chi2 essentially zero.
-    assert result.csq < 1e-12, f"[{name}] BK fit chi-square unexpectedly large: {result.csq}"
+    # 2N residuals, 6 free params, noise-free obs -> the DATA chi-square is
+    # essentially zero.  result.csq also carries the bound-orbit energy prior on
+    # gdot, and under the 1/gamma-scaled convention (issue #445) that term is no
+    # longer zero here: gdot is now gamma*(v.n0), the velocity along the fiducial
+    # line of sight, where it used to be d(gamma)/dt = -gamma^2*(r_hat.v).  These
+    # truth states are circular at the epoch (r.v = 0 exactly), so the old gdot
+    # -- and with it the prior -- vanished identically.  That was an accident of
+    # the truth states, not a property of the fit, and the old 1e-12 threshold
+    # was calibrated on it.
+    #
+    # The floor is therefore gdot^2 / sigma_gdot_sq evaluated at truth: 3.8e-9
+    # for the mainbelt case and 6.2e-12 for the TNO.  Both are far below the
+    # per-observation weight, so they are irrelevant against real astrometry
+    # (chi2 ~ 2N ~ 24 for 1" data), and the state-recovery assertion above --
+    # which is unchanged and tight -- is what actually pins the fit.
+    assert result.csq < 1e-6, f"[{name}] BK fit chi-square unexpectedly large: {result.csq}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #445. Closes #444.

The Bernstein-Khushalani dots were the plain time derivatives of the coordinates. They are now the velocity components in the orthonormal fiducial basis, scaled by gamma:

```
adot = γ (v · a),   bdot = γ (v · b),   gdot = γ (v · n₀)
```

This makes `gdot` the line-of-sight velocity — the parameter angles-only astrometry constrains least, and the one the bound-orbit energy prior exists to regularize. Under the old convention it was the barycentric radial rate, a different quantity except when n₀ ∥ r̂.

Three things fall out, and the diff is net −60 lines in `bk_basis.cpp`:

- the velocity becomes diagonal in the fiducial basis;
- `dcart_dbk` loses its entire second-derivative block, since v no longer depends on α or β;
- `sigma_gdot_sq` collapses to `2μγ³ − adot² − bdot²`, with no (α, β) dependence.

`bk_fit.cpp` needed no change — it works through the transforms generically.

**BK-IOD.** The exact relation carries a factor `s = √(1+α²+β²)` on three columns. Undoing it needs no iteration: scaling a column and dividing the matching parameter by the same factor is an exact least-squares identity, so α and β come out already correct and one division finishes it. Seed error over the 98-case diagnostic set improves from a median of 0.0126 to 0.0091, better in 59 of 84.

**#444** is fixed in the same comment block: γ was documented as `1/|r_helio|` two lines below a struct that says barycenter.

**Regression.** Fitted orbits move by at most 1.6e-5 au against a formal σ of 577 au, and covariances are unchanged to 1.6e-6 relative. Confirmed across 307 real short arcs — see the comment below.

**One test threshold moved.** `test_bk_native_fit_recovers_known_state` required `csq < 1e-12`, now `1e-6`. Its truth states are circular at epoch, so the old `gdot = −γ²(r̂·v)` vanished identically and the energy prior contributed nothing; the threshold was calibrated on that accident. The new `gdot` does not vanish, and `csq` floors at the prior evaluated at truth — which matches the converged value to seven digits, so the fit still lands on truth. The state-recovery assertion is unchanged and is what pins it.

**Found but not fixed here:** `converged()` (`orbit_fit.cpp:815`) is an absolute test applied to parameters spanning seven decades, so it is not invariant under reparameterization. Filed as #477; it is shared with the Cartesian fit, so it does not belong in this PR.
