### PR TITLE
Give the documentation a landing page (#440)

### DIFF
--- a/docs/dev_guide.rst
+++ b/docs/dev_guide.rst
@@ -1,0 +1,65 @@
+Developer guide
+===============
+
+This page is for people working *on* Layup. If you only want to use it, start
+at the :doc:`home page <index>` instead.
+
+Setting up an environment
+-------------------------
+
+Before installing any dependencies or writing code, create a virtual
+environment. LINCC-Frameworks engineers primarily use ``conda``:
+
+.. code-block:: console
+
+   >> conda create -n <env_name> python=3.11
+   >> conda activate <env_name>
+
+Alternatively, use Python's ``venv`` module:
+
+.. code-block:: console
+
+   >> python -m venv venv
+   >> source venv/bin/activate
+
+Once you have an environment, install the project for local development:
+
+.. code-block:: console
+
+   >> pip install -e .'[dev]'
+   >> pre-commit install
+   >> conda install pandoc
+
+Notes:
+
+1. The single quotes around ``'[dev]'`` may not be required for your operating
+   system.
+2. ``pre-commit install`` initializes pre-commit for this local repository, so
+   that a set of checks runs before each commit completes. For more
+   information, see the Python Project Template documentation on
+   `pre-commit <https://lincc-ppt.readthedocs.io/en/latest/practices/precommit.html>`_.
+3. Installing ``pandoc`` lets you verify that automatic rendering of Jupyter
+   notebooks into documentation works as expected. See the Python Project
+   Template documentation on
+   `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/latest/practices/sphinx.html#python-notebooks>`_.
+
+Running the tests
+-----------------
+
+.. code-block:: console
+
+   >> pytest
+
+Building the documentation
+--------------------------
+
+The Sphinx dependencies are listed in ``docs/requirements.txt`` rather than in
+the ``dev`` extra, so install them separately:
+
+.. code-block:: console
+
+   >> pip install -r docs/requirements.txt
+   >> cd docs
+   >> make html
+
+The rendered pages land in ``docs/_build/html``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,4 @@
-
 .. layup documentation main file.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
 
 .. image:: images/layup_logo.png
   :width: 410
@@ -10,53 +7,169 @@
 
 ========================================================================================
 
-Dev Guide - Getting Started
----------------------------
+**Layup** is an open-source package for orbit determination at the scale of the
+Vera C. Rubin Observatory's Legacy Survey of Space and Time (LSST). It is a
+companion to the `Sorcha <https://sorcha.readthedocs.io>`_ survey simulator.
 
-Before installing any dependencies or writing code, it's a great idea to create a
-virtual environment. LINCC-Frameworks engineers primarily use `conda` to manage virtual
-environments. If you have conda installed locally, you can run the following to
-create and activate a new environment.
+Layup is built on REBOUND/ASSIST for ephemeris-quality numerical integrations,
+with a C++ engine behind a Python command-line interface and API. It can ingest
 
-.. code-block:: console
+* optical astrometry in obs80 and ADES formats,
+* radar range and Doppler measurements,
+* streak (position + rate) measurements from shift-and-stack surveys, and
+* observations from space-based platforms,
 
-   >> conda create -n <env_name> python=3.11
-   >> conda activate <env_name>
+and it fits all of them with the same machinery. Layup offers two orbit
+parameterizations — a six-parameter Cartesian state and a Bernstein-Khushalani
+basis of distance-scaled parameters in a local tangent-plane frame — and can fit
+both gravitational and non-gravitational accelerations. Every fit reports a full
+state covariance, which Layup propagates through element and frame conversions
+and through ephemeris predictions, to support attribution and linking.
 
-Alternatively, you can create a virtual environment with python's `venv` module.
+
+Installation
+------------
+
+Layup builds a C++ extension, so installing it needs a compiler as well as a
+recent Python.
+
+============  ==================================================================
+Python        3.11 or newer
+Compiler      a C++17 compiler — Xcode command line tools on macOS,
+              ``build-essential`` or equivalent on Linux
+pip           21.3 or newer (editable installs need PEP 660 support)
+Platforms     macOS and Linux. Windows is not supported and is not tested
+Disk          about 3.2 GB free, roughly 1.5 GB of it the reference data
+              fetched by ``layup bootstrap``
+============  ==================================================================
+
+.. warning::
+
+   Do **not** install Layup with ``pip install layup``. The ``layup`` name on
+   PyPI currently holds an unrelated placeholder package, so that command
+   succeeds and installs nothing, with no error. Install from source as below
+   until the first release is published.
+
+It is a good idea to create a virtual environment first:
 
 .. code-block:: console
 
    >> python -m venv venv
    >> source venv/bin/activate
 
-Once you have created a new environment, you can install this project for local
-development using the following commands:
+Then clone and install:
 
 .. code-block:: console
 
-   >> pip install -e .'[dev]'
-   >> pre-commit install
-   >> conda install pandoc
+   >> git clone https://github.com/Smithsonian/layup.git
+   >> cd layup
+   >> pip install .
+
+If that fails with *"File setup.py or setup.cfg not found"*, your pip predates
+PEP 660 — run ``pip install --upgrade pip`` first. The ``python3`` shipped with
+macOS is too old; install a newer Python before creating the environment.
 
 
-Notes:
+Quickstart
+----------
 
-1) The single quotes around ``'[dev]'`` may not be required for your operating system.
-2) ``pre-commit install`` will initialize pre-commit for this local repository, so
-   that a set of tests will be run prior to completing a local commit. For more
-   information, see the Python Project Template documentation on
-   `pre-commit <https://lincc-ppt.readthedocs.io/en/latest/practices/precommit.html>`_.
-3) Installing ``pandoc`` allows you to verify that automatic rendering of Jupyter notebooks
-   into documentation for ReadTheDocs works as expected. For more information, see
-   the Python Project Template documentation on
-   `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/latest/practices/sphinx.html#python-notebooks>`_.
+Layup needs SPICE planetary kernels, the small-body kernel, MPC observatory
+codes, and the astrometry debiasing tables. Download them once with:
 
