### PR TITLE
Document the orbitfit status flags

### DIFF
--- a/docs/fit_flags.rst
+++ b/docs/fit_flags.rst
@@ -1,13 +1,63 @@
-Orbit fit status flags
+Orbit fit status
 ========================================================================================
 
-Every fit that ``layup orbitfit`` produces carries an integer ``flag`` column
-reporting how the fit ended. The values are listed below, together with the part
-of the code that sets each one.
+Every fit that ``layup orbitfit`` produces reports its outcome in six columns: a
+single-value summary, ``flag``, and five columns that report the individual facts
+behind it.
 
-``flag = 0`` means the differential correction converged and the result passed
-the quality gates that are currently applied. It does not assert that the orbit
-is physically plausible; see :ref:`flag-groups` below.
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Column
+     - Meaning
+   * - ``flag``
+     - Summary. ``0`` if and only if the fit converged and passed every check.
+   * - ``converged``
+     - ``1`` if the differential correction reached a solution. A fit can converge
+       and still be rejected, so this is not the same as ``flag == 0``.
+   * - ``stage``
+     - How far the fitting pipeline got before it stopped. See below.
+   * - ``failed_csq``
+     - ``1`` if the fit converged but its chi-square per degree of freedom is above
+       the acceptance threshold.
+   * - ``failed_cov``
+     - ``1`` if the fit converged but its covariance is degenerate, or a variance is
+       non-positive.
+   * - ``failed_physical``
+     - ``1`` if the fit converged but describes an orbit no real object could occupy.
+       Reserved: the check itself is not applied yet, so this column is currently
+       always ``0``.
+
+The three ``failed_*`` columns are named for their polarity: each is ``1`` when the
+fit *failed* that check. A clean fit is therefore zero across all of them, which
+matches ``flag == 0``.
+
+Which column should I filter on?
+----------------------------------------------------------------------------------------
+
+**For orbits you intend to use, filter on** ``flag == 0``. That is the summary, it
+means the fit converged and every check passed, and it is what the rest of ``layup``
+uses internally.
+
+Read the other columns when you need to know *why* something was rejected — for
+triage, for diagnosing a survey's failure modes, or to accept fits that failed a
+particular check on purpose.
+
+.. warning::
+
+   **Do not filter on** ``flag == 2`` **or** ``flag == 6`` **to count rejections.**
+   They under-report. ``flag`` records a single outcome, and where a fit stopped
+   takes precedence over why it was rejected: a candidate that converged and was
+   then rejected on chi-square is reported as ``3`` or ``4`` if the pipeline went on
+   to run out of candidates or fail its build-up. The ``failed_csq`` and
+   ``failed_cov`` columns do not have this problem — they record the fitter's own
+   verdict before any of that happens. Count rejections there.
+
+Values of ``flag``
+----------------------------------------------------------------------------------------
+
+The values are an enumeration, not a severity ordering.
 
 .. list-table::
    :header-rows: 1
@@ -18,64 +68,67 @@ is physically plausible; see :ref:`flag-groups` below.
    * - ``-1``
      - Not attempted. A placeholder written for rows that were never fit.
    * - ``0``
-     - Converged and accepted.
+     - Converged, and passed every check.
    * - ``1``
-     - Did not converge. This is the initial value, left in place when nothing
-       better is reached.
+     - The differential correction did not converge.
    * - ``2``
-     - Converged, but the chi-square per degree of freedom is above threshold.
-       A quality gate applied to a fit that did converge.
+     - Converged; chi-square per degree of freedom above threshold. See the warning
+       above before counting these.
    * - ``3``
-     - Initial orbit determination (IOD) produced candidates, but none of them
-       converged on the primary interval. The least-bad attempt, by chi-square,
-       is returned so that the caller has something to inspect.
+     - Initial orbit determination produced candidate orbits, but none of them
+       converged on the primary interval. The least-bad attempt, by chi-square, is
+       returned so the caller has something to inspect.
    * - ``4``
      - The primary interval converged, but the incremental build-up to the full
-       set of observations failed partway. The flag is set at the segment where
-       it broke.
+       observation set failed partway.
    * - ``5``
-     - No solution at all. Either the IOD returned no candidates and
-       ``iod='auto'`` was not in use, so there was no fallback, or ``'auto'``
-       produced no Gauss roots and no usable Bernstein-Khushalani seed.
+     - No solution at all: initial orbit determination produced no candidates and no
+       fallback seed was usable.
    * - ``6``
-     - Converged, but weakly constrained: the covariance is degenerate, or a
-       variance is non-positive.
+     - Converged; covariance degenerate, or a variance non-positive. See the warning
+       above before counting these.
    * - ``7``
-     - Incremental update only. The prior covariance was not positive-definite,
-       so the information update is ill-posed and the driver falls back to a
-       full refit over all observations.
+     - Incremental update only. The prior covariance was not positive-definite, so
+       the information update is ill-posed and the driver falls back to a full refit.
    * - ``8``
