### PR TITLE
test: invoke layup CLI subprocesses under the interpreter under test

### DIFF
--- a/tests/layup/test_comet.py
+++ b/tests/layup/test_comet.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 import pytest
 import rebound
@@ -214,7 +215,17 @@ def test_comet_output(tmpdir):
     # The demo comet fixture is keyed by ObjID; comet's -pid now defaults to
     # provID (CLI-consistency), so pass -pid ObjID explicitly.
     result = subprocess.run(
-        ["layup", "comet", str(input_file), "-f", "-o", str(temp_out_file), "-pid", "ObjID"]
+        [
+            sys.executable,
+            "-m",
+            "layup_cmdline.comet",
+            str(input_file),
+            "-f",
+            "-o",
+            str(temp_out_file),
+            "-pid",
+            "ObjID",
+        ]
     )
 
     assert result.returncode == 0

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -221,7 +222,17 @@ def test_predict_output(tmpdir):
     temp_out_file = f"test_output_{input_file.stem}"
 
     result = subprocess.run(
-        ["layup", "predict", str(input_file), "-f", "-o", str(temp_out_file), "-s", start]
+        [
+            sys.executable,
+            "-m",
+            "layup_cmdline.predict",
+            str(input_file),
+            "-f",
+            "-o",
+            str(temp_out_file),
+            "-s",
+            start,
+        ]
     )
 
     assert result.returncode == 0
@@ -282,8 +293,9 @@ def test_predict_output(tmpdir):
 
     result = subprocess.run(
         [
-            "layup",
-            "predict",
+            sys.executable,
+            "-m",
+            "layup_cmdline.predict",
             str(input_file),
             "-f",
             "-o",
@@ -421,8 +433,9 @@ def test_get_onsky_data_output(tmpdir):
 
     result = subprocess.run(
         [
-            "layup",
-            "predict",
+            sys.executable,
+            "-m",
+            "layup_cmdline.predict",
             str(input_file),
             "-f",
             "-o",


### PR DESCRIPTION
## Problem

`test_predict_output` (and the `-sg` / `-osd` variants) and `test_comet_output`
invoke the CLI as a subprocess with a bare `"layup"` argv entry:

```python
result = subprocess.run(["layup", "predict", str(input_file), ...])
```

`"layup"` is resolved against `PATH`, so these tests exercise whichever
installation of layup comes first on the machine — not necessarily the working
tree under test. On a machine where a different environment (e.g. a conda env
with a broken `assist`/`rebound` link) shadows the intended one, all three
tests fail with `assert 1 == 0` and an unrelated `OSError: dlopen ...
librebound...` buried in captured stderr. The failure looks like a code
regression when it is purely an environment-resolution problem — and the tests
can also pass for the wrong reason, exercising a stale install while the
working tree is broken.

## Fix

Replace the bare `"layup"` argv entries with the interpreter under test,
invoking the same entry-point modules directly:

```python
result = subprocess.run(
    [sys.executable, "-m", "layup_cmdline.predict", str(input_file), ...]
)
```

and similarly `sys.executable -m layup_cmdline.comet` in `test_comet.py`.

The console scripts `layup-predict = "layup_cmdline.predict:main"` and
`layup-comet = "layup_cmdline.comet:main"` wrap exactly those `main()`
functions, and both modules already carry `if __name__ == "__main__": main()`,
so `python -m` runs the identical entry point. The subprocess now inherits the
interpreter running the test suite (the environment where layup is installed
for development), no `PATH` lookup involved — the working tree under test is
always what gets exercised.

All four call sites are changed (the issue listed three; the `-sg` variant in
`test_predict.py` had the same problem).

## Tests

- `tests/layup/test_predict.py` — `test_predict_output`,
  `test_predict_output` with `-sg`, `test_get_onsky_data_output`
- `tests/layup/test_comet.py` — `test_comet_output`

These are the subprocess tests that previously depended on `PATH` resolution.
Verified locally with the repository built as `pip install -e ".[dev]"`
(editable install in a fresh venv) and `layup bootstrap` data present:

```
tests/layup/test_predict.py::test_predict_output PASSED
tests/layup/test_predict.py::test_get_onsky_data_output PASSED
tests/layup/test_comet.py::test_comet_output PASSED
3 passed in 191.98s
```

`black --check` clean on both files.

**Regression proof (PATH dependence):** with `PATH=/usr/bin:/bin` (no venv bin
on PATH), the old bare-`"layup"` invocation raises
`FileNotFoundError: 'layup'` — the subprocess-dependent tests would fail
outright (or, with a shadowing install, fail with the misleading
`librebound`/`libassist` `OSError` described in the issue). The new
`sys.executable -m layup_cmdline.predict --help` invocation under the same
restricted PATH exits 0 and prints the expected usage, showing the tests now
exercise the interpreter under test regardless of `PATH`.

## Limitations

- This changes only the test invocation, not the CLI itself. If layup is not
  installed in the environment running the tests, the subprocess fails to
  import `layup_cmdline.predict` — but that environment could not have run the
  tests at all before, since the in-process imports already require the
  package.
- The `layup` dispatcher (`layup_cmdline.main`, the `layup <verb>` wrapper)
  still resolves `layup-<verb>` scripts via `PATH` internally; these tests
  bypass the dispatcher by invoking the verb modules directly, which is also
  one less process layer.