+.. code-block:: console
+
+   >> layup bootstrap
+
+This fetches roughly 1 GB, which expands to about 1.5 GB on disk.
+
+Fit an orbit
+^^^^^^^^^^^^
+
+Layup bundles a demo dataset. Copy it into your working directory and print the
+matching example command:
+
+.. code-block:: console
+
+   >> layup demo prepare orbitfit
+   >> layup demo howto orbitfit
+
+``prepare`` writes ``holman_data_working.csv`` — 4135 astrometric observations
+of asteroid (3666) Holman, in ADES CSV form — to the current directory, and
+``howto`` prints the ready-to-run command. Fit it with:
+
+.. code-block:: console
+
+   >> layup orbitfit holman_data_working.csv ADES_csv -o demo_orbitfit_output
+
+This writes the best-fit barycentric Cartesian orbit and its covariance to
+``demo_orbitfit_output.csv``. Supported input formats are ``MPC80col``,
+``ADES_csv``, ``ADES_psv``, ``ADES_xml``, and ``ADES_hdf5``.
+
+Convert and predict
+^^^^^^^^^^^^^^^^^^^
+
+Convert the result to another orbit representation (Cometary, Keplerian, …):
+
+.. code-block:: console
+
+   >> layup convert demo_orbitfit_output.csv KEP -o demo_orbit_kep
+
+Predict future on-sky positions, with uncertainties, for an observatory:
+
+.. code-block:: console
+
+   >> layup predict demo_orbitfit_output.csv --days 30 --station X05 -o my_predictions
+
+Every verb takes ``--help`` for its full set of options — engine choice, IOD
+method, non-gravitational parameters, parallel workers, and so on:
+
+.. code-block:: console
+
+   >> layup orbitfit --help
+
+
+Where to go next
+----------------
+
+* The same load → fit → convert → predict workflow is available from Python.
+  The :doc:`orbit fitting API notebook <notebooks/orbit_fitting_api>` works
+  through it end to end.
+* :doc:`Controlling parallelism <parallelism>` — how Layup sizes its worker
+  pool, and how to stop it oversubscribing a shared machine.
+* `API Reference <autoapi/index.html>`_ — every public module, class and
+  function.
+* :doc:`Developer guide <dev_guide>` — setting up a development environment and
+  running the tests.
+
+.. note::
+
+   A plain install does not include Jupyter; it lives in the ``dev`` extra. To
+   run the notebooks locally, install with ``pip install -e ".[dev]"``.
+
+
+Citing Layup
+------------
+
+If Layup contributes to work you publish, please cite it. Citation details will
+be listed here with the first release.
+
+
+Getting help
+------------
+
+Please open an issue at
+`github.com/Smithsonian/layup/issues <https://github.com/Smithsonian/layup/issues>`_
+for bug reports, questions, and feature requests.
+
+.. Once Smithsonian/layup#466 merges, link CONTRIBUTING.md, CODE_OF_CONDUCT.md
+   and SUPPORT.md from this section -- they do not exist on main yet, so they
+   are deliberately not linked.
 
 .. toctree::
    :hidden:
 
    Home page <self>
    Controlling parallelism <parallelism>
