### PR TITLE
Dispatch layup verbs from installed metadata, not PATH (#500)

### DIFF
--- a/src/layup/utilities/data_utilities_for_tests.py
+++ b/src/layup/utilities/data_utilities_for_tests.py
@@ -44,3 +44,24 @@ def get_test_filepath(filename):
 
     # Returned path: `<base_directory>/tests/data/filename`
     return os.path.join(THIS_DIR, "tests/data", filename)
+
+
+def layup_cli(*args):
+    """argv prefix that runs *this* environment's ``layup``, not ``PATH``'s.
+
+    ``subprocess.run(["layup", ...])`` resolves the name against ``PATH``, so a
+    test exercises whichever installation comes first on the machine rather than
+    the one under test. That fails confusingly when another layup is installed
+    (a conda environment with a broken assist/rebound link, say) and, worse,
+    passes for the wrong reason when the stale installation happens to work
+    (issue #500).
+
+    Console scripts are installed alongside the interpreter running the tests,
+    so resolving from ``sys.executable`` pins the invocation to this environment
+    while still exercising the real entry point and its subcommand dispatch.
+    """
+    import sys
+    from pathlib import Path
+
+    exe = Path(sys.executable).parent / "layup"
+    return [str(exe) if exe.exists() else "layup", *args]

--- a/src/layup/utilities/data_utilities_for_tests.py
+++ b/src/layup/utilities/data_utilities_for_tests.py
@@ -47,18 +47,17 @@ def get_test_filepath(filename):
 
 
 def layup_cli(*args):
-    """argv prefix that runs *this* environment's ``layup``, not ``PATH``'s.
+    """Build an argv that runs this environment's ``layup``, not ``PATH``'s.
 
-    ``subprocess.run(["layup", ...])`` resolves the name against ``PATH``, so a
-    test exercises whichever installation comes first on the machine rather than
-    the one under test. That fails confusingly when another layup is installed
-    (a conda environment with a broken assist/rebound link, say) and, worse,
-    passes for the wrong reason when the stale installation happens to work
-    (issue #500).
+    ``subprocess.run(["layup", ...])`` resolves the name against ``PATH``, so
+    the test runs whichever layup comes first on the machine instead of the one
+    being tested. On a machine with an older layup installed the test fails on
+    arguments the current code added, and -- worse -- when the older one happens
+    to accept them, it passes without testing anything (issue #500).
 
-    Console scripts are installed alongside the interpreter running the tests,
-    so resolving from ``sys.executable`` pins the invocation to this environment
-    while still exercising the real entry point and its subcommand dispatch.
+    Console scripts are installed next to the interpreter, so resolving from
+    ``sys.executable`` pins the call to this environment while still going
+    through the real entry point and its verb dispatch.
     """
     import sys
     from pathlib import Path

--- a/src/layup_cmdline/main.py
+++ b/src/layup_cmdline/main.py
@@ -8,12 +8,11 @@ from importlib.metadata import distribution
 
 
 def find_layup_verbs():
-    """The verbs this installation provides, as a dict of name -> entry point.
+    """Return the verbs this installation provides, as a dict mapping verb name
+    to entry point.
 
-    Read from the installed package's own metadata. Do not go back to searching
-    PATH for executables named layup-<verb>: that ran whichever layup came first
-    on PATH, which on a machine with more than one installation was often not
-    the one the user meant.
+    The names come from the installed package's own metadata, so they are the
+    verbs belonging to this layup, not whichever ones happen to be first on PATH.
     """
     verbs = {}
     for ep in distribution("layup").entry_points:

--- a/src/layup_cmdline/main.py
+++ b/src/layup_cmdline/main.py
@@ -1,34 +1,25 @@
 import argparse
 import sys
+from importlib.metadata import distribution
 
 #
 # Generic verb dispatcher code
 #
 
 
-def _verb_entry_points():
-    """The ``layup-*`` console scripts *this* installation declares, by verb.
+def find_layup_verbs():
+    """The verbs this installation provides, as a dict of name -> entry point.
 
-    Taken from the installed distribution's own metadata rather than by
-    searching ``PATH``. Searching ``PATH`` picked up any executable named
-    ``layup-<verb>`` anywhere on it, so with two layup installations on one
-    machine the dispatcher could run the other one's verb -- and an executable
-    dropped in any writable directory earlier on ``PATH`` (an empty ``PATH``
-    entry means the working directory) would be run in preference to the real
-    one, with the user's privileges.
+    Read from the installed package's own metadata. Do not go back to searching
+    PATH for executables named layup-<verb>: that ran whichever layup came first
+    on PATH, which on a machine with more than one installation was often not
+    the one the user meant.
     """
-    from importlib.metadata import distribution
-
     verbs = {}
     for ep in distribution("layup").entry_points:
         if ep.group == "console_scripts" and ep.name.startswith("layup-"):
             verbs[ep.name[len("layup-") :]] = ep
     return verbs
-
-
-def find_layup_verbs():
-    """Available layup verbs, from this installation's own metadata."""
-    return sorted(_verb_entry_points())
 
 
 def main():
@@ -69,7 +60,7 @@ def main():
         action="store_true",
     )
 
-    parser.add_argument("verb", nargs="?", choices=available_verbs, help="Verb to execute")
+    parser.add_argument("verb", nargs="?", choices=sorted(available_verbs), help="Verb to execute")
     parser.add_argument("args", nargs=argparse.REMAINDER, help="Arguments for the verb")
 
     args = parser.parse_args()
@@ -87,7 +78,7 @@ def main():
         sys.exit(1)
 
     utility = f"layup-{args.verb}"
-    entry = _verb_entry_points().get(args.verb)
+    entry = available_verbs.get(args.verb)
     if entry is None:
         print(f"Error: '{utility}' is not available.")
         sys.exit(1)

--- a/src/layup_cmdline/main.py
+++ b/src/layup_cmdline/main.py
@@ -1,23 +1,34 @@
 import argparse
-import subprocess
 import sys
-import shutil
-import os
 
 #
 # Generic verb dispatcher code
 #
 
 
+def _verb_entry_points():
+    """The ``layup-*`` console scripts *this* installation declares, by verb.
+
+    Taken from the installed distribution's own metadata rather than by
+    searching ``PATH``. Searching ``PATH`` picked up any executable named
+    ``layup-<verb>`` anywhere on it, so with two layup installations on one
+    machine the dispatcher could run the other one's verb -- and an executable
+    dropped in any writable directory earlier on ``PATH`` (an empty ``PATH``
+    entry means the working directory) would be run in preference to the real
+    one, with the user's privileges.
+    """
+    from importlib.metadata import distribution
+
+    verbs = {}
+    for ep in distribution("layup").entry_points:
+        if ep.group == "console_scripts" and ep.name.startswith("layup-"):
+            verbs[ep.name[len("layup-") :]] = ep
+    return verbs
+
+
 def find_layup_verbs():
-    """Find available layup commands in the system's PATH."""
-    layup_verbs = []
-    for directory in os.environ.get("PATH", "").split(os.pathsep):
-        if os.path.isdir(directory):
-            for item in os.listdir(directory):
-                if item.startswith("layup-") and os.access(os.path.join(directory, item), os.X_OK):
-                    layup_verbs.append(item[len("layup-") :])
-    return sorted(set(layup_verbs))
+    """Available layup verbs, from this installation's own metadata."""
+    return sorted(_verb_entry_points())
 
 
 def main():
@@ -75,21 +86,27 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    # Construct the full command name
     utility = f"layup-{args.verb}"
-
-    # Ensure the command is available
-    if not shutil.which(utility):
+    entry = _verb_entry_points().get(args.verb)
+    if entry is None:
         print(f"Error: '{utility}' is not available.")
         sys.exit(1)
 
-    # Execute the command with the remaining arguments
+    # Run the verb in this process. Nothing is resolved by name, so the verb
+    # that runs is always the one belonging to this installation.
+    verb_main = entry.load()
+    argv = sys.argv
+    sys.argv = [utility, *args.args]
     try:
-        result = subprocess.run([utility] + args.args, check=True)
-        sys.exit(result.returncode)
-    except subprocess.CalledProcessError as e:
-        print(f"Error: Command '{utility}' failed with exit code {e.returncode}.")
-        sys.exit(e.returncode)
+        code = verb_main()
+    except SystemExit as exc:  # the verbs exit on their own error paths
+        code = exc.code
+    finally:
+        sys.argv = argv
+    if code not in (0, None):
+        print(f"Error: Command '{utility}' failed with exit code {code}.")
+        sys.exit(code)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/tests/layup/test_comet.py
+++ b/tests/layup/test_comet.py
@@ -6,7 +6,7 @@ import rebound
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from layup.comet import _remove_spc, _assist_integrate, _direction_of_integration, _apply_comet, comet_cli
-from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.utilities.data_utilities_for_tests import get_test_filepath, layup_cli
 from layup.utilities.file_io.CSVReader import CSVDataReader
 import pandas as pd
 import assist
@@ -214,7 +214,7 @@ def test_comet_output(tmpdir):
     # The demo comet fixture is keyed by ObjID; comet's -pid now defaults to
     # provID (CLI-consistency), so pass -pid ObjID explicitly.
     result = subprocess.run(
-        ["layup", "comet", str(input_file), "-f", "-o", str(temp_out_file), "-pid", "ObjID"]
+        layup_cli("comet", str(input_file), "-f", "-o", str(temp_out_file), "-pid", "ObjID")
     )
 
     assert result.returncode == 0

--- a/tests/layup/test_predict.py
+++ b/tests/layup/test_predict.py
@@ -15,7 +15,7 @@ from layup.predict import (
     layup_get_residual_vectors,
     layup_calculate_rates_and_geometry,
 )
-from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.utilities.data_utilities_for_tests import get_test_filepath, layup_cli
 from layup.utilities.file_io.CSVReader import CSVDataReader
 
 
@@ -221,7 +221,7 @@ def test_predict_output(tmpdir):
     temp_out_file = f"test_output_{input_file.stem}"
 
     result = subprocess.run(
-        ["layup", "predict", str(input_file), "-f", "-o", str(temp_out_file), "-s", start]
+        layup_cli("predict", str(input_file), "-f", "-o", str(temp_out_file), "-s", start)
     )
 
     assert result.returncode == 0
@@ -281,8 +281,7 @@ def test_predict_output(tmpdir):
     # Testing the output of the sexagesimal conversion separately
 
     result = subprocess.run(
-        [
-            "layup",
+        layup_cli(
             "predict",
             str(input_file),
             "-f",
@@ -291,7 +290,7 @@ def test_predict_output(tmpdir):
             "-s",
             start,
             "-sg",
-        ]
+        )
     )
 
     assert result.returncode == 0
@@ -420,8 +419,7 @@ def test_get_onsky_data_output(tmpdir):
     temp_out_file = f"test_output_{input_file.stem}"
 
     result = subprocess.run(
-        [
-            "layup",
+        layup_cli(
             "predict",
             str(input_file),
             "-f",
@@ -430,7 +428,7 @@ def test_get_onsky_data_output(tmpdir):
             "-s",
             start,
             "-osd",
-        ]
+        )
     )
     assert result.returncode == 0
     result_file = Path(f"{tmpdir}/{temp_out_file}.csv")


### PR DESCRIPTION
`layup <verb>` chose which program to run by `PATH` order.

`find_layup_verbs()` walked every `PATH` directory for executables named
`layup-*`, and the dispatcher ran `layup-<verb>` as a bare name, so resolution
was left to the OS.

Two consequences. With two layup installations on one machine, `layup comet`
from one environment can execute the other's `layup-comet` -- that is how this
surfaced, and it is what made the three CLI tests in #500 fail. And any
executable named `layup-<verb>` in a writable directory earlier on `PATH` runs
in preference to the real one, with the user's privileges; an empty `PATH`
entry means the working directory, and shared systems often carry
group-writable bin directories.

Verbs now come from the installed distribution's entry points and run in this
process, so nothing is resolved by name.

Also pins the three CLI subprocess tests to this environment's console script.
With the conda installation first on `PATH` -- the configuration that was
failing -- all three now pass. Full suite: 488 passed, 1 skipped.

Closes #500. Suggest v1.0: this is a correctness problem in the shipped CLI
rather than the test hygiene the issue describes.