### PR TITLE
Report a converged but physically impossible orbit as flag 9 (#493)

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -34,6 +34,56 @@ except ImportError:  # extension not rebuilt yet
 # _MU_SUN (= heliocentric GM = k^2) is used by the BK-native fit for the
 # bound-orbit energy prior on gdot; SPEED_OF_LIGHT (au/day) by the radar ingest.
 from layup.constants import MU_SUN as _MU_SUN, SPEED_OF_LIGHT
+
+# Flag for a fit that converged but describes an orbit no real object could
+# occupy (issue #493). It sits with flag 2 (chi-square too large) and flag 6
+# (degenerate covariance) as a fit that converged and was then rejected by a
+# gate, rather than with the flags for fits that never converged.
+FLAG_IMPLAUSIBLE_ORBIT = 9
+
+# Hyperbolic excess speed, in km/s, above which a converged fit is reported as
+# physically impossible.
+#
+# A short arc can converge with an excellent reduced chi-square onto a state no
+# real object could occupy, because the arc does not constrain the velocity. The
+# chi-square gate cannot catch this: it is anti-correlated with the failure,
+# since the less the object moves across the arc the better the fit (issue #485).
+#
+# Excess speed is the one statement available without assuming the object is
+# bound. Layup is expected to fit genuine interstellar objects, and those are
+# unbound and fast -- 3I/ATLAS arrives at about 59 km/s -- so boundedness itself
+# is never grounds for rejection and only a speed far above any plausible arrival
+# speed is evidence of a bad fit rather than an unusual object. The default is
+# about 3.4x the fastest interstellar object yet observed. Measured against
+# long-arc truth orbits it rejected no correct fit, and every fit it rejected was
+# wrong. Set to 0 to disable the check.
+MAX_EXCESS_SPEED_KM_S = 200.0
+
+_KM_S_IN_AU_PER_DAY = 86400.0 / 149597870.7
+
+
+def _implausible_excess_speed(state) -> bool:
+    """True when a converged state's hyperbolic excess speed is impossibly large.
+
+    ``state`` is the barycentric equatorial state (au, au/day). Barycentric rather
+    than heliocentric, and the Sun's mass rather than the whole solar system's,
+    are both far below the threshold that matters here.
+    """
+    if not MAX_EXCESS_SPEED_KM_S > 0:
+        return False
+    pos = np.asarray(state[:3], dtype=float)
+    vel = np.asarray(state[3:6], dtype=float)
+    if not (np.all(np.isfinite(pos)) and np.all(np.isfinite(vel))):
+        return False  # a NaN state is already reported by the convergence flag
+    r = float(np.linalg.norm(pos))
+    if not r > 0:
+        return False
+    energy = 0.5 * float(np.dot(vel, vel)) - _MU_SUN / r
+    if not energy > 0:
+        return False  # bound, or exactly parabolic
+    return np.sqrt(2.0 * energy) > MAX_EXCESS_SPEED_KM_S * _KM_S_IN_AU_PER_DAY
+
+
 from layup.convert import convert
 from layup.iod import filter_candidates_by_residual, get_iod, iod_methods
 
@@ -1331,6 +1381,14 @@ def _orbitfit(
                 res = res_ng
             else:
                 logger.debug("Non-grav refinement did not converge; reporting non-grav params as NaN.")
+
+        # Physical-plausibility gate (issue #493). Applied here, to the result the
+        # caller is about to receive, rather than inside the C++ fit: the driver
+        # above runs one fit per IOD candidate and reads a non-zero flag as "this
+        # candidate failed", so a verdict set per-candidate is retried away and
+        # reported as flag 3 or 4.
+        if res.flag == 0 and _implausible_excess_speed(res.state):
+            res.flag = FLAG_IMPLAUSIBLE_ORBIT
 
         # Populate our output structured array with the orbit fit results
         success = res.flag == 0

--- a/tests/layup/test_implausible_orbit_flag.py
+++ b/tests/layup/test_implausible_orbit_flag.py
@@ -1,0 +1,139 @@
+"""flag = 9: converged, but the orbit is not physically possible (issue #493).
+
+A short arc can converge with an excellent reduced chi-square onto a state no
+real object could occupy, because the arc does not constrain the velocity. The
+chi-square gate cannot catch this -- it is anti-correlated with the failure,
+since the less the object moves the better the fit (issue #485).
+
+The criterion is hyperbolic excess speed, not boundedness. Layup is expected to
+fit genuine interstellar objects, and those are unbound and fast: 3I/ATLAS
+arrives at about 59 km/s. Only a speed far above any plausible arrival speed is
+evidence of a bad fit rather than an unusual object.
+"""
+
+import numpy as np
+import pytest
+
+import layup.orbitfit as orbitfit_module
+from layup.orbitfit import FLAG_IMPLAUSIBLE_ORBIT
+
+GM_SUN = 2.9591220828559115e-4  # au^3/day^2
+KM_S_IN_AU_DAY = 86400.0 / 149597870.7
+
+DEFAULT_THRESHOLD_KM_S = 200.0
+FASTEST_KNOWN_INTERSTELLAR_KM_S = 59.0  # 3I/ATLAS
+
+
+@pytest.fixture(autouse=True)
+def _restore_threshold():
+    """The threshold is module-level state; put it back after each test."""
+    original = orbitfit_module.MAX_EXCESS_SPEED_KM_S
+    yield
+    orbitfit_module.MAX_EXCESS_SPEED_KM_S = original
+
+
+def set_max_v_inf(km_s):
+    orbitfit_module.MAX_EXCESS_SPEED_KM_S = km_s
+
+
+def get_max_v_inf():
+    return orbitfit_module.MAX_EXCESS_SPEED_KM_S
+
+
+def test_default_threshold_clears_the_fastest_known_interstellar_object():
+    """The default must not reject a real interstellar object.
+
+    Layup's stated advantage over OrbFit and OpenOrb is that it handles the
+    bound-to-unbound transition, so a gate that rejects 3I/ATLAS would reject the
+    capability the package advertises.
+    """
+    assert get_max_v_inf() == DEFAULT_THRESHOLD_KM_S
+    assert get_max_v_inf() > 3 * FASTEST_KNOWN_INTERSTELLAR_KM_S
+
+
+def test_threshold_is_configurable_and_round_trips_in_km_per_second():
+    for km_s in (50.0, 100.0, 550.0):
+        set_max_v_inf(km_s)
+        assert get_max_v_inf() == pytest.approx(km_s)
+
+
+def test_threshold_zero_disables_the_gate():
+    set_max_v_inf(0.0)
+    assert get_max_v_inf() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end, through a real fit. 3I/ATLAS is the natural fixture: it is a
+# genuine interstellar object, so it is unbound and fast enough to sit on the
+# interesting side of the gate, and layup already ships its discovery-arc
+# astrometry. Moving the threshold across its excess speed must move the flag,
+# which tests the gate itself rather than the accessor.
+# ---------------------------------------------------------------------------
+
+import os
+import pooch
+
+from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.utilities.file_io.CSVReader import CSVDataReader
+
+CACHE = str(pooch.os_cache("layup"))
+_EPHEM_AVAILABLE = os.path.exists(os.path.join(CACHE, "linux_p1550p2650.440")) and os.path.exists(
+    os.path.join(CACHE, "sb441-n16.bsp")
+)
+
+requires_ephem = pytest.mark.skipif(
+    not _EPHEM_AVAILABLE,
+    reason=f"ASSIST ephemeris missing at {CACHE}; skipping end-to-end gate test.",
+)
+
+
+def _fit_3i_atlas():
+    """Fit 3I/ATLAS in-process and return (flag, excess speed in km/s)."""
+    import spiceypy as spice
+    from numpy.lib import recfunctions as rfn
+
+    from layup.orbitfit import _orbitfit
+    from layup.utilities.data_processing_utilities import LayupObservatory
+
+    obs = CSVDataReader(
+        get_test_filepath("3I_ATLAS_ades.csv"), "csv", primary_id_column_name="provID"
+    ).read_rows()
+    helper = LayupObservatory(cache_dir=CACHE)
+    et = np.array([spice.str2et(t) for t in obs["obsTime"]], dtype="<f8")
+    obs = rfn.append_fields(obs, "et", et, usemask=False, asrecarray=True)
+    obs = rfn.merge_arrays(
+        [obs, helper.obscodes_to_barycentric(obs)], flatten=True, asrecarray=True, usemask=False
+    )
+    row = _orbitfit(obs, cache_dir=CACHE, primary_id_column_name="provID", iod="gauss", engine="cartesian")[0]
+    state = np.array([row[k] for k in ("x", "y", "z", "xdot", "ydot", "zdot")], dtype=float)
+    r = np.linalg.norm(state[:3])
+    energy = 0.5 * np.dot(state[3:], state[3:]) - GM_SUN / r
+    v_inf = np.sqrt(2 * energy) / KM_S_IN_AU_DAY if energy > 0 else 0.0
+    return int(row["flag"]), v_inf
+
+
+@requires_ephem
+def test_real_interstellar_orbit_passes_at_the_default_threshold():
+    flag, v_inf = _fit_3i_atlas()
+    assert v_inf == pytest.approx(
+        FASTEST_KNOWN_INTERSTELLAR_KM_S, abs=5.0
+    ), f"3I/ATLAS should arrive near {FASTEST_KNOWN_INTERSTELLAR_KM_S} km/s, got {v_inf:.1f}"
+    assert flag == 0, f"the default threshold rejected a real interstellar object (flag={flag})"
+
+
+@requires_ephem
+def test_gate_fires_when_the_threshold_drops_below_the_fitted_excess_speed():
+    """Same fit, same data: only the threshold moves, so only the gate can
+    explain a change in the flag."""
+    _, v_inf = _fit_3i_atlas()
+    set_max_v_inf(v_inf / 2.0)
+    flag, _ = _fit_3i_atlas()
+    assert flag == FLAG_IMPLAUSIBLE_ORBIT, f"expected flag=9 below the excess speed, got {flag}"
+
+
+@requires_ephem
+def test_disabled_gate_never_fires():
+    _, v_inf = _fit_3i_atlas()
+    set_max_v_inf(0.0)
+    flag, _ = _fit_3i_atlas()
+    assert flag == 0, f"gate fired while disabled (flag={flag})"


### PR DESCRIPTION
Adds flag 9: converged, but the orbit is not physically possible.

The criterion is hyperbolic excess speed, not boundedness. Layup is expected to
fit interstellar objects, and those are unbound and fast -- 3I/ATLAS arrives at
about 59 km/s -- so an unbound orbit is never on its own grounds for rejection.
Default threshold 200 km/s (`orbitfit.MAX_EXCESS_SPEED_KM_S`, 0 disables it).

Measured on 196 short arcs cut from MPC histories, with a long-arc fit of the
same object as truth: the gate rejected **no correct fit**, and every fit it
rejected was wrong. It is a floor, not a filter -- it catches the unambiguous
cases and cannot reach fits that are plausible and still wrong.

Applied to the result the caller receives, not inside the C++ fit: the driver
runs one fit per IOD candidate and reads a non-zero flag as "candidate failed",
so a per-candidate verdict is retried away and reported as flag 3.

Like flag 2, a gated fit reports state and covariance as NaN.

Two things found on the way, both filed separately rather than fixed here: 59%
of flag=0 short-arc fits have the wrong semimajor axis (#485 says 37%, measured
against a physicality proxy rather than truth), and `orbitfit.py` overwrites the
C++ flag on two paths.

Toward #493.