-   API Reference <autoapi/index>
    Notebooks <notebooks>
+   API Reference <autoapi/index>
+   Developer guide <dev_guide>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,24 +7,33 @@
 
 ========================================================================================
 
-**Layup** is an open-source package for orbit determination at the scale of the
-Vera C. Rubin Observatory's Legacy Survey of Space and Time (LSST). It is a
-companion to the `Sorcha <https://sorcha.readthedocs.io>`_ survey simulator.
+.. This paragraph is M.J.H.'s, taken from the Layup paper's Summary. Keep the two
+   in step: if the paper's summary changes, change this with it. The only edits
+   made here were dropping the paper's citation keys and setting Layup in RST
+   literal markup.
 
-Layup is built on REBOUND/ASSIST for ephemeris-quality numerical integrations,
-with a C++ engine behind a Python command-line interface and API. It can ingest
+The Vera C. Rubin Observatory's Legacy Survey of Space and Time (LSST) is under
+way. The LSST is expected to raise the number of known solar system objects in
+the Minor Planet Center's catalogs to roughly 127,000 near-Earth objects (NEOs),
+5.1 million main-belt asteroids (MBAs), 1200–2000 Centaurs, and 37,000
+trans-Neptunian objects (TNOs) — a four- to nine-fold increase over the currently
+known populations. The solar system community needs efficient tools to maximize
+the scientific yield of the survey.
 
-* optical astrometry in obs80 and ADES formats,
-* radar range and Doppler measurements,
-* streak (position + rate) measurements from shift-and-stack surveys, and
-* observations from space-based platforms,
-
-and it fits all of them with the same machinery. Layup offers two orbit
-parameterizations — a six-parameter Cartesian state and a Bernstein-Khushalani
-basis of distance-scaled parameters in a local tangent-plane frame — and can fit
-both gravitational and non-gravitational accelerations. Every fit reports a full
-state covariance, which Layup propagates through element and frame conversions
-and through ephemeris predictions, to support attribution and linking.
+``Layup`` is an open-source package for orbit determination at LSST scale that
+serves as a companion to the `Sorcha <https://sorcha.readthedocs.io>`_ survey
+simulator. ``Layup`` is built on REBOUND/ASSIST for ephemeris-quality numerical
+integrations, with a C++ engine and a Python command-line interface and API. It
+can ingest astrometry in obs80 and ADES formats, as well as radar range and
+Doppler observations, streak (position + rate) measurements from shift-and-stack
+surveys, and space-based observations. ``Layup`` provides two orbit
+parameterizations — a 6-parameter Cartesian state and a Bernstein-Khushalani
+basis (distance-scaled parameters in a local tangent-plane reference frame) — and
+can fit both gravitational and non-gravitational accelerations. Gauss and
+Bernstein-Khushalani initial orbit determination (IOD) are included, and
+additional IOD methods can be added easily. Every ``Layup`` fit reports a full
+state covariance, which it propagates through element and frame conversions and
+through ephemeris predictions to support attribution and linking.
 
 
 Installation


