### PR TITLE
Fix the docstrings that render broken in the API reference (#440)

### DIFF
--- a/src/layup/comet.py
+++ b/src/layup/comet.py
@@ -318,24 +318,24 @@ def comet_cli(
     """
     Determines original orbit for comets with support for parallel processing.
 
-     Note that the output file will be written in the caller's current working directory.
+    Note that the output file will be written in the caller's current working directory.
 
-     Parameters
-     ----------
-     input : str
-         The path to the input file.
-     output_file_stem : str
-         The stem of the output file.
-     file_format : str, optional (default="csv")
-         The format of the output file. Must be one of: "csv", "hdf5"
-     chunk_size : int, optional (default=10_000)
-         The number of rows to read in at a time.
-     num_workers : int, optional (default=-1)
-         The number of workers to use for parallel processing of the individual
-         chunk. If -1, the number of workers will be set to the number of CPUs on
-         the system.
-     cli_args : argparse, optional (default=None)
-         The argparse object that was created when running from the CLI.
+    Parameters
+    ----------
+    input : str
+        The path to the input file.
+    output_file_stem : str
+        The stem of the output file.
+    file_format : str, optional (default="csv")
+        The format of the output file. Must be one of: "csv", "hdf5"
+    chunk_size : int, optional (default=10_000)
+        The number of rows to read in at a time.
+    num_workers : int, optional (default=-1)
+        The number of workers to use for parallel processing of the individual
+        chunk. If -1, the number of workers will be set to the number of CPUs on
+        the system.
+    cli_args : argparse, optional (default=None)
+        The argparse object that was created when running from the CLI.
     """
 
     input_file = Path(input)

--- a/src/layup/iod.py
+++ b/src/layup/iod.py
@@ -118,7 +118,7 @@ register_iod("gauss", gauss_iod)
 def _passes_physical_bounds(candidate, min_r_au: float = _MIN_R_AU, max_r_au: float = _MAX_R_AU) -> bool:
     """Cheap algebraic feasibility check on an IOD candidate state.
 
-    Rejects candidates with non-positive r² or |r| outside [min, max]
+    Rejects candidates with non-positive r² or ``|r|`` outside [min, max]
     AU. Deliberately does *not* reject hyperbolic-looking velocities:
     Gauss's velocity can be wildly wrong even for the correct
     geometric root, and LM walks those to convergence routinely.
@@ -155,7 +155,7 @@ def _predict_rho_hat(ephem, state, state_epoch, obs):
 
 
 def _inertial_min_geocentric_AU(state, state_epoch, observations) -> float:
-    """Smallest |candidate - observer| over the observation arc, treating
+    """Smallest ``|candidate - observer|`` over the observation arc, treating
     candidate motion as inertial (position + velocity·Δt).
 
     Used to detect candidates whose trajectory passes close to Earth (or

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -806,8 +806,10 @@ def _pick_best_root(candidates, min_r_au):
     """Pick the best converged candidate from a list of LM results.
 
     "Best" means smallest χ² among candidates that
-      (1) report flag == 0 (LM converged), and
-      (2) have heliocentric distance > min_r_au (physical orbit).
+
+    1. report ``flag == 0`` (LM converged), and
+    2. have heliocentric distance > ``min_r_au`` (physical orbit).
+
     Returns None if no candidate satisfies (1); in that case the caller
     typically retries at a larger LM budget. If (1) is met but (2)
     isn't, the smallest-χ² convergent root is still returned (better

--- a/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
+++ b/src/layup/utilities/bootstrap_utilties/create_meta_kernel.py
@@ -27,7 +27,8 @@ from layup.utilities.layup_configs import AuxiliaryConfigs
 
 
 def _split_kernel_path_str(abspath: str, split=77):
-    """If abspath string is longer than 77 chars, split it up in the meta kernel by inserting "+',\n'".
+    r"""If abspath string is longer than 77 chars, split it up in the meta kernel by inserting "+',\n'".
+
     77 is the default because the character limit in SPICE is 80 before the string needs split.
 
     Parameters
@@ -36,10 +37,11 @@ def _split_kernel_path_str(abspath: str, split=77):
         The filepath string that needs split.
     Split : int
         The maximum size each part of the filepath can be before it needs split.
+
     Returns
-    ---------
+    -------
     abspath : str
-    The filepath string split into chunks of required size.
+        The filepath string split into chunks of required size.
     """
 
     n_iter = int(len(str(abspath)) / split)  # Number of splits required

--- a/src/layup/utilities/layup_logging.py
+++ b/src/layup/utilities/layup_logging.py
@@ -17,31 +17,33 @@ class LayupLogger:
 
     Example 1 - LayupLogger in a command line verb
     (See layup_cmdline/log.py for a working example)
-    ```
-    def execute():
-        from layup.utilities.layup_logging import LayupLogger
 
-        layup_logger = LayupLogger()
+    .. code-block:: python
 
-        # Create a child logger. NOTE - that the name starts with "layup.<blah>"
-        # Failure to specify a name with that form could result in lost logs.
-        logger = layup_logger.get_logger("layup.log_cmdline")
+        def execute():
+            from layup.utilities.layup_logging import LayupLogger
 
-        logger.info("Sending a log message.")  # Use the logger
-    ```
+            layup_logger = LayupLogger()
+
+            # Create a child logger. NOTE - that the name starts with "layup.<blah>"
+            # Failure to specify a name with that form could result in lost logs.
+            logger = layup_logger.get_logger("layup.log_cmdline")
+
+            logger.info("Sending a log message.")  # Use the logger
 
     Example 2 - LayupLogger in a context manager
     This would likely be the usage within a Jupyter notebook
-    ```
-    from layup.utilities.layup_logging import LayupLogger
 
-    with LayupLogger() as layup_logger:
-        # Create a child logger. NOTE - that the name starts with "layup.<blah>"
-        # Failure to specify a name with that form could result in lost logs.
-        logger = layup_logger.get_logger("layup.interactive")
+    .. code-block:: python
 
-        logger.info("Sending a log message from a notebook.")
-    ```
+        from layup.utilities.layup_logging import LayupLogger
+
+        with LayupLogger() as layup_logger:
+            # Create a child logger. NOTE - that the name starts with "layup.<blah>"
+            # Failure to specify a name with that form could result in lost logs.
+            logger = layup_logger.get_logger("layup.interactive")
+
+            logger.info("Sending a log message from a notebook.")
     """
 
     def __init__(self, log_directory="."):


### PR DESCRIPTION
Toward #440. Does not close it.

Docstring text only — **no code changes**, `black --check` clean, and the touched
modules' tests pass.

## What was wrong

The autoapi-generated API reference emitted **18 docutils warnings and errors**. These
are not cosmetic: each one means a docstring renders wrongly on the published site,
and the API reference is what a JOSS reviewer clicks through to check that the
functionality is documented.

Five root causes:

**1. Markdown fences in an RST docstring** — `layup_logging.LayupLogger` wrapped its two
usage examples in ``` fences. RST reads that as an unterminated inline literal. This
alone accounted for **8 of the 18 messages**, and the two examples rendered as
run-together prose rather than code. Now `.. code-block:: python`.

**2. A `\n` escape in a non-raw docstring** — `create_meta_kernel._split_kernel_path_str`
documents that it inserts `"+',\n'"`. In a normal (non-raw) docstring Python turns that
`\n` into a *real newline*, breaking the summary line in half. Everything after it became
an indented block, which is why its `Parameters` and `Returns` headings were reported as
unexpected section titles. The docstring is now raw, so the `\n` stays the two characters
the author meant. Its `Returns` section was also missing a preceding blank line and its
return description was not indented — both fixed.

**3. Notation parsed as markup, and silently dropped** — `iod._passes_physical_bounds`
and `iod._inertial_min_geocentric_AU` write `|r|` and `|candidate - observer|`. RST reads
`|...|` as a **substitution reference**; undefined, so the notation vanished from the
rendered page and the reader saw a sentence with a hole in it. Now inline literals.

**4. One stray space** — `comet.comet_cli`'s docstring is indented five spaces from its
second line onward while the summary is indented four. That made the whole body an
indented block and its `Parameters` heading an unexpected section title.

**5. A list that unindented without a blank line** — `orbitfit._pick_best_root`'s (1)/(2)
enumeration ended a definition list mid-flow. Now a proper RST enumerated list.

## Verification

Built the docs before and after: **18 docstring warnings → 0.**

The notebooks need `pandoc`, which is not installed on this machine, so they were
excluded from *both* builds — they are untouched by this change and CI builds them. The
~84 autoapi `python_import_resolution` warnings are a separate pre-existing issue, are
unchanged, and are not addressed here.

`tests/layup/test_comet.py::test_comet_output` fails locally, but it fails identically on
`main` with this branch's changes stashed: it shells out to `layup` on PATH, which on this
machine is a conda build that cannot `dlopen` librebound. Different install than the one
being changed.

## One thing deliberately NOT fixed

`create_meta_kernel.py` has a module-level string literal **after** its imports (lines
6–26, the example meta-kernel output). Because it is not the first statement in the file
it is not the module docstring — it is a no-op expression, and none of it reaches the
documentation. Moving it above the imports would publish it, which changes *what the page
says* rather than how it renders. That is a call for whoever knows the intent, so I left
it.

## Relationship to #478

Independent. #478 rewrites the documentation landing page (`docs/*.rst`); this changes
docstrings in `src/`. They touch no common files and can merge in either order.
