### PR TITLE
Defer close-approach IOD candidates instead of fitting them in polynomial order

### DIFF
--- a/src/layup/iod.py
+++ b/src/layup/iod.py
@@ -181,6 +181,47 @@ def _inertial_min_geocentric_AU(state, state_epoch, observations) -> float:
     return math.sqrt(min_d2)
 
 
+def partition_close_approach(observations, candidates, close_earth_AU: float = _CLOSE_EARTH_AU):
+    """Split IOD candidates into those safe to integrate and those to defer.
+
+    A Gauss root whose trajectory passes very close to Earth is expensive
+    rather than wrong-looking: the integrator resolves the encounter step by
+    step and a single candidate can consume the whole fit budget. On short
+    main-belt arcs the offender is usually the degenerate branch that
+    collapses onto Earth's own orbit -- near-zero topocentric distance,
+    co-moving with the observer -- which is spurious for the objects that
+    produce it and is rejected at 10^4-10^6 sigma when it is actually
+    evaluated (Smithsonian/layup#465).
+
+    These candidates cannot simply be dropped: for a genuine near-Earth
+    object with a real close approach, the close root is the *correct*
+    orbit. So they are deferred, not discarded. The caller fits the safe
+    candidates first and only falls back to the deferred ones if none of
+    them converged.
+
+    The same ``close_earth_AU`` threshold and the same inertial
+    approximation are used as in :func:`filter_candidates_by_residual`,
+    which passes these candidates through its residual test unfiltered for
+    the same reason.
+
+    Returns
+    -------
+    (safe, deferred) : tuple[list, list]
+        Both preserve the input ordering. ``deferred`` is empty in the
+        common case.
+    """
+    safe, deferred = [], []
+    for c in candidates:
+        try:
+            min_geo = _inertial_min_geocentric_AU(c.state, c.epoch, observations)
+        except Exception:
+            # Unreadable candidate: treat as safe and let the picker judge it.
+            safe.append(c)
+            continue
+        (deferred if min_geo < close_earth_AU else safe).append(c)
+    return safe, deferred
+
+
 def filter_candidates_by_residual(
     candidates,
     observations,

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -35,7 +35,7 @@ except ImportError:  # extension not rebuilt yet
 # bound-orbit energy prior on gdot; SPEED_OF_LIGHT (au/day) by the radar ingest.
 from layup.constants import MU_SUN as _MU_SUN, SPEED_OF_LIGHT
 from layup.convert import convert
-from layup.iod import filter_candidates_by_residual, get_iod, iod_methods
+from layup.iod import filter_candidates_by_residual, get_iod, iod_methods, partition_close_approach
 
 from layup.utilities.astrometric_uncertainty import astrometric_uncertainty_Veres2017
 from layup.utilities.data_processing_utilities import (
@@ -941,9 +941,25 @@ def do_fit(
         set_ias15_adaptive_mode(picker_ias15_adaptive_mode)
 
     obs = [observations[i] for i in seq[0]]
+
+    # Order the candidates by how expensive they are to integrate, not by the
+    # order the polynomial produced them (layup#465). A root whose trajectory
+    # grazes the Earth makes the integrator resolve the encounter and can
+    # consume the entire fit budget on its own; on short main-belt arcs that
+    # root is the degenerate Earth-orbit branch and is spurious. Fit the rest
+    # first and only come back to it if nothing else converged -- deferred,
+    # never discarded, because for a genuine near-Earth object the close root
+    # is the right answer.
+    safe, deferred = partition_close_approach(observations, solns)
+    if deferred:
+        logger.debug(f"Deferring {len(deferred)}/{len(solns)} close-approach candidate(s)")
+
     try:
-        candidates = [_run_fit(assist_ephem, soln, obs, engine, screen_iter_max) for soln in solns]
+        candidates = [_run_fit(assist_ephem, soln, obs, engine, screen_iter_max) for soln in safe]
         x = _pick_best_root(candidates, min_r_helio_AU)
+        if x is None and deferred:
+            candidates += [_run_fit(assist_ephem, soln, obs, engine, screen_iter_max) for soln in deferred]
+            x = _pick_best_root(candidates, min_r_helio_AU)
         if x is None:
             candidates = [_run_fit(assist_ephem, soln, obs, engine, full_iter_max) for soln in solns]
             x = _pick_best_root(candidates, min_r_helio_AU)

--- a/tests/layup/test_close_approach_deferral.py
+++ b/tests/layup/test_close_approach_deferral.py
@@ -1,0 +1,87 @@
+"""Close-approach IOD candidates are deferred, not discarded (layup#465).
+
+A Gauss root whose trajectory grazes the Earth is expensive to integrate
+rather than obviously wrong, and on short main-belt arcs it is the
+degenerate branch that collapses onto Earth's own orbit. The picker fits
+the other roots first and only returns to it if none of them converged.
+"""
+
+import numpy as np
+import pytest
+
+from layup.iod import _CLOSE_EARTH_AU, partition_close_approach
+
+
+class _Obs:
+    """Minimal stand-in for the C++ Observation the partition reads."""
+
+    def __init__(self, epoch, observer_position):
+        self.epoch = epoch
+        self.observer_position = observer_position
+
+
+class _Cand:
+    """Minimal stand-in for an IOD candidate."""
+
+    def __init__(self, state, epoch=0.0):
+        self.state = list(state)
+        self.epoch = epoch
+
+
+# Observer sitting at 1 au along x at three epochs, near enough to static
+# over the arc that the geometry below is easy to reason about.
+_OBS = [_Obs(float(t), (1.0, 0.0, 0.0)) for t in (0.0, 1.0, 2.0)]
+
+# A main-belt-like root: 2.5 au away from the observer, never close.
+_FAR = _Cand((3.5, 0.0, 0.0, 0.0, 0.0, 0.0))
+
+# The degenerate branch: sitting essentially on the observer and co-moving,
+# so its minimum geocentric distance over the arc is ~0.
+_CLOSE = _Cand((1.001, 0.0, 0.0, 0.0, 0.0, 0.0))
+
+
+def test_far_candidate_is_safe():
+    safe, deferred = partition_close_approach(_OBS, [_FAR])
+    assert safe == [_FAR]
+    assert deferred == []
+
+
+def test_close_candidate_is_deferred_not_dropped():
+    safe, deferred = partition_close_approach(_OBS, [_CLOSE])
+    assert safe == []
+    assert deferred == [_CLOSE], "close candidates must be kept for fallback"
+
+
+def test_partition_preserves_every_candidate_and_its_order():
+    cands = [_FAR, _CLOSE, _Cand((-4.0, 1.0, 0.0, 0.0, 0.0, 0.0))]
+    safe, deferred = partition_close_approach(_OBS, cands)
+    assert len(safe) + len(deferred) == len(cands), "no candidate may be lost"
+    assert safe == [cands[0], cands[2]]
+    assert deferred == [cands[1]]
+
+
+def test_threshold_is_the_shared_close_earth_constant():
+    """Just inside and just outside _CLOSE_EARTH_AU land on opposite sides."""
+    inside = _Cand((1.0 + 0.5 * _CLOSE_EARTH_AU, 0.0, 0.0, 0.0, 0.0, 0.0))
+    outside = _Cand((1.0 + 2.0 * _CLOSE_EARTH_AU, 0.0, 0.0, 0.0, 0.0, 0.0))
+    safe, deferred = partition_close_approach(_OBS, [inside, outside])
+    assert deferred == [inside]
+    assert safe == [outside]
+
+
+def test_motion_towards_the_observer_is_detected():
+    """The test is over the whole arc, not just the candidate's epoch."""
+    # Starts 1 au beyond the observer, arrives at it by the last epoch.
+    approaching = _Cand((2.0, 0.0, 0.0, -0.5, 0.0, 0.0))
+    safe, deferred = partition_close_approach(_OBS, [approaching])
+    assert deferred == [approaching]
+
+
+def test_unreadable_candidate_is_treated_as_safe():
+    class _Bad:
+        state = property(lambda self: (_ for _ in ()).throw(RuntimeError("no state")))
+        epoch = 0.0
+
+    bad = _Bad()
+    safe, deferred = partition_close_approach(_OBS, [bad])
+    assert safe == [bad] and deferred == []


### PR DESCRIPTION
Closes #465.

A Gauss root that grazes the Earth is expensive rather than obviously wrong:
the integrator resolves the encounter step by step and one candidate can
consume the whole fit budget. On short main-belt arcs it is the degenerate
branch that collapses onto Earth's own orbit, and it is rejected at
1e4-1e6 sigma once it is actually evaluated (traces in the issue).

This partitions the candidates on the existing `_CLOSE_EARTH_AU`, fits the
rest first, and returns to the close ones only if none of the others
converged. **Deferred, not discarded** -- for a genuine near-Earth object with
a real close approach the close root is the correct orbit, which is why
(308635) 2005 YU55 and (367943) Duende must keep working.

No new tunable, no change to the residual prefilter.

**Effect.** 500 Rubin-only arcs (MPC observatory code X05), 420 s deadline:

| | discoveries | known |
|---|---|---|
| converged, before | 229 (91.6%) | 201 (80.4%) |
| converged, after | **247 (98.8%)** | **248 (99.2%)** |
| exceeded the deadline, before | 18 | 37 |
| exceeded the deadline, after | **0** | **0** |

The quality statistics are unchanged -- median reduced chi-square identical at
0.0061 and 0.0023, formal sigma_a/a and |da/a| moving in the third digit -- so
the newly-converging objects are ordinary fits that were previously never
reached, not marginal ones squeaking in. Six arcs that returned nothing after
420 s now finish in ~0.04 s.

Also 96.8% of a 400-object MPC sample now fits from a cold start with no
initial guess at all.

**Tests.** Six unit tests on the partition: a far candidate is safe, a close one
is deferred and never dropped, ordering and completeness are preserved, the
threshold is the shared constant, motion toward the observer during the arc is
detected, and an unreadable candidate degrades to safe. Full suite 491 passed,
1 skipped. (`test_comet_output` fails locally on a stale `layup` on PATH -- the
problem #506 fixes -- and is unrelated.)

The five arcs that still return flag 3 are a separate matter: #509.