-     - Incremental update applied without a full set of observations supplied
-       for the refit. Bookkeeping rather than a fit failure.
+     - Incremental update applied without a full observation set supplied for the
+       refit. Bookkeeping rather than a fit failure.
 
-.. _flag-groups:
-
-What the groups mean
+Values of ``stage``
 ----------------------------------------------------------------------------------------
 
-The values are an enumeration, not a severity ordering. They fall into four
-groups:
+How far the pipeline got. Unlike ``flag``, this says nothing about whether the
+result was accepted.
 
-Converged and accepted
-   ``0``.
+.. list-table::
+   :header-rows: 1
+   :widths: 8 92
 
-Converged, but rejected by a gate
-   ``2`` and ``6``. The differential correction reached a solution, which was
-   then rejected — on chi-square per degree of freedom, or on a degenerate
-   covariance.
-
-Never converged
-   ``1``, ``3``, ``4``, ``5`` and ``7``. These distinguish where along the
-   initial orbit determination and incremental-fit path the attempt stopped.
-
-Bookkeeping
-   ``-1`` and ``8``. Neither reports on the quality of a fit.
+   * - Stage
+     - Meaning
+   * - ``0``
+     - Not attempted.
+   * - ``1``
+     - Initial orbit determination produced nothing usable, so nothing was fit.
+   * - ``2``
+     - Reached the fit over the primary interval.
+   * - ``3``
+     - Reached the incremental build-up to all observations.
+   * - ``4``
+     - Fit the full observation set.
+   * - ``5``
+     - Sequential-update bookkeeping rather than a fresh fit.
 
 .. note::
 
-   The gates behind ``flag = 2`` and ``flag = 6`` are statistical, not physical.
-   A fit can converge, sit comfortably inside both gates, and still describe an
-   orbit that is not physically plausible — for example one implying an
-   absolute magnitude far fainter than any object the survey could have
-   detected. Short arcs are the usual case. Treat ``flag = 0`` as "the
-   estimator succeeded", not as "the orbit is real".
+   **A converged fit is not necessarily a real orbit.** The checks behind
+   ``failed_csq`` and ``failed_cov`` are statistical: they ask whether the estimator
+   behaved, not whether the answer is physically possible. A short arc can converge
+   with an excellent chi-square onto a state no object could occupy, because the arc
+   does not constrain the velocity — and chi-square cannot catch it, since the less
+   the object moves across the arc the better the fit. ``failed_physical`` is
+   reserved for that check. Until it is applied, treat ``flag == 0`` as "the
+   estimator succeeded", not as "the orbit is real", and screen short arcs yourself.
+
+The values are defined once, in ``layup.constants``, as ``FLAG_*``, ``STAGE_*`` and
+``OUTCOME_COLUMNS``.

--- a/docs/fit_flags.rst
+++ b/docs/fit_flags.rst
@@ -25,9 +25,8 @@ behind it.
      - ``1`` if the fit converged but its covariance is degenerate, or a variance is
        non-positive.
    * - ``failed_physical``
-     - ``1`` if the fit converged but describes an orbit no real object could occupy.
-       Reserved: the check itself is not applied yet, so this column is currently
-       always ``0``.
+     - ``1`` if the fit converged but describes an orbit no real object could occupy:
+       its hyperbolic excess speed is implausibly large.
 
 The three ``failed_*`` columns are named for their polarity: each is ``1`` when the
 fit *failed* that check. A clean fit is therefore zero across all of them, which
@@ -93,6 +92,8 @@ The values are an enumeration, not a severity ordering.
    * - ``8``
      - Incremental update applied without a full observation set supplied for the
        refit. Bookkeeping rather than a fit failure.
+   * - ``9``
+     - Converged, but the orbit is not physically possible. See the note below.
 
 Values of ``stage``
 ----------------------------------------------------------------------------------------
@@ -121,14 +122,22 @@ result was accepted.
 
 .. note::
 
-   **A converged fit is not necessarily a real orbit.** The checks behind
+   **The physical check is a floor, not a guarantee.** The checks behind
    ``failed_csq`` and ``failed_cov`` are statistical: they ask whether the estimator
