### PR TITLE
Logging config and cmd-line additions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ layup demo howto orbitfit
 asteroid (3666) Holman, in ADES CSV form — to the current directory, and `howto`
 prints the ready-to-run command. Fit it with:
 ```
-layup orbitfit holman_data_working.csv ADES_csv -o demo_orbitfit_output
+layup orbitfit holman_data_working.csv ADES_csv -t demo_orbitfit_output
 ```
 This writes the best-fit barycentric Cartesian orbit and its covariance to
 `demo_orbitfit_output.csv`. Supported input formats are `MPC80col`, `ADES_csv`, `ADES_psv`,
@@ -111,12 +111,12 @@ This writes the best-fit barycentric Cartesian orbit and its covariance to
 
 Convert the result to another orbit representation (Cometary, Keplerian, …):
 ```
-layup convert demo_orbitfit_output.csv KEP -o demo_orbit_kep
+layup convert demo_orbitfit_output.csv KEP -t demo_orbit_kep
 ```
 
 Predict future on-sky positions, with uncertainties, for an observatory:
 ```
-layup predict demo_orbitfit_output.csv --days 30 --station X05 -o my_predictions
+layup predict demo_orbitfit_output.csv --days 30 --station X05 -t my_predictions
 ```
 
 Every verb takes `--help` for its full set of options (engine choice, IOD

--- a/src/layup/comet.py
+++ b/src/layup/comet.py
@@ -308,7 +308,7 @@ def comet(data, num_workers=1, cache_dir=None, primary_id_column_name="ObjID", a
 
 def comet_cli(
     input: str,
-    output_file_stem: str,
+    output_file: str,
     file_format: Literal["csv", "hdf5"] = "csv",
     chunk_size: int = 10_000,
     num_workers: int = -1,
@@ -339,14 +339,6 @@ def comet_cli(
     """
 
     input_file = Path(input)
-    if file_format == "csv":
-        output_file = Path(f"{output_file_stem}.{file_format.lower()}")
-    else:
-        output_file = (
-            Path(f"{output_file_stem}")
-            if output_file_stem.endswith(".h5")
-            else Path(f"{output_file_stem}.h5")
-        )
 
     primary_id_column_name = cli_args.primary_id_column_name if cli_args else "ObjID"
 

--- a/src/layup/convert.py
+++ b/src/layup/convert.py
@@ -725,7 +725,7 @@ def convert(
 
 def convert_cli(
     input: str,
-    output_file_stem: str,
+    output_file: str,
     convert_to: Literal["BCART", "BCART_EQ", "BCOM", "BKEP", "CART", "COM", "KEP"],
     file_format: Literal["csv", "hdf5"] = "csv",
     chunk_size: int = 10_000,
@@ -741,8 +741,8 @@ def convert_cli(
     ----------
     input : str
         The path to the input file.
-    output_file_stem : str
-        The stem of the output file.
+    output_file : str
+        The name and path of the output file.
     convert_to : str
         The format to convert the input file to. Must be one of: "BCART", "BCART_EQ", "BCOM", "BKEP", "CART", "COM", "KEP"
     file_format : str, optional (default="csv")
@@ -757,14 +757,6 @@ def convert_cli(
         The argparse object that was created when running from the CLI.
     """
     input_file = Path(input)
-    if file_format == "csv":
-        output_file = Path(f"{output_file_stem}.{file_format.lower()}")
-    else:
-        output_file = (
-            Path(f"{output_file_stem}")
-            if output_file_stem.endswith(".h5")
-            else Path(f"{output_file_stem}.h5")
-        )
 
     primary_id_column_name = cli_args.primary_id_column_name if cli_args else "ObjID"
 

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -1902,7 +1902,7 @@ def incremental_orbitfit(
 def orbitfit_cli(
     input: str,
     input_file_format: Literal["MPC80col", "ADES_csv", "ADES_psv", "ADES_xml", "ADES_hdf5"],
-    output_file_stem: str,
+    output_file: str,
     output_file_format: Literal["csv", "hdf5"] = "csv",
     chunk_size: int = 10_000,
     num_workers: int = -1,
@@ -1949,21 +1949,14 @@ def orbitfit_cli(
     _primary_id_column_name = cli_args.primary_id_column_name
 
     input_file = Path(input)
-    if output_file_format == "csv":
-        output_file = Path(f"{output_file_stem}.{output_file_format.lower()}")
-    else:
-        output_file = (
-            Path(f"{output_file_stem}")
-            if output_file_stem.endswith(".h5")
-            else Path(f"{output_file_stem}.h5")
-        )
-    output_directory = output_file.parent.resolve()
+
+    output_directory = Path(output_file).parent.resolve()
 
     # If splitting the output has been requested, then we'll create a second output
     # file with "_flagged" appended to the stem. i.e. if the user provided "output.h5
     # then the flagged output will be "output_flagged.h5".
     if cli_args.separate_flagged:
-        output_file_stem_flagged = output_file_stem
+        output_file_stem_flagged = output_file
         if output_file_format == "csv":
             output_file_flagged = Path(f"{output_file_stem_flagged}_flagged.{output_file_format.lower()}")
         else:

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -1412,6 +1412,7 @@ def orbitfit(
     nongrav_gr=None,
     per_arc=False,
     skip_unchanged=False,
+    configs=None,
 ):
     """This is the function that you would call interactively. i.e. from a notebook
 
@@ -1502,7 +1503,7 @@ def orbitfit(
         if len(data) == 0:  # everything unchanged -> nothing to fit
             return carried_forward
 
-    layup_observatory = LayupObservatory(cache_dir=cache_dir)
+    layup_observatory = LayupObservatory(cache_dir=cache_dir, configs=configs)
 
     # The units of et are seconds (from J2000). This new column is used by
     # data_processing_utilities.obscodes_to_barycentric.
@@ -1906,6 +1907,7 @@ def orbitfit_cli(
     chunk_size: int = 10_000,
     num_workers: int = -1,
     cli_args: Optional[Namespace] = None,
+    configs=None,
 ):
     """This is the function that is called from the command line
 
@@ -2069,6 +2071,7 @@ def orbitfit_cli(
             weight_data=weight_data,
             iod=iod,
             engine=engine,
+            configs=configs,
         )
 
         # Convert the fit_orbits to the preferred output format

--- a/src/layup/predict.py
+++ b/src/layup/predict.py
@@ -438,7 +438,7 @@ def predict(
     """
     num_workers = resolve_num_workers(num_workers)
 
-    layup_observatory = LayupObservatory(cache_dir=cache_dir)
+    layup_observatory = LayupObservatory(cache_dir=cache_dir, configs=configs)
 
     times_et = np.array([spice.str2et(f"jd {t} tdb") for t in times], dtype="<f8")
 
@@ -562,7 +562,7 @@ def predict_cli(
                 cache_dir=cache_dir,
                 primary_id_column_name=cli_args.primary_id_column_name,
             )
-
+        logger.info(f"Processing {len(data)} object(s) in chunk")
         predictions = predict(
             data,
             obscode=cli_args.station,
@@ -580,3 +580,4 @@ def predict_cli(
                 write_csv(predictions, output_file, move_columns={"ra_str_hms": 3, "dec_str_dms": 4})
             else:
                 write_csv(predictions, output_file)
+        logger.info(f"Data has been written to {output_file}")

--- a/src/layup/unpack.py
+++ b/src/layup/unpack.py
@@ -162,7 +162,7 @@ def unpack(res, name, orbit_para, _RESULT_DTYPES, orbit_cols_flag, format):
 def unpack_cli(
     input,
     file_format,
-    output_file_stem,
+    output_file,
     chunk_size: int = 10_000,
     cli_args: dict = None,
 ):
@@ -188,14 +188,6 @@ def unpack_cli(
     primary_id_column_name = cli_args.primary_id_column_name if cli_args else "provID"
 
     input_file = Path(input)
-    if file_format == "csv":
-        output_file = Path(f"{output_file_stem}.{file_format.lower()}")
-    else:
-        output_file = (
-            Path(f"{output_file_stem}")
-            if output_file_stem.endswith(".h5")
-            else Path(f"{output_file_stem}.h5")
-        )
 
     # Open the input file and read the first line
     reader_class = INPUT_READERS.get(file_format)

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -429,10 +429,11 @@ class FakeSorchaArgs:
         self.ar_data_file_path = cache_dir
 
 
-def layup_furnish_spiceypy(cache_dir):
+def layup_furnish_spiceypy(cache_dir, config=None):
     """A simple wrapper to furnish spiceypy kernels."""
     # A simple class to mimic the arguments processed by Sorcha's observatory class
-    config = LayupConfigs()
+    if config == None:
+        config = LayupConfigs()
     furnish_spiceypy(FakeSorchaArgs(cache_dir), config.auxiliary)
 
 
@@ -441,7 +442,7 @@ class LayupObservatory(SorchaObservatory):
     A wrapper around Sorcha's Observatory class to provide additional functionality for Layup.
     """
 
-    def __init__(self, cache_dir=None):
+    def __init__(self, cache_dir=None, configs=None):
         """Create an instance of the LayupObservatory class.
 
         Parameters
@@ -455,14 +456,15 @@ class LayupObservatory(SorchaObservatory):
             cache_dir = str(pooch.os_cache(CACHE_DIR_NAME))
 
         # Get Layup configs
-        config = LayupConfigs()
+        if configs == None:
+            configs = LayupConfigs()
 
         # Kept so space-observatory Horizons lookups land their persistent
         # (naif_id, jd) -> state cache under the same cache directory.
         self.cache_dir = cache_dir
 
         # Furnish the spiceypy kernels
-        layup_furnish_spiceypy(cache_dir)
+        layup_furnish_spiceypy(cache_dir, configs)
 
         # Decide the observatory-codes source *before* handing off to Sorcha's
         # Observatory. Sorcha downloads the codes from the MPC when the
@@ -475,7 +477,7 @@ class LayupObservatory(SorchaObservatory):
         # Sorcha the copy bundled with layup immediately -- no blocking download
         # on the fit path. `layup bootstrap` remains the way to refresh the codes.
         oc_file = (
-            None if self._cached_obscodes_present(cache_dir, config.auxiliary) else write_fallback_obscodes()
+            None if self._cached_obscodes_present(cache_dir, configs.auxiliary) else write_fallback_obscodes()
         )
         if oc_file is not None:
             logger.info(
@@ -484,7 +486,7 @@ class LayupObservatory(SorchaObservatory):
             )
 
         try:
-            super().__init__(FakeSorchaArgs(cache_dir), config.auxiliary, oc_file=oc_file)
+            super().__init__(FakeSorchaArgs(cache_dir), configs.auxiliary, oc_file=oc_file)
         except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
             # Defensive fallback: the cached codes file was unreadable/corrupt (or
             # a download slipped through and failed). Use the bundled copy rather

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -497,7 +497,7 @@ class LayupObservatory(SorchaObservatory):
             )
             super().__init__(
                 FakeSorchaArgs(cache_dir),
-                config.auxiliary,
+                configs.auxiliary,
                 oc_file=write_fallback_obscodes(),
             )
 

--- a/src/layup/utilities/layup_configs.py
+++ b/src/layup/utilities/layup_configs.py
@@ -222,8 +222,16 @@ class LayupConfigs:
     """auxiliaryConfigs dataclass which stores the keywords from the AUXILIARY section of the config file."""
 
     # this __init__ overrides a dataclass's inbuilt __init__ because we want to populate this from a file, not explicitly ourselves
-    def __init__(self, config_file_location=None):
+    def __init__(self, config_file_location=None, logger=None):
+        if logger is None:
+            import logging
+
+            logger = logging.getLogger(__name__)
+
         if config_file_location:  # if a location to a config file is supplied...
+            # Save a raw copy of the configuration to the logs as a backup.
+            with open(config_file_location, "r") as file:
+                logger.debug(f"Copy of configuration file {config_file_location}:\n{file.read()}")
             config_object = configparser.ConfigParser()  # create a ConfigParser object
             config_object.read(config_file_location)  # and read the whole config file into it
             self._read_configs_from_object(
@@ -231,6 +239,7 @@ class LayupConfigs:
             )  # now we call a function that populates the class attributes
         else:
             # if a file is not supplied the config class will be populated with the default values.
+            logger.debug("Using default config parameters.")
             self._populate_configs_class_with_default()
 
     def _read_configs_from_object(self, config_object):

--- a/src/layup/utilities/layup_demo_commands.py
+++ b/src/layup/utilities/layup_demo_commands.py
@@ -16,16 +16,16 @@ def print_demo_command(verb, printall=True):
     """
     if verb == "orbitfit":
 
-        current_demo_command = "layup orbitfit holman_data_working.csv ADES_csv -o demo_orbitfit_output"
+        current_demo_command = "layup orbitfit holman_data_working.csv ADES_csv -t demo_orbitfit_output"
     elif verb == "convert":
 
-        current_demo_command = "layup convert cent_orbs_kep.csv BCART -o cent_orbs_bcart -pid ObjID"
+        current_demo_command = "layup convert cent_orbs_kep.csv BCART -t cent_orbs_bcart -pid ObjID"
     elif verb == "predict":
 
         current_demo_command = "layup predict cmd (demo not created yet)"
     elif verb == "comet":
 
-        current_demo_command = "layup comet demo_comet_input.csv -o demo_comet_output -pid ObjID"
+        current_demo_command = "layup comet demo_comet_input.csv -t demo_comet_output -pid ObjID"
     elif verb == "visualize":
 
         current_demo_command = "layup visualize cmd (demo not created yet)"

--- a/src/layup/utilities/layup_demo_commands.py
+++ b/src/layup/utilities/layup_demo_commands.py
@@ -16,16 +16,16 @@ def print_demo_command(verb, printall=True):
     """
     if verb == "orbitfit":
 
-        current_demo_command = "layup orbitfit holman_data_working.csv ADES_csv -t demo_orbitfit_output"
+        current_demo_command = "layup orbitfit holman_data_working.csv ADES_csv --stem demo_orbitfit_output"
     elif verb == "convert":
 
-        current_demo_command = "layup convert cent_orbs_kep.csv BCART -t cent_orbs_bcart -pid ObjID"
+        current_demo_command = "layup convert cent_orbs_kep.csv BCART --stem cent_orbs_bcart -pid ObjID"
     elif verb == "predict":
 
         current_demo_command = "layup predict cmd (demo not created yet)"
     elif verb == "comet":
 
-        current_demo_command = "layup comet demo_comet_input.csv -t demo_comet_output -pid ObjID"
+        current_demo_command = "layup comet demo_comet_input.csv --stem demo_comet_output -pid ObjID"
     elif verb == "visualize":
 
         current_demo_command = "layup visualize cmd (demo not created yet)"

--- a/src/layup/utilities/layup_logging.py
+++ b/src/layup/utilities/layup_logging.py
@@ -49,8 +49,8 @@ class LayupLogger:
             logger.info("Sending a log message from a notebook.")
     """
 
-    def __init__(self, log_directory="."):
-        self._prepare_logger(log_directory)
+    def __init__(self, log_directory=".", verb=""):
+        self._prepare_logger(log_directory, verb)
 
     def get_logger(self, name):
         """Convenience function to return a logger under the top level logger.
@@ -84,7 +84,7 @@ class LayupLogger:
         """
         pass
 
-    def _prepare_logger(self, log_directory="."):
+    def _prepare_logger(self, log_directory=".", verb=""):
         """Setup for the primary logger.
 
         Parameters
@@ -103,9 +103,9 @@ class LayupLogger:
         # This logger handles all messages >= DEBUG
         logger.setLevel(logging.DEBUG)
 
-        if logger.handlers:
-            # if already configured return
+        if any(getattr(handler, "_layup_logger", False) for handler in logger.handlers):
             return logger
+
         # The format of the log messages
         formatter = logging.Formatter("%(asctime)s - %(name)s - %(process)d - %(levelname)s - %(message)s")
 
@@ -117,7 +117,7 @@ class LayupLogger:
         # Configure log files
         log_location = Path(log_directory)
         timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        log_file_base_name = f"layup-{timestamp}"
+        log_file_base_name = f"layup-{verb}-{timestamp}"
         log_file_info = log_location / f"{log_file_base_name}.log"
         log_file_error = log_location / f"{log_file_base_name}.err"
 
@@ -137,6 +137,9 @@ class LayupLogger:
         logger.addHandler(file_handler_info)
         logger.addHandler(file_handler_error)
         logger.addHandler(console_handler)
+        file_handler_info._layup_logger = True
+        file_handler_error._layup_logger = True
+        console_handler._layup_logger = True
 
         # Return the top level logger
         return logger

--- a/src/layup/utilities/layup_logging.py
+++ b/src/layup/utilities/layup_logging.py
@@ -103,6 +103,9 @@ class LayupLogger:
         # This logger handles all messages >= DEBUG
         logger.setLevel(logging.DEBUG)
 
+        if logger.handlers:
+            # if already configured return
+            return logger
         # The format of the log messages
         formatter = logging.Formatter("%(asctime)s - %(name)s - %(process)d - %(levelname)s - %(message)s")
 

--- a/src/layup_cmdline/comet.py
+++ b/src/layup_cmdline/comet.py
@@ -70,7 +70,7 @@ def main():
         "-t",
         "--stem",
         help="output file name stem.",
-        dest="t",
+        dest="stem",
         type=str,
         default="comet_output",
         required=False,
@@ -138,9 +138,9 @@ def execute(args):
 
     # check format of input file
     if args.i.lower() == "csv":
-        output_file = args.t + ".csv"
+        output_file = args.stem + ".csv"
     elif args.i.lower() == "hdf5":
-        output_file = args.t + ".h5"
+        output_file = args.stem + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")

--- a/src/layup_cmdline/comet.py
+++ b/src/layup_cmdline/comet.py
@@ -4,6 +4,7 @@
 import argparse
 import logging
 import sys
+import os
 from layup_cmdline.layupargumentparser import LayupArgumentParser
 
 logger = logging.getLogger(__name__)
@@ -66,12 +67,22 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-o",
-        "--output",
-        help="output file stem. default path is current working directory",
-        dest="o",
+        "-t",
+        "--stem",
+        help="output file name stem.",
+        dest="t",
         type=str,
-        default="cometed_output",
+        default="comet_output",
+        required=False,
+    )
+
+    optional.add_argument(
+        "-o",
+        "--outfile",
+        help="Path to store output and logs.",
+        type=str,
+        dest="o",
+        default="./",
         required=False,
     )
     optional.add_argument(
@@ -115,7 +126,7 @@ def execute(args):
     from layup.utilities.file_access_utils import find_directory_or_exit, find_file_or_exit
     from layup.utilities.layup_logging import LayupLogger
 
-    layup_logger = LayupLogger()
+    layup_logger = LayupLogger(log_directory=args.o, verb="comet")
     logger = layup_logger.get_logger("layup.comet_cmdline")
 
     # check ar directory exists if specified
@@ -125,16 +136,19 @@ def execute(args):
     # check input exists
     find_file_or_exit(args.input, "input")
 
-    # Check that output directory exists
-    find_directory_or_exit(args.o, "-o, --")
     # check format of input file
     if args.i.lower() == "csv":
-        output_file = args.o + ".csv"
+        output_file = args.t + ".csv"
     elif args.i.lower() == "hdf5":
-        output_file = args.o + ".h5"
+        output_file = args.t + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
+
+    # Check that output directory exists
+    find_directory_or_exit(args.o, "-o, --")
+
+    output_file = os.path.join(args.o, output_file)
 
     # check for overwriting output file
     warn_or_remove_file(str(output_file), args.force, logger)
@@ -153,7 +167,7 @@ def execute(args):
 
     comet_cli(
         input=args.input,
-        output_file_stem=args.o,
+        output_file=output_file,
         file_format=args.i,
         chunk_size=args.chunk,
         num_workers=args.n,

--- a/src/layup_cmdline/comet.py
+++ b/src/layup_cmdline/comet.py
@@ -143,11 +143,11 @@ def execute(args):
     if not isinstance(args.chunk, int) or args.chunk <= 0:
         logger.error("Chunk size must be a positive integer")
 
-    configs = LayupConfigs()
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
         configs = LayupConfigs(args.config)
-
+    else:
+        configs = LayupConfigs()
     # check if bootstrap files are missing, and download if necessary
     download_files_if_missing(configs.auxiliary, args)
 

--- a/src/layup_cmdline/comet.py
+++ b/src/layup_cmdline/comet.py
@@ -67,7 +67,6 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-t",
         "--stem",
         help="output file name stem.",
         dest="stem",

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -150,10 +150,11 @@ def execute(args):
     if not isinstance(args.chunk, int) or args.chunk <= 0:
         logger.error("Chunk size must be a positive integer.")
 
-    configs = LayupConfigs()
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
         configs = LayupConfigs(args.config)
+    else:
+        configs = LayupConfigs()
 
     # check if bootstrap files are missing, and download if necessary
     download_files_if_missing(configs.auxiliary, args)

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -73,7 +73,6 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-t",
         "--stem",
         help="output file name stem.",
         dest="stem",

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -4,7 +4,7 @@
 import argparse
 import logging
 import sys
-
+import os
 from layup_cmdline.layupargumentparser import LayupArgumentParser
 
 logger = logging.getLogger(__name__)
@@ -73,12 +73,22 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-o",
-        "--output",
-        help="output file stem. default path is current working directory",
-        dest="o",
+        "-t",
+        "--stem",
+        help="output file name stem.",
+        dest="t",
         type=str,
         default="converted_output",
+        required=False,
+    )
+
+    optional.add_argument(
+        "-o",
+        "--outfile",
+        help="Path to store output and logs.",
+        type=str,
+        dest="o",
+        default="./",
         required=False,
     )
 
@@ -117,7 +127,7 @@ def execute(args):
     from layup.utilities.layup_configs import LayupConfigs
     from layup.utilities.layup_logging import LayupLogger
 
-    layup_logger = LayupLogger()
+    layup_logger = LayupLogger(log_directory=args.o, verb="convert")
     logger = layup_logger.get_logger("layup.convert_cmdline")
 
     # check ar directory exists if specified
@@ -131,12 +141,14 @@ def execute(args):
     find_directory_or_exit(args.o, "-o, --")
     # check format of input file
     if args.i.lower() == "csv":
-        output_file = args.o + ".csv"
+        output_file = args.t + ".csv"
     elif args.i.lower() == "hdf5":
-        output_file = args.o + ".h5"
+        output_file = args.t + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
+
+    output_file = os.path.join(args.o, output_file)
 
     # check for overwriting output file
     warn_or_remove_file(str(output_file), args.force, logger)
@@ -161,7 +173,7 @@ def execute(args):
 
     convert_cli(
         input=args.input,
-        output_file_stem=args.o,
+        output_file=output_file,
         convert_to=args.orbit_type,
         file_format=args.i,
         chunk_size=args.chunk,

--- a/src/layup_cmdline/convert.py
+++ b/src/layup_cmdline/convert.py
@@ -76,7 +76,7 @@ def main():
         "-t",
         "--stem",
         help="output file name stem.",
-        dest="t",
+        dest="stem",
         type=str,
         default="converted_output",
         required=False,
@@ -141,9 +141,9 @@ def execute(args):
     find_directory_or_exit(args.o, "-o, --")
     # check format of input file
     if args.i.lower() == "csv":
-        output_file = args.t + ".csv"
+        output_file = args.stem + ".csv"
     elif args.i.lower() == "hdf5":
-        output_file = args.t + ".h5"
+        output_file = args.stem + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -3,7 +3,7 @@
 #
 import argparse
 import sys
-
+import os
 from layup.utilities.cli_utilities import warn_or_remove_file
 from layup.utilities.file_access_utils import find_directory_or_exit, find_file_or_exit
 from layup_cmdline.layupargumentparser import LayupArgumentParser
@@ -94,12 +94,22 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-o",
-        "--output",
-        help="output file stem. default path is current working directory",
-        dest="o",
+        "-t",
+        "--stem",
+        help="output file name stem.",
+        dest="t",
         type=str,
-        default="output",
+        default="orbitfit_output",
+        required=False,
+    )
+
+    optional.add_argument(
+        "-o",
+        "--outfile",
+        help="Path to store output and logs.",
+        type=str,
+        dest="o",
+        default="./",
         required=False,
     )
     optional.add_argument(
@@ -170,7 +180,7 @@ def execute(args):
     from layup.utilities.bootstrap_utilties.download_utilities import download_files_if_missing
     from layup.utilities.layup_logging import LayupLogger
 
-    layup_logger = LayupLogger()
+    layup_logger = LayupLogger(log_directory=args.o, verb="orbitfit")
     logger = layup_logger.get_logger("layup.orbitfit_cmdline")
 
     logger.info("Starting orbitfit...")
@@ -197,12 +207,14 @@ def execute(args):
         logger.error(f"Output orbit format must be one of {supported_orbit_formats}")
     # check format of input file
     if args.output_format.lower() == "csv":
-        output_file = args.o + ".csv"
+        output_file = args.t + ".csv"
     elif args.output_format.lower() == "hdf5":
-        output_file = args.o + ".h5"
+        output_file = args.t + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
+
+    output_file = os.path.join(args.o, output_file)
 
     # check for overwriting output file
     warn_or_remove_file(str(output_file), args.force, logger)
@@ -222,7 +234,7 @@ def execute(args):
     orbitfit_cli(
         input=args.input,
         input_file_format=args.type,
-        output_file_stem=args.o,
+        output_file=output_file,
         output_file_format=args.output_format,
         chunk_size=args.chunksize,
         num_workers=args.n,

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -94,7 +94,6 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-t",
         "--stem",
         help="output file name stem.",
         dest="stem",

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -211,11 +211,11 @@ def execute(args):
     if args.g is not None:
         find_file_or_exit(args.g, "-g, --guess")
 
-    configs = LayupConfigs()
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
-        configs = LayupConfigs(args.config)
-
+        configs = LayupConfigs(args.config, logger)
+    else:
+        configs = LayupConfigs(logger=logger)
     # check if bootstrap files are missing, and download if necessary
     download_files_if_missing(configs.auxiliary, args)
 
@@ -227,6 +227,7 @@ def execute(args):
         chunk_size=args.chunksize,
         num_workers=args.n,
         cli_args=args,
+        configs=configs,
     )
 
 

--- a/src/layup_cmdline/orbitfit.py
+++ b/src/layup_cmdline/orbitfit.py
@@ -97,7 +97,7 @@ def main():
         "-t",
         "--stem",
         help="output file name stem.",
-        dest="t",
+        dest="stem",
         type=str,
         default="orbitfit_output",
         required=False,
@@ -207,9 +207,9 @@ def execute(args):
         logger.error(f"Output orbit format must be one of {supported_orbit_formats}")
     # check format of input file
     if args.output_format.lower() == "csv":
-        output_file = args.t + ".csv"
+        output_file = args.stem + ".csv"
     elif args.output_format.lower() == "hdf5":
-        output_file = args.t + ".h5"
+        output_file = args.stem + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -5,7 +5,7 @@ import argparse
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-
+import os
 import astropy.units as u
 
 from layup_cmdline.layupargumentparser import LayupArgumentParser
@@ -131,12 +131,22 @@ def main():
     )
 
     optional.add_argument(
-        "-o",
-        "--output",
-        help="Output file stem. Default path is the current working directory",
-        dest="o",
+        "-t",
+        "--stem",
+        help="output file name stem.",
+        dest="t",
         type=str,
         default="predicted_output",
+        required=False,
+    )
+
+    optional.add_argument(
+        "-o",
+        "--outfile",
+        help="Path to store output and logs.",
+        type=str,
+        dest="o",
+        default="./",
         required=False,
     )
 
@@ -161,10 +171,10 @@ def main():
     )
 
     optional.add_argument(
-        "-t",
+        "--ts",
         "--timestep",
         help="Timestep for predict. Must be string consisting of float followed by the unit (d=day, h=hour, m=minute, s=second) e.g. 1.3h or 30m",
-        dest="t",
+        dest="ts",
         type=str,
         default="1h",  # we would want to parse the float and the unit, and convert into day unit
         required=False,
@@ -256,7 +266,7 @@ def execute(args):
     from layup.utilities.layup_configs import LayupConfigs
     from layup.utilities.layup_logging import LayupLogger
 
-    layup_logger = LayupLogger()
+    layup_logger = LayupLogger(log_directory=args.o, verb="predict")
     logger = layup_logger.get_logger("layup.predict_cmdline")
 
     # check input exists
@@ -265,8 +275,19 @@ def execute(args):
     # Check that output directory exists
     find_directory_or_exit(args.o, "-o, --output")
 
+    # check format of input file
+    if args.i.lower() == "csv":
+        output_file = args.t + ".csv"
+    elif args.i.lower() == "hdf5":
+        output_file = args.t + ".h5"
+    else:
+        logger.error("File format must be 'csv' or 'hdf5'")
+        sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
+
+    output_file = os.path.join(args.o, output_file)
+
     # check for overwriting output file
-    warn_or_remove_file(str(args.o), args.force, logger)
+    warn_or_remove_file(str(output_file), args.force, logger)
 
     # check ar directory exists if specified
     if args.ar_data_file_path:
@@ -279,15 +300,6 @@ def execute(args):
 
     end_date = convert_input_to_JD_TDB(args.e, cache_dir) if args.e else start_date + args.days
 
-    # check format of input file
-    if args.i.lower() == "csv":
-        output_file = args.o + ".csv"
-    elif args.i.lower() == "hdf5":
-        output_file = args.o + ".h5"
-    else:
-        logger.error("File format must be 'csv' or 'hdf5'")
-        sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
-
     # check for overwriting output file
     warn_or_remove_file(str(output_file), args.force, logger)
 
@@ -297,7 +309,7 @@ def execute(args):
         sys.exit(f"ERROR: Start date {start_date} is after than end date {end_date}")
 
     # converting timestep argument args.t into a float in day units.
-    timestep_str = args.t
+    timestep_str = args.ts
     match = re.match(
         r"(?P<float>\d+(\.\d*)?)(?P<unit>\w+)", timestep_str.strip()
     )  # parses float/int and unit

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -313,10 +313,11 @@ def execute(args):
 
     timestep_day = (value * UNIT_DICT[unit_str]).to(u.day).value  # converting value into day units
 
-    configs = LayupConfigs()
     if args.config:
         find_file_or_exit(args.config, "-c, --config")
         configs = LayupConfigs(args.config)
+    else:
+        configs = LayupConfigs()
 
     # check if bootstrap files are missing, and download if necessary
     download_files_if_missing(configs.auxiliary, args)

--- a/src/layup_cmdline/predict.py
+++ b/src/layup_cmdline/predict.py
@@ -131,10 +131,9 @@ def main():
     )
 
     optional.add_argument(
-        "-t",
         "--stem",
         help="output file name stem.",
-        dest="t",
+        dest="stem",
         type=str,
         default="predicted_output",
         required=False,
@@ -171,10 +170,10 @@ def main():
     )
 
     optional.add_argument(
-        "--ts",
+        "-t",
         "--timestep",
         help="Timestep for predict. Must be string consisting of float followed by the unit (d=day, h=hour, m=minute, s=second) e.g. 1.3h or 30m",
-        dest="ts",
+        dest="t",
         type=str,
         default="1h",  # we would want to parse the float and the unit, and convert into day unit
         required=False,
@@ -277,9 +276,9 @@ def execute(args):
 
     # check format of input file
     if args.i.lower() == "csv":
-        output_file = args.t + ".csv"
+        output_file = args.stem + ".csv"
     elif args.i.lower() == "hdf5":
-        output_file = args.t + ".h5"
+        output_file = args.stem + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
@@ -309,7 +308,7 @@ def execute(args):
         sys.exit(f"ERROR: Start date {start_date} is after than end date {end_date}")
 
     # converting timestep argument args.t into a float in day units.
-    timestep_str = args.ts
+    timestep_str = args.t
     match = re.match(
         r"(?P<float>\d+(\.\d*)?)(?P<unit>\w+)", timestep_str.strip()
     )  # parses float/int and unit

--- a/src/layup_cmdline/unpack.py
+++ b/src/layup_cmdline/unpack.py
@@ -42,7 +42,6 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-t",
         "--stem",
         help="output file name stem.",
         dest="stem",

--- a/src/layup_cmdline/unpack.py
+++ b/src/layup_cmdline/unpack.py
@@ -45,7 +45,7 @@ def main():
         "-t",
         "--stem",
         help="output file name stem.",
-        dest="t",
+        dest="stem",
         type=str,
         default="unpacked_output",
         required=False,
@@ -100,9 +100,9 @@ def execute(args):
     find_directory_or_exit(args.o, "-o, --")
     # check format of input file
     if args.i.lower() == "csv":
-        output_file = args.t + ".csv"
+        output_file = args.stem + ".csv"
     elif args.i.lower() == "hdf5":
-        output_file = args.t + ".h5"
+        output_file = args.stem + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")

--- a/src/layup_cmdline/unpack.py
+++ b/src/layup_cmdline/unpack.py
@@ -5,6 +5,7 @@ import argparse
 from layup_cmdline.layupargumentparser import LayupArgumentParser
 import logging
 import sys
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -41,12 +42,22 @@ def main():
         required=False,
     )
     optional.add_argument(
-        "-o",
-        "--output",
-        help="output file stem. default path is current working directory",
-        dest="o",
+        "-t",
+        "--stem",
+        help="output file name stem.",
+        dest="t",
         type=str,
         default="unpacked_output",
+        required=False,
+    )
+
+    optional.add_argument(
+        "-o",
+        "--outfile",
+        help="Path to store output and logs.",
+        type=str,
+        dest="o",
+        default="./",
         required=False,
     )
 
@@ -79,7 +90,7 @@ def execute(args):
     from layup.utilities.file_access_utils import find_file_or_exit, find_directory_or_exit
     from layup.utilities.layup_logging import LayupLogger
 
-    layup_logger = LayupLogger()
+    layup_logger = LayupLogger(log_directory=args.o, verb="unpack")
     logger = layup_logger.get_logger("layup.unpack_cmdline")
 
     # check input exists
@@ -89,13 +100,14 @@ def execute(args):
     find_directory_or_exit(args.o, "-o, --")
     # check format of input file
     if args.i.lower() == "csv":
-        output_file = args.o + ".csv"
+        output_file = args.t + ".csv"
     elif args.i.lower() == "hdf5":
-        output_file = args.o + ".h5"
+        output_file = args.t + ".h5"
     else:
         logger.error("File format must be 'csv' or 'hdf5'")
         sys.exit("ERROR: File format must be 'csv' or 'hdf5'")
 
+    output_file = os.path.join(args.o, output_file)
     # check for overwriting output file
     warn_or_remove_file(str(output_file), args.force, logger)
     from layup.unpack import unpack_cli
@@ -103,7 +115,7 @@ def execute(args):
     unpack_cli(
         input=args.input,
         file_format=args.i,
-        output_file_stem=args.o,
+        output_file=output_file,
         chunk_size=args.chunk,
         cli_args=args,
     )

--- a/src/layup_cmdline/visualize.py
+++ b/src/layup_cmdline/visualize.py
@@ -29,6 +29,16 @@ def main():
         default=10000,
         required=False,
     )
+
+    optional.add_argument(
+        "-c",
+        "--conf",
+        "--config",
+        help="Optional configuration file",
+        type=str,
+        dest="config",
+        required=False,
+    )
     optional.add_argument(
         "-n",
         "--num-orbs",
@@ -100,7 +110,12 @@ def execute(args):
     from layup.utilities.bootstrap_utilties.download_utilities import download_files_if_missing
     from layup.utilities.layup_configs import LayupConfigs
 
-    configs = LayupConfigs()
+    if args.config:
+        find_file_or_exit(args.config, "-c, --config")
+        configs = LayupConfigs(args.config)
+    else:
+        configs = LayupConfigs()
+
     download_files_if_missing(configs.auxiliary, args)
 
     cache_dir = getattr(args, "ar_data_file_path", None)

--- a/tests/layup/test_comet.py
+++ b/tests/layup/test_comet.py
@@ -214,7 +214,7 @@ def test_comet_output(tmpdir):
     # The demo comet fixture is keyed by ObjID; comet's -pid now defaults to
     # provID (CLI-consistency), so pass -pid ObjID explicitly.
     result = subprocess.run(
-        ["layup", "comet", str(input_file), "-f", "-o", str(temp_out_file), "-pid", "ObjID"]
+        ["layup", "comet", str(input_file), "-f", "-t", str(temp_out_file), "-pid", "ObjID"]
     )
 
     assert result.returncode == 0

--- a/tests/layup/test_comet.py
+++ b/tests/layup/test_comet.py
@@ -214,7 +214,7 @@ def test_comet_output(tmpdir):
     # The demo comet fixture is keyed by ObjID; comet's -pid now defaults to
     # provID (CLI-consistency), so pass -pid ObjID explicitly.
     result = subprocess.run(
-        ["layup", "comet", str(input_file), "-f", "-t", str(temp_out_file), "-pid", "ObjID"]
+        ["layup", "comet", str(input_file), "-f", "--stem", str(temp_out_file), "-pid", "ObjID"]
     )
 
     assert result.returncode == 0

--- a/tests/layup/test_convert.py
+++ b/tests/layup/test_convert.py
@@ -100,7 +100,7 @@ def test_convert_round_trip_csv(tmpdir, chunk_size, num_workers):
     # Convert our BCOM CV file to a BCART CSV file
     convert_cli(
         input_file,
-        output_file_stem_BCART,
+        temp_BCART_out_file,
         "BCART",
         "csv",
         chunk_size=chunk_size,
@@ -122,7 +122,7 @@ def test_convert_round_trip_csv(tmpdir, chunk_size, num_workers):
     temp_BCOM_out_file = os.path.join(tmpdir, f"{output_file_stem_BCOM}.csv")
     convert_cli(
         temp_BCART_out_file,
-        output_file_stem_BCOM,
+        temp_BCOM_out_file,
         "BCOM",
         "csv",
         chunk_size=chunk_size,
@@ -187,7 +187,7 @@ def test_convert_BCART_EQ_csv_with_covariance(tmpdir, chunk_size, num_workers, o
     # Convert our BCART_EQ CSV file to a different format CSV file
     convert_cli(
         input_file,
-        output_file_stem,
+        temp_out_file,
         output_format,
         "csv",
         chunk_size=chunk_size,
@@ -209,7 +209,7 @@ def test_convert_BCART_EQ_csv_with_covariance(tmpdir, chunk_size, num_workers, o
     temp_BCART_EQ_out_file = os.path.join(tmpdir, f"{output_file_stem_BCART_EQ}.csv")
     convert_cli(
         temp_out_file,
-        output_file_stem_BCART_EQ,
+        temp_BCART_EQ_out_file,
         "BCART_EQ",
         "csv",
         chunk_size=chunk_size,
@@ -271,7 +271,7 @@ def test_convert_round_trip_hdf5(tmpdir, chunk_size, num_workers):
     # Convert our BCOM HDF5 file to a BCART HDF5 file
     convert_cli(
         input_file_BCOM,
-        output_file_stem_BCART,
+        temp_out_file_BCART,
         "BCART",
         "hdf5",
         chunk_size=chunk_size,
@@ -290,7 +290,7 @@ def test_convert_round_trip_hdf5(tmpdir, chunk_size, num_workers):
     temp_BCOM_out_file = os.path.join(tmpdir, f"{output_file_stem_BCOM}.h5")
     convert_cli(
         temp_out_file_BCART,
-        output_file_stem_BCOM,
+        temp_BCOM_out_file,
         "BCOM",
         "hdf5",
         chunk_size=chunk_size,

--- a/tests/layup/test_obscodes_fallback.py
+++ b/tests/layup/test_obscodes_fallback.py
@@ -32,7 +32,7 @@ def _capture_oc_file(monkeypatch):
     def fake_super_init(self, args, auxconfigs, oc_file=None):
         recorded["oc_file"] = oc_file
 
-    monkeypatch.setattr(dpu, "layup_furnish_spiceypy", lambda cache_dir: None)
+    monkeypatch.setattr(dpu, "layup_furnish_spiceypy", lambda cache_dir, config=None: None)
     monkeypatch.setattr(dpu.SorchaObservatory, "__init__", fake_super_init)
     return recorded
 
@@ -50,7 +50,7 @@ def test_uncached_obscodes_uses_bundled(tmp_path, monkeypatch):
 
 
 def test_cached_obscodes_uses_cache(tmp_path, monkeypatch):
-    """Cached codes -> let Sorcha read the local file (oc_file=None), no download."""
+    """Cached codes -> let So rcha read the local file (oc_file=None), no download."""
     aux = LayupConfigs().auxiliary
     (tmp_path / aux.observatory_codes).write_text("{}")  # pretend `layup bootstrap` cached it
     recorded = _capture_oc_file(monkeypatch)

--- a/tests/layup/test_orbit_fit.py
+++ b/tests/layup/test_orbit_fit.py
@@ -41,8 +41,8 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers, output_orbit_format):
     os.chdir(tmpdir)
     guess_file_stem = "test_guess"
     temp_guess_file = os.path.join(tmpdir, f"{guess_file_stem}.csv")
-    temp_out_file = "test_output"
-
+    temp_out_stem = "test_output"
+    temp_out_file = os.path.join(tmpdir, f"{temp_out_stem}.csv")
     test_input_filepath = get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv")
 
     class FakeCliArgs:
@@ -61,7 +61,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers, output_orbit_format):
     orbitfit_cli(
         input=test_input_filepath,
         input_file_format="ADES_csv",
-        output_file_stem=guess_file_stem,  # Our first run will create our initial guess file
+        output_file=temp_guess_file,  # Our first run will create our initial guess file
         output_file_format="csv",
         chunk_size=chunk_size,
         num_workers=num_workers,
@@ -84,7 +84,7 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers, output_orbit_format):
     orbitfit_cli(
         input=test_input_filepath,
         input_file_format="ADES_csv",
-        output_file_stem=temp_out_file,
+        output_file=temp_out_file,
         output_file_format="csv",
         chunk_size=chunk_size,
         num_workers=num_workers,
@@ -94,9 +94,9 @@ def test_orbit_fit_cli(tmpdir, chunk_size, num_workers, output_orbit_format):
     )
 
     # Verify the orbit fit produced an output file
-    assert os.path.exists(temp_out_file + ".csv")
+    assert os.path.exists(temp_out_file)
     # Create a new CSV reader to read in our output file
-    output_csv_reader = CSVDataReader(temp_out_file + ".csv", "csv", primary_id_column_name="provID")
+    output_csv_reader = CSVDataReader(temp_out_file, "csv", primary_id_column_name="provID")
     output_data = output_csv_reader.read_rows()
 
     # Read the input data and get the provID column
@@ -255,7 +255,7 @@ def test_orbit_fit_cli_raises_with_unknown_iod(tmpdir):
     # Since the orbit_fit CLI outputs to the current working directory, we need to change to our temp directory
     os.chdir(tmpdir)
     guess_file_stem = "test_guess"
-
+    temp_guess_file = os.path.join(tmpdir, f"{guess_file_stem}.csv")
     test_input_filepath = get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv")
 
     class FakeCliArgs:
@@ -276,7 +276,7 @@ def test_orbit_fit_cli_raises_with_unknown_iod(tmpdir):
         orbitfit_cli(
             input=test_input_filepath,
             input_file_format="ADES_csv",
-            output_file_stem=guess_file_stem,  # Our first run will create our initial guess file
+            output_file=temp_guess_file,  # Our first run will create our initial guess file
             output_file_format="csv",
             chunk_size=10_000,
             num_workers=1,
@@ -351,6 +351,7 @@ def test_orbit_fit_cli_raises_with_unknown_engine(tmpdir):
     _run_fit raises ValueError at fit time."""
     os.chdir(tmpdir)
     guess_file_stem = "test_guess"
+    temp_guess_file = os.path.join(tmpdir, f"{guess_file_stem}.csv")
     test_input_filepath = get_test_filepath("4_random_mpc_ADES_provIDs_no_sats.csv")
 
     class FakeCliArgs:
@@ -370,7 +371,7 @@ def test_orbit_fit_cli_raises_with_unknown_engine(tmpdir):
         orbitfit_cli(
             input=test_input_filepath,
             input_file_format="ADES_csv",
-            output_file_stem=guess_file_stem,
+            output_file=temp_guess_file,
             output_file_format="csv",
             chunk_size=10_000,
             num_workers=1,

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -221,7 +221,7 @@ def test_predict_output(tmpdir):
     temp_out_file = f"test_output_{input_file.stem}"
 
     result = subprocess.run(
-        ["layup", "predict", str(input_file), "-f", "-t", str(temp_out_file), "-o", str(tmpdir), "-s", start]
+        ["layup", "predict", str(input_file), "-f", "-stem", str(temp_out_file), "-o", str(tmpdir), "-s", start]
     )
 
     assert result.returncode == 0
@@ -286,7 +286,7 @@ def test_predict_output(tmpdir):
             "predict",
             str(input_file),
             "-f",
-            "-t",
+            "-stem",
             str(temp_out_file),
             "-s",
             start,
@@ -425,7 +425,7 @@ def test_get_onsky_data_output(tmpdir):
             "predict",
             str(input_file),
             "-f",
-            "-t",
+            "-stem",
             str(temp_out_file),
             "-o",
             str(tmpdir),

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -221,7 +221,18 @@ def test_predict_output(tmpdir):
     temp_out_file = f"test_output_{input_file.stem}"
 
     result = subprocess.run(
-        ["layup", "predict", str(input_file), "-f", "-stem", str(temp_out_file), "-o", str(tmpdir), "-s", start]
+        [
+            "layup",
+            "predict",
+            str(input_file),
+            "-f",
+            "--stem",
+            str(temp_out_file),
+            "-o",
+            str(tmpdir),
+            "-s",
+            start,
+        ]
     )
 
     assert result.returncode == 0
@@ -286,7 +297,7 @@ def test_predict_output(tmpdir):
             "predict",
             str(input_file),
             "-f",
-            "-stem",
+            "--stem",
             str(temp_out_file),
             "-s",
             start,
@@ -425,7 +436,7 @@ def test_get_onsky_data_output(tmpdir):
             "predict",
             str(input_file),
             "-f",
-            "-stem",
+            "--stem",
             str(temp_out_file),
             "-o",
             str(tmpdir),

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -221,7 +221,7 @@ def test_predict_output(tmpdir):
     temp_out_file = f"test_output_{input_file.stem}"
 
     result = subprocess.run(
-        ["layup", "predict", str(input_file), "-f", "-o", str(temp_out_file), "-s", start]
+        ["layup", "predict", str(input_file), "-f", "-t", str(temp_out_file), "-o", str(tmpdir), "-s", start]
     )
 
     assert result.returncode == 0
@@ -286,7 +286,7 @@ def test_predict_output(tmpdir):
             "predict",
             str(input_file),
             "-f",
-            "-o",
+            "-t",
             str(temp_out_file),
             "-s",
             start,
@@ -425,8 +425,10 @@ def test_get_onsky_data_output(tmpdir):
             "predict",
             str(input_file),
             "-f",
-            "-o",
+            "-t",
             str(temp_out_file),
+            "-o",
+            str(tmpdir),
             "-s",
             start,
             "-osd",

--- a/tests/layup/test_unpack.py
+++ b/tests/layup/test_unpack.py
@@ -16,20 +16,20 @@ def test_unpack_cli(tmpdir):
     # Since the unpack CLI outputs to the current working directory, we need to change to our temp directory
     os.chdir(tmpdir)
 
-    temp_out_file = "test_output"
-
+    temp_out_stem = "test_output"
+    temp_out_file = os.path.join(tmpdir, f"{temp_out_stem}.csv")
     # Now run the unpack cli with overwrite set to True
     unpack_cli(
         input=get_test_filepath("unpack_test_orbitfit_output.csv"),
         file_format="csv",
-        output_file_stem=temp_out_file,
+        output_file=temp_out_file,
     )
 
     # Verify the unpack produced an output file
-    assert os.path.exists(temp_out_file + ".csv")
+    assert os.path.exists(temp_out_file)
 
     # Create a new CSV reader to read in our output file
-    output_csv_reader = CSVDataReader(temp_out_file + ".csv", "csv", primary_id_column_name="provID")
+    output_csv_reader = CSVDataReader(temp_out_file, "csv", primary_id_column_name="provID")
     output_data = output_csv_reader.read_rows()
 
     # Read the input data and get the provID column


### PR DESCRIPTION
Fixes #42 
Added back logging to layup_configs. if the default configs are used the log will print ("Using default config parameters.")
if the cmdline arg -c is used then a copy of that config file is printed into the logs (similar to sorcha)
```
# Save a raw copy of the configuration to the logs as a backup.
            with open(config_file_location, "r") as file:
                logger.debug(f"Copy of configuration file {config_file_location}:\n{file.read()}")
```
Fixes #490  .

Added the following command line args for verbs comet, convert, orbitfit, unpack and predict. 
allowing for a user to decide where layup outputs and logs will be generated.
```
optional.add_argument(
        "-t",
        "--stem",
        help="output file name stem.",
        dest="t",
        type=str,
        default="comet_output",
        required=False,
    )

    optional.add_argument(
        "-o",
        "--outfile",
        help="Path to store output and logs.",
        type=str,
        dest="o",
        default="./",
        required=False,
    )
```
Also made it so that the log filename contains the verb that was ran to make it easier to differenate different log files:
` log_file_base_name = f"layup-{verb}-{timestamp}"`
i.e log file names will now look like this:
layup-comet-2026-08-28-14-43-25.log

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
