### PR TITLE
Only create the .err log file if something is logged to it (#481)

### DIFF
--- a/src/layup/utilities/layup_logging.py
+++ b/src/layup/utilities/layup_logging.py
@@ -11,6 +11,9 @@ class LayupLogger:
     3) layup-<datetime>.err depending on the log level. See the `_prepare_logger`
     method for details about which levels are sent to which handlers.
 
+    The .err file is created lazily: it appears only if something is actually
+    logged at ERROR or above, so a clean run does not leave an empty one.
+
     LayupLogger is intended to be used in one of two ways in general. Either
     instantiated within the `execute()` function in one of the layup_cmdline verbs
     or as a context manager when calling the API directly.
@@ -118,8 +121,10 @@ class LayupLogger:
         file_handler_info.setFormatter(formatter)
         file_handler_info.setLevel(logging.DEBUG)
 
-        # File handler that will record all messaged >= ERROR
-        file_handler_error = logging.FileHandler(log_file_error)
+        # File handler that will record all messaged >= ERROR.
+        # delay=True defers creating the file until a record is actually emitted,
+        # so a run that logs nothing at ERROR leaves no empty .err behind (#481).
+        file_handler_error = logging.FileHandler(log_file_error, delay=True)
         file_handler_error.setFormatter(formatter)
         file_handler_error.setLevel(logging.ERROR)
 

--- a/tests/layup/test_layup_logging.py
+++ b/tests/layup/test_layup_logging.py
@@ -1,0 +1,55 @@
+"""Tests for LayupLogger's file handlers.
+
+The .err file is created lazily (issue #481): following the documented
+quickstart used to leave an empty layup-<timestamp>.err beside every command,
+which reads as though something had gone wrong on a run that succeeded.
+"""
+
+import logging
+
+import pytest
+
+from layup.utilities.layup_logging import LayupLogger
+
+
+@pytest.fixture
+def clean_layup_logger():
+    """Remove any handlers LayupLogger has already attached, and restore them after.
+
+    LayupLogger configures the shared top-level ``layup`` logger, so without this
+    a second instantiation in the same process stacks handlers on top of the
+    first and the tests see each other's output.
+    """
+    top = logging.getLogger("layup")
+    saved = top.handlers[:]
+    top.handlers = []
+    yield
+    for h in top.handlers:
+        h.close()
+    top.handlers = saved
+
+
+def test_no_err_file_when_nothing_is_logged_at_error(tmp_path, clean_layup_logger):
+    """A run that logs nothing at ERROR leaves no .err file behind."""
+    logger = LayupLogger(log_directory=str(tmp_path)).get_logger("layup.test")
+    logger.info("an ordinary run")
+    logger.warning("a warning is not an error")
+
+    assert list(tmp_path.glob("*.log")), "the .log file should always be written"
+    assert not list(tmp_path.glob("*.err")), (
+        "an .err file was created for a run that logged nothing at ERROR: "
+        f"{[p.name for p in tmp_path.glob('*.err')]}"
+    )
+
+
+def test_err_file_is_written_when_an_error_is_logged(tmp_path, clean_layup_logger):
+    """An ERROR still produces an .err file, containing the message."""
+    logger = LayupLogger(log_directory=str(tmp_path)).get_logger("layup.test")
+    logger.info("starting")
+    logger.error("something actually went wrong")
+
+    err = list(tmp_path.glob("*.err"))
+    assert len(err) == 1, f"expected exactly one .err file, got {[p.name for p in err]}"
+    contents = err[0].read_text()
+    assert "something actually went wrong" in contents
+    assert "starting" not in contents, "the .err file should carry only ERROR and above"


### PR DESCRIPTION
Addresses the **second** half of #481 — the empty `.err` files. The first half, whether the `log` verb should remain on the user-facing CLI, is a decision about the CLI surface and is with the team, so nothing here touches it.

## The problem

Following the documented quickstart left an empty `layup-<timestamp>.err` beside every command:

```
demo_orbit_kep.csv                 layup-2026-08-24-19-40-18.err
demo_orbitfit_output.csv           layup-2026-08-24-19-40-18.log
holman_data_working.csv            layup-2026-08-24-19-40-33.err
layup-2026-08-24-19-39-18.err      layup-2026-08-24-19-40-33.log
layup-2026-08-24-19-39-18.log      layup-2026-08-24-19-40-38.err
my_predictions.csv                 layup-2026-08-24-19-40-38.log
```

Eight log files against four real outputs, and **four of the eight `.err` files were empty**. A user who did everything correctly gets an error log for every step, which invites the thought that something went wrong.

## The fix

`logging.FileHandler` opens its file eagerly, so the `.err` was created whether or not anything was ever written to it. `delay=True` defers the open until a record is actually emitted — which is precisely the intended semantics: the file appears if and only if something was logged at ERROR or above.

One line, plus a comment and a docstring note.

The `.log` handler is deliberately left eager: it always receives INFO records, so delaying it would change nothing.

## Tests

Adds `tests/layup/test_layup_logging.py` — the first tests to cover the logger at all:

- a clean run (INFO + WARNING) leaves **no** `.err`;
- an ERROR still produces the file, and it carries only ERROR and above.

**Both were confirmed to fail with `delay=True` removed**, rather than assumed to be testing something. That check felt worth doing explicitly given #467 recently had to arm four assertions that were passing without asserting anything.

The tests share a fixture that strips handlers from the top-level `layup` logger. `LayupLogger` configures a shared logger, so without it a second instantiation in the same process stacks handlers on the first and the tests observe each other's output.

## How this was found

A clean-room fresh-user run-through on `main` @ `719761c` — fresh clone, fresh venv, following only the published instructions. Worth recording that the rest of that run passed: clone, `pip install -e .`, `bootstrap`, `demo prepare`/`howto`, `orbitfit`, `convert` and `predict` all succeeded, and the fitted elements for (3666) Holman match JPL SBDB to 8e-7 in *a*, 1e-4 in *e* and 9e-6 in *i*.

## Not addressed here

There is still no way to redirect the log directory — the files land in the current working directory unconditionally. That probably belongs with #448's cache-location setting rather than getting its own mechanism, so it is deliberately left out.