-   behaved, not whether the answer is physically possible. A short arc can converge
-   with an excellent chi-square onto a state no object could occupy, because the arc
-   does not constrain the velocity — and chi-square cannot catch it, since the less
-   the object moves across the arc the better the fit. ``failed_physical`` is
-   reserved for that check. Until it is applied, treat ``flag == 0`` as "the
-   estimator succeeded", not as "the orbit is real", and screen short arcs yourself.
+   behaved, not whether the answer is possible. A short arc can converge with an
+   excellent chi-square onto a state no object could occupy, because the arc does
+   not constrain the velocity — and chi-square cannot catch it, since the less the
+   object moves across the arc the better the fit.
+
+   ``failed_physical`` catches the extreme case, on hyperbolic excess speed. The
+   threshold is deliberately generous: layup is expected to fit genuine interstellar
+   objects, which are unbound and fast — 3I/ATLAS arrives at about 59 km/s — so being
+   unbound is never itself grounds for rejection, and the default sits well above any
+   plausible arrival speed. It will therefore accept short-arc orbits that are
+   implausible without being impossible. Screen short arcs on your own criteria as
+   well. The threshold is ``MAX_EXCESS_SPEED_KM_S`` in ``layup.constants``; lower it
+   to reject anything near-unbound, or set it far above any achievable speed to
+   switch the check off.
 
 The values are defined once, in ``layup.constants``, as ``FLAG_*``, ``STAGE_*`` and
 ``OUTCOME_COLUMNS``.

--- a/docs/fit_flags.rst
+++ b/docs/fit_flags.rst
@@ -1,0 +1,81 @@
+Orbit fit status flags
+========================================================================================
+
+Every fit that ``layup orbitfit`` produces carries an integer ``flag`` column
+reporting how the fit ended. The values are listed below, together with the part
+of the code that sets each one.
+
+``flag = 0`` means the differential correction converged and the result passed
+the quality gates that are currently applied. It does not assert that the orbit
+is physically plausible; see :ref:`flag-groups` below.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 8 92
+
+   * - Flag
+     - Meaning
+   * - ``-1``
+     - Not attempted. A placeholder written for rows that were never fit.
+   * - ``0``
+     - Converged and accepted.
+   * - ``1``
+     - Did not converge. This is the initial value, left in place when nothing
+       better is reached.
+   * - ``2``
+     - Converged, but the chi-square per degree of freedom is above threshold.
+       A quality gate applied to a fit that did converge.
+   * - ``3``
+     - Initial orbit determination (IOD) produced candidates, but none of them
+       converged on the primary interval. The least-bad attempt, by chi-square,
+       is returned so that the caller has something to inspect.
+   * - ``4``
+     - The primary interval converged, but the incremental build-up to the full
+       set of observations failed partway. The flag is set at the segment where
+       it broke.
+   * - ``5``
+     - No solution at all. Either the IOD returned no candidates and
+       ``iod='auto'`` was not in use, so there was no fallback, or ``'auto'``
+       produced no Gauss roots and no usable Bernstein-Khushalani seed.
+   * - ``6``
+     - Converged, but weakly constrained: the covariance is degenerate, or a
+       variance is non-positive.
+   * - ``7``
+     - Incremental update only. The prior covariance was not positive-definite,
+       so the information update is ill-posed and the driver falls back to a
+       full refit over all observations.
+   * - ``8``
+     - Incremental update applied without a full set of observations supplied
+       for the refit. Bookkeeping rather than a fit failure.
+
+.. _flag-groups:
+
+What the groups mean
+----------------------------------------------------------------------------------------
+
+The values are an enumeration, not a severity ordering. They fall into four
+groups:
+
+Converged and accepted
+   ``0``.
+
+Converged, but rejected by a gate
+   ``2`` and ``6``. The differential correction reached a solution, which was
+   then rejected — on chi-square per degree of freedom, or on a degenerate
+   covariance.
+
+Never converged
+   ``1``, ``3``, ``4``, ``5`` and ``7``. These distinguish where along the
+   initial orbit determination and incremental-fit path the attempt stopped.
+
+Bookkeeping
+   ``-1`` and ``8``. Neither reports on the quality of a fit.
+
+.. note::
+
+   The gates behind ``flag = 2`` and ``flag = 6`` are statistical, not physical.
+   A fit can converge, sit comfortably inside both gates, and still describe an
+   orbit that is not physically plausible — for example one implying an
+   absolute magnitude far fainter than any object the survey could have
+   detected. Short arcs are the usual case. Treat ``flag = 0`` as "the
+   estimator succeeded", not as "the orbit is real".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -179,6 +179,7 @@ for bug reports, questions, and feature requests.
 
    Home page <self>
    Controlling parallelism <parallelism>
+   Orbit fit status flags <fit_flags>
    Notebooks <notebooks>
    API Reference <autoapi/index>
    Developer guide <dev_guide>


### PR DESCRIPTION
The fit outcome is reported in six columns and none of them were written
down anywhere. This adds a docs page describing each one and when to read it.

The columns are `flag`, a summary that is `0` if and only if the fit converged
and passed every check, plus `converged`, `stage`, and three `failed_*` columns
carrying the individual verdicts. A clean fit is zero across all of them.

The page also warns that `flag == 2` and `flag == 6` under-report rejections:
where a fit stopped overwrites why it was rejected, so rejections should be
counted on `failed_csq` and `failed_cov`.

Closes #499.

Relevant to #493, but documents only what the code does today.