### PR TITLE
Keep post-convergence gate verdicts in the fit flag (#499)

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -34,6 +34,14 @@ except ImportError:  # extension not rebuilt yet
 # _MU_SUN (= heliocentric GM = k^2) is used by the BK-native fit for the
 # bound-orbit energy prior on gdot; SPEED_OF_LIGHT (au/day) by the radar ingest.
 from layup.constants import MU_SUN as _MU_SUN, SPEED_OF_LIGHT
+
+# Flag values the driver assigns. The fitter's own verdicts (0 converged,
+# 1 did not converge, 2 chi-square per degree of freedom above threshold,
+# 6 degenerate covariance) come from the C++ side; these are the driver's.
+FLAG_DID_NOT_CONVERGE = 1  # the fitter's, tested here before overwriting
+FLAG_NO_ROOT_CONVERGED = 3  # IOD gave candidates, none converged
+FLAG_BUILDUP_FAILED = 4  # incremental build-up stopped at a segment
+
 from layup.convert import convert
 from layup.iod import filter_candidates_by_residual, get_iod, iod_methods
 
@@ -978,7 +986,13 @@ def do_fit(
         logger.debug(
             f"Primary interval: no root converged " f"(best csq={x.csq:.3g}, n_roots={len(candidates)})"
         )
-        x.flag = 3
+        # Only a plain non-convergence becomes the driver's "no root converged"
+        # marker. A candidate that converged and was then rejected by a
+        # post-convergence gate carries the reason for that rejection, and it is
+        # more informative than 3: overwriting it reported a fit that reached a
+        # solution as one that never did (issue #499).
+        if x.flag == FLAG_DID_NOT_CONVERGE:
+            x.flag = FLAG_NO_ROOT_CONVERGED
         return x
 
     # Attempt to fit all the data, given the fit of the primary interval
@@ -997,7 +1011,10 @@ def do_fit(
             logger.debug(f"Incremental fit segment {i} of {len(seq)} " f"(n_obs={len(obs)})")
             x = _run_fit(assist_ephem, x, obs, engine)
             if x.flag != 0:
-                x.flag = 4
+                # As above: keep a gate verdict, which says why the build-up
+                # stopped, rather than replacing it with where it stopped.
+                if x.flag == FLAG_DID_NOT_CONVERGE:
+                    x.flag = FLAG_BUILDUP_FAILED
                 break
             logger.debug(f"Result `state`: {x.state}")
             logger.debug(f"Epoch: {x.epoch}, CSQ: {x.csq}, ndof: {x.ndof}, num obs: {len(obs)}")

--- a/tests/layup/test_flag_preservation.py
+++ b/tests/layup/test_flag_preservation.py
@@ -1,0 +1,64 @@
+"""Gate verdicts survive the driver's own flag assignments (issue #499).
+
+`do_fit` marks where a fit gave up: 3 when no IOD root converged on the primary
+interval, 4 when the incremental build-up stopped at a segment. Both used to be
+assigned unconditionally, overwriting whatever the fitter returned -- so a
+candidate that *converged* and was then rejected by a post-convergence gate
+(2 = chi-square per degree of freedom above threshold, 6 = degenerate
+covariance) was reported as one that never converged, and the reason was lost.
+
+These pin the distinction: a plain non-convergence still gets the driver's
+marker, a gate verdict is kept.
+"""
+
+import numpy as np
+import pytest
+
+import layup.orbitfit as orbitfit
+from layup.orbitfit import (
+    FLAG_BUILDUP_FAILED,
+    FLAG_DID_NOT_CONVERGE,
+    FLAG_NO_ROOT_CONVERGED,
+)
+
+
+class _Fit:
+    """Stand-in for the C++ FitResult, carrying only what do_fit reads."""
+
+    def __init__(self, flag, csq=1.0):
+        self.flag = flag
+        self.csq = csq
+        self.ndof = 1
+        self.state = [1.0, 0.0, 0.0, 0.0, 0.017, 0.0]
+        self.epoch = 2460000.5
+        self.cov = [0.0] * 36
+        self.method = "test"
+        self.niter = 1
+
+
+def _drive(monkeypatch, flags, n_obs=6):
+    """Run do_fit with _run_fit returning `flags` in turn, and no real IOD."""
+    seq = iter(flags)
+    monkeypatch.setattr(orbitfit, "_run_fit", lambda *a, **k: _Fit(next(seq)))
+    monkeypatch.setattr(orbitfit, "get_iod", lambda name: (lambda obs, s: [_Fit(0)]))
+    monkeypatch.setattr(orbitfit, "filter_candidates_by_residual", lambda cands, *a, **k: (list(cands), None))
+    monkeypatch.setattr(orbitfit, "get_ephem", lambda *a, **k: None)
+    observations = [object()] * n_obs
+    return orbitfit.do_fit(observations, [list(range(n_obs))], cache_dir="/tmp", iod="gauss")
+
+
+@pytest.mark.parametrize("gate_flag", [2, 6])
+def test_gate_verdict_survives_the_no_root_marker(monkeypatch, gate_flag):
+    """A converged-then-rejected candidate keeps its reason, not flag 3."""
+    result = _drive(monkeypatch, [gate_flag, gate_flag, gate_flag])
+    assert result.flag == gate_flag, f"gate verdict {gate_flag} was overwritten with {result.flag}"
+
+
+def test_plain_nonconvergence_still_gets_the_no_root_marker(monkeypatch):
+    result = _drive(monkeypatch, [FLAG_DID_NOT_CONVERGE] * 3)
+    assert result.flag == FLAG_NO_ROOT_CONVERGED
+
+
+def test_constants_match_the_documented_values():
+    """The values are an output format; they must not drift silently."""
+    assert (FLAG_DID_NOT_CONVERGE, FLAG_NO_ROOT_CONVERGED, FLAG_BUILDUP_FAILED) == (1, 3, 4)


### PR DESCRIPTION
`do_fit` assigned its own markers unconditionally -- 3 where no IOD root
converged, 4 where the incremental build-up stopped -- overwriting whatever
the fitter returned.

A candidate that converged and was then rejected by a gate (2 = chi-square per
degree of freedom above threshold, 6 = degenerate covariance) was therefore
reported as a fit that never converged. Anything triaging on flag 2
under-counts.

Only a plain non-convergence now becomes the driver's marker. The three values
it assigns are named rather than bare integers, since they are an output
format.

Four tests drive `_run_fit` through each path. Against the previous behaviour
the two gate cases fail with "gate verdict 2 was overwritten with 3"; the
plain-non-convergence case passes either way, so the tests pin the distinction
rather than the change.

Closes #499.