### PR DESCRIPTION
Toward #440 — a first pass, not the whole issue. **#440 deliberately stays open**; see the last section. (Worded carefully on purpose: GitHub's auto-close parser reads a closing keyword sitting immediately before an issue number and ignores any negation wrapped around it, so the obvious phrasing would have shut the issue on merge.)

## The problem

The published front page at [layup.readthedocs.io](https://layup.readthedocs.io/en/latest/)
is still the LINCC project template's boilerplate. Its only heading is
**"Dev Guide - Getting Started"** and its first instruction is `conda create`.

It never says what Layup is, how a user installs it, or shows it doing
anything. A reader arriving from the paper or from the repository lands on
contributor bootstrap instructions for a package whose purpose is never stated.

This matters now because it is one of the things a JOSS reviewer checks
directly: whether the documentation states the need, gives installation
instructions, and includes example usage.

## The fix is mostly assembly, not writing

Everything else in the docs already exists and builds: the autoapi API
reference, the notebooks, the parallelism page. And the missing content was
already written — the README has a requirements table and a three-part
quickstart, and the JOSS paper has a statement of need that has been through
review. None of it was ever wired into the landing page.

So this PR assembles a real one:

- **what Layup is**, and the four observation types it ingests, condensed from
  the paper's summary;
- **installation**, with the requirements table from the README;
- **a quickstart** — `layup bootstrap`, then the bundled (3666) Holman demo
  through `orbitfit`, `convert` and `predict`;
- **where to go next** — the API notebook, parallelism, the API reference, and
  the developer guide.

The developer setup that used to *be* the front page is not deleted, just moved
to `docs/dev_guide.rst` and labelled for contributors, which is what it always
was.

## Two things worth your attention

**1. The install section deliberately does not say `pip install layup`,** and
carries a warning box saying so.

That command currently *succeeds* and installs a 1.3 kB placeholder: the
`layup` name on PyPI holds version 0.0.1, uploaded 2025-01-09 — four days
before this repository's first commit — containing an empty `__init__.py` with
no dependencies. A reader following it would get a silent no-op, then find that
nothing works, and reasonably conclude the package is broken. That is worse
than giving no instructions at all.

This is the same fact behind the PyPI badge being commented out of the README.
The section should change to `pip install layup` **in the same PR that
publishes the first real release** (#436 / #471), not before and not after.

**2. The Sphinx dependencies are in `docs/requirements.txt`, not the `dev`
extra.** `pip install -e .'[dev]'` does not let you build the documentation,
though the old front page implied it did (it told you to install pandoc so that
notebook rendering "works as expected"). The new developer guide says where
they actually live.

## Testing

Built locally with Sphinx. Both new pages render with no warnings of their own,
and the toctree resolves. The notebooks need `pandoc`, which is not installed
on this machine, so that part of the build was excluded from the check — it is
untouched by this change, and CI builds it.

## Deliberately left out

- **Community-file links.** `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` and
  `SUPPORT.md` do not exist on `main` yet; they arrive with #466. An RST
  comment marks the spot so the link is a one-line follow-up rather than a
  rediscovery.
- **A citation.** The "Citing Layup" section is a placeholder pointing at the
  first release, since there is no DOI yet.

## Why #440 stays open

#440 is "review/update of read the docs documentation" — broader than the front
page. At least one thing surfaced while building that belongs to it rather than
here: the autoapi-generated API reference emits a substantial number of
docstring formatting errors (unexpected section titles, undefined substitutions
such as `|r|` being read as a substitution reference, definition lists ending
without a blank line). Those are real defects in the rendered API pages, but
they are fixes to docstrings across the source tree, not to the landing page,
and they should not hold up the front door.
