### PR TITLE
Report fit outcome as independent columns instead of one flag (#499)

### DIFF
--- a/src/layup/constants.py
+++ b/src/layup/constants.py
@@ -1,4 +1,4 @@
-"""Physical constants for layup, defined once.
+"""Constants for layup, defined once.
 
 Before this module these values were re-declared in several places
 (``orbitfit.py``, ``predict.py``, ``iod.py``,
@@ -11,6 +11,10 @@ Importing everything from here gives a single, citable source of truth.
 Units follow layup's internal convention: distances in astronomical units (au),
 times in days, so GM values are in au^3/day^2 and the speed of light is in
 au/day.
+
+The orbit-fit status values at the end are here for the same reason: they are an
+output format, read by callers as well as written by the fitter, and they were
+previously scattered as bare integers across ``orbitfit.py``.
 """
 
 from __future__ import annotations
@@ -34,3 +38,48 @@ MU_SUN = 0.00029591220828559104
 # determination (Gauss's method) where the reference point is the solar-system
 # barycentre rather than the Sun.
 GMtotal = 0.0002963092748799319
+
+
+# ---------------------------------------------------------------------------
+# Orbit-fit status
+#
+# ``flag`` is the single-value summary an orbit fit reports. It is 0 if and only
+# if the fit converged and passed every check; the values below name the ways it
+# can be non-zero. The columns further down report the same information as
+# independent facts, which is what a caller should filter on when it needs to
+# know *which* check failed.
+# ---------------------------------------------------------------------------
+
+FLAG_NOT_ATTEMPTED = -1  # placeholder for a row that was never fit
+FLAG_CONVERGED = 0  # converged, and every check passed
+FLAG_DID_NOT_CONVERGE = 1  # the differential correction did not converge
+FLAG_CSQ_TOO_LARGE = 2  # converged; reduced chi-square above threshold
+FLAG_NO_ROOT_CONVERGED = 3  # candidates were produced, none converged on the primary interval
+FLAG_BUILDUP_FAILED = 4  # primary interval converged; the incremental build-up did not
+FLAG_NO_SOLUTION = 5  # no initial-orbit candidates and no usable fallback seed
+FLAG_DEGENERATE_COV = 6  # converged; covariance degenerate, or a variance non-positive
+FLAG_PRIOR_NOT_POSITIVE_DEFINITE = 7  # incremental: prior covariance ill-posed, so a full refit
+FLAG_INCREMENTAL_NO_FULL_OBS = 8  # incremental update with no full observation set to refit from
+
+# How far the fitting pipeline got before it stopped.
+STAGE_NOT_ATTEMPTED = 0
+STAGE_NO_CANDIDATES = 1  # initial orbit determination produced nothing usable
+STAGE_PRIMARY = 2  # reached the fit over the primary interval
+STAGE_BUILDUP = 3  # reached the incremental build-up to all observations
+STAGE_COMPLETE = 4  # fit the full observation set
+STAGE_INCREMENTAL = 5  # sequential-update bookkeeping rather than a fresh fit
+
+# The fit outcome as independent facts, one output column each. Named for their
+# polarity: each ``failed_*`` is 1 when the fit failed that check, so a clean fit
+# is zero across all of them, matching ``flag == FLAG_CONVERGED``. A ``passed_*``
+# convention would make a never-attempted fit (all zero) indistinguishable from
+# one that failed everything.
+OUTCOME_COLUMNS = ("converged", "stage", "failed_csq", "failed_cov", "failed_physical")
+
+# Which check each of the fitter's own post-convergence verdicts reports as
+# failed. Both are set *after* the Levenberg-Marquardt loop converges, so each
+# means "converged, then rejected".
+CXX_GATE_FLAGS = {FLAG_CSQ_TOO_LARGE: "failed_csq", FLAG_DEGENERATE_COV: "failed_cov"}
+
+# The flags that mean the differential correction reached a solution.
+CONVERGED_FLAGS = (FLAG_CONVERGED, FLAG_CSQ_TOO_LARGE, FLAG_DEGENERATE_COV)

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -31,7 +31,7 @@ try:
 except ImportError:  # extension not rebuilt yet
     get_ias15_adaptive_mode = lambda: -1
     set_ias15_adaptive_mode = lambda m: None
-# _MU_SUN (= heliocentric GM = k^2) is used by the BK-native fit for the
+# MU_SUN (= heliocentric GM = k^2) is used by the BK-native fit for the
 # bound-orbit energy prior on gdot; SPEED_OF_LIGHT (au/day) by the radar ingest.
 from layup.constants import (
     CONVERGED_FLAGS,
@@ -45,7 +45,7 @@ from layup.constants import (
     FLAG_NO_SOLUTION,
     FLAG_NOT_ATTEMPTED,
     FLAG_PRIOR_NOT_POSITIVE_DEFINITE,
-    MU_SUN as _MU_SUN,
+    MU_SUN,
     OUTCOME_COLUMNS,
     SPEED_OF_LIGHT,
     STAGE_BUILDUP,
@@ -152,7 +152,7 @@ def _run_fit(assist_ephem, initial_guess, observations, engine, iter_max=100):
     if engine == "cartesian":
         return run_from_vector_with_initial_guess(assist_ephem, initial_guess, observations, iter_max)
     if engine == "bk_native":
-        return run_bk_native_fit(assist_ephem, initial_guess, observations, _MU_SUN)
+        return run_bk_native_fit(assist_ephem, initial_guess, observations, MU_SUN)
     raise ValueError(f"Unknown engine {engine!r}; expected one of 'cartesian', 'bk_native'.")
 
 
@@ -1077,7 +1077,7 @@ def do_fit(
         # diagnostic scan Gauss+BK covers ~90% of cases vs ~84% for Gauss alone.
         # Epoch convention matches do_gauss_iod's middle observation.
         logger.debug(f"All {len(solns)} Gauss roots failed; trying BK-IOD fallback")
-        bk_seed = run_bk_iod(obs, float(obs[len(obs) // 2].epoch), _MU_SUN)
+        bk_seed = run_bk_iod(obs, float(obs[len(obs) // 2].epoch), MU_SUN)
         if bk_seed.flag == 0:
             cand = _run_fit(assist_ephem, bk_seed, obs, engine, full_iter_max)
             candidates.append(cand)

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -290,6 +290,11 @@ def _get_result_dtypes(primary_id_column_name: str, nongrav_names=(), per_arc=Fa
             ("FORMAT", "O"),  # Orbit format
         ]
         + [(col_name, "f8") for col_name in get_cov_columns()]  # Flat covariance matrix (36 elements)
+        # Fit outcome as independent facts (issues #493, #495, #499). Grouped with
+        # the other unconditional columns, before the optional non-grav ones, so
+        # that both existing layout invariants still hold: the fingerprint stays
+        # last, and the non-grav columns stay immediately before it.
+        + [(name, "i1") for name in OUTCOME_COLUMNS]
         + [  # non-grav params (issue #351), value + 1-sigma per fitted param
             (col, "f8") for n in nongrav_names for col in (n.lower(), n.lower() + "_unc")
         ]
@@ -651,6 +656,92 @@ def _build_sequence(jds, sep_dt=90.0):
     return seq
 
 
+# ---------------------------------------------------------------------------
+# Fit outcome (issues #493, #495, #499)
+#
+# ``flag`` is one integer carrying three unrelated things: whether the estimator
+# converged, how far along the pipeline it stopped, and which post-convergence
+# gate rejected the result. Those are not mutually exclusive, so one integer
+# cannot hold them -- the driver used to write its stage marker over a gate
+# verdict, reporting a fit that *had* reached a solution as one that never did.
+#
+# The columns below report each fact on its own and leave the combining to the
+# reader. ``flag`` is unchanged and remains the summary: 0 if and only if the
+# fit converged and every gate passed.
+# ---------------------------------------------------------------------------
+
+STAGE_NOT_ATTEMPTED = 0
+STAGE_NO_CANDIDATES = 1  # initial orbit determination produced nothing usable
+STAGE_PRIMARY = 2  # reached the fit over the primary interval
+STAGE_BUILDUP = 3  # reached the incremental build-up to all observations
+STAGE_COMPLETE = 4  # fit the full observation set
+STAGE_INCREMENTAL = 5  # sequential-update bookkeeping rather than a fresh fit
+
+OUTCOME_COLUMNS = ("converged", "stage", "gate_csq", "gate_cov", "gate_physical")
+
+# The fitter's own verdicts, and which gate each one reports. 2 and 6 are both
+# set *after* the Levenberg-Marquardt loop has converged (orbit_fit.cpp: the
+# reduced-chi-square test reads chi2_final, and the conditioning test is guarded
+# by `flag == 0`), so each means "converged, then rejected" -- which is exactly
+# the fact the driver used to discard.
+_CXX_GATE = {2: "gate_csq", 6: "gate_cov"}
+
+
+@dataclass
+class FitOutcome:
+    """What happened to one fit, as independent facts.
+
+    ``FitResult`` is a pybind11 class declared without ``py::dynamic_attr()``, so
+    these cannot be attached to it; they are carried here instead and written to
+    their own output columns.
+    """
+
+    converged: bool = False  # the differential correction reached a solution
+    stage: int = STAGE_NOT_ATTEMPTED  # how far the pipeline got
+    gate_csq: bool = False  # chi-square per degree of freedom above threshold
+    gate_cov: bool = False  # covariance degenerate, or a variance non-positive
+    gate_physical: bool = False  # hyperbolic excess speed implausible (issue #493)
+
+    def record(self, fit):
+        """Read the fitter's own verdict, before any driver flag overwrites it."""
+        self.converged = fit.flag in (0, 2, 6)
+        gate = _CXX_GATE.get(fit.flag)
+        if gate is not None:
+            setattr(self, gate, True)
+
+    def as_row(self):
+        """The output columns, in ``OUTCOME_COLUMNS`` order."""
+        return (
+            int(self.converged),
+            int(self.stage),
+            int(self.gate_csq),
+            int(self.gate_cov),
+            int(self.gate_physical),
+        )
+
+    @classmethod
+    def from_flag(cls, flag):
+        """Reconstruct what the summary flag still permits, for the paths that do
+        not run through ``do_fit`` and so never observed the intermediate state.
+        Lossy by construction -- a gate verdict that was overwritten is gone."""
+        outcome = cls()
+        outcome.converged = flag in (0, 2, 6)
+        gate = _CXX_GATE.get(flag)
+        if gate is not None:
+            setattr(outcome, gate, True)
+        outcome.stage = {
+            0: STAGE_COMPLETE,
+            2: STAGE_COMPLETE,
+            6: STAGE_COMPLETE,
+            3: STAGE_PRIMARY,
+            4: STAGE_BUILDUP,
+            5: STAGE_NO_CANDIDATES,
+            7: STAGE_INCREMENTAL,
+            8: STAGE_INCREMENTAL,
+        }.get(flag, STAGE_NOT_ATTEMPTED)
+        return outcome
+
+
 def create_empty_result(id, dtypes):
     """Create an empty return object
 
@@ -682,6 +773,8 @@ def create_empty_result(id, dtypes):
                 "NONE",  # format
             )
             + (np.nan,) * 36  # Flat covariance matrix
+            # never attempted: not converged, no stage reached, no gate applied
+            + ((0, STAGE_NOT_ATTEMPTED, 0, 0, 0) if "converged" in dtypes.names else ())
             # non-grav columns (issue #351): NaN per a1/a2/a3 (+ _unc) that is present
             + tuple(np.nan for n in ("a1", "a2", "a3") if n in dtypes.names for _ in (0, 1))
             # obs fingerprint (issue #419): empty hash never matches, so a failed
@@ -834,6 +927,7 @@ def do_fit(
     min_r_helio_AU: float = _PICKER_MIN_R_HELIO_AU,
     prefilter_threshold_sigma: float = _PREFILTER_THRESHOLD_SIGMA,
     picker_ias15_adaptive_mode: int = _PICKER_IAS15_ADAPTIVE_MODE,
+    outcome: "FitOutcome | None" = None,
 ):
     """Carry out an orbit fit to a list of observations.
 
@@ -879,6 +973,9 @@ def do_fit(
         best-effort or sentinel FitResult with a non-zero flag.
     """
 
+    if outcome is None:
+        outcome = FitOutcome()
+
     # 'auto' is a strategy, not a registered IOD: seed candidates with Gauss,
     # then (after the picker, below) fall back to the BK 5-parameter linear IOD
     # if every Gauss root fails to converge. Any other value is a registry name.
@@ -896,6 +993,7 @@ def do_fit(
     if not solns and not is_auto:
         logger.debug(f"IOD {iod!r} returned no candidates")
         x = FitResult()
+        outcome.stage = STAGE_NO_CANDIDATES
         x.flag = 5
         return x
 
@@ -972,12 +1070,18 @@ def do_fit(
             # 'auto' with zero Gauss roots and no usable BK seed: nothing to
             # surface, so return an explicit no-solution sentinel.
             x = FitResult()
+            outcome.stage = STAGE_NO_CANDIDATES
             x.flag = 5
             return x
         x = min(candidates, key=lambda c: c.csq)
         logger.debug(
             f"Primary interval: no root converged " f"(best csq={x.csq:.3g}, n_roots={len(candidates)})"
         )
+        # Record the fitter's own verdict first. Assigning 3 here is what used
+        # to lose it: a candidate that converged and was then rejected by a gate
+        # was reported as one that never converged (issue #499).
+        outcome.stage = STAGE_PRIMARY
+        outcome.record(x)
         x.flag = 3
         return x
 
@@ -997,6 +1101,8 @@ def do_fit(
             logger.debug(f"Incremental fit segment {i} of {len(seq)} " f"(n_obs={len(obs)})")
             x = _run_fit(assist_ephem, x, obs, engine)
             if x.flag != 0:
+                outcome.stage = STAGE_BUILDUP
+                outcome.record(x)
                 x.flag = 4
                 break
             logger.debug(f"Result `state`: {x.state}")
@@ -1005,6 +1111,13 @@ def do_fit(
         logger.debug(f"Result `state`: {x.state}")
         logger.debug(f"Epoch: {x.epoch}, CSQ: {x.csq}, ndof: {x.ndof}, num obs: {len(obs)}")
 
+    # Only the paths that reach here without having already recorded -- a clean
+    # fit, or a build-up that completed every segment. The early-return paths
+    # above recorded the fitter's verdict *before* overwriting `flag`, so
+    # re-reading it here would replace that verdict with the driver's marker.
+    if outcome.stage == STAGE_NOT_ATTEMPTED:
+        outcome.stage = STAGE_COMPLETE
+        outcome.record(x)
     return x
 
 
@@ -1288,6 +1401,7 @@ def _orbitfit(
         sequence = _build_sequence(jds, sep_dt=90.0)
 
         # Perform the orbit fitting
+        outcome = FitOutcome()
         if initial_guess is None or initial_guess["flag"] != 0:
             if iod.lower() in ["gauss", "auto"]:
                 res = do_fit(
@@ -1296,12 +1410,16 @@ def _orbitfit(
                     cache_dir=kernels_loc,
                     iod=iod.lower(),
                     engine=engine,
+                    outcome=outcome,
                 )
             else:
                 res = do_other_fit(iod=iod.lower())
         else:
             guess_to_use = parse_fit_result(initial_guess)
             res = run_from_vector_with_initial_guess(get_ephem(kernels_loc), guess_to_use, observations)
+            # This path does not run the staged pipeline, so there is no
+            # intermediate state to have observed; report what the flag allows.
+            outcome = FitOutcome.from_flag(res.flag)
 
         # Non-gravitational params (issue #351): once the 6-parameter orbit has
         # converged, refine it jointly with the requested non-grav params, seeded
@@ -1331,6 +1449,10 @@ def _orbitfit(
                 res = res_ng
             else:
                 logger.debug("Non-grav refinement did not converge; reporting non-grav params as NaN.")
+
+        # The non-grav refinement above can replace `res`, so take the gate
+        # verdicts from whatever is actually being returned.
+        outcome.record(res)
 
         # Populate our output structured array with the orbit fit results
         success = res.flag == 0
@@ -1387,6 +1509,7 @@ def _orbitfit(
                     ("BCART_EQ" if success else "NONE"),  # The base format returned by the C++ code
                 )
                 + cov_matrix  # Flat covariance matrix
+                + outcome.as_row()  # independent outcome facts (issue #499)
                 + nongrav_cols  # non-grav params + uncertainties (issue #351), when fit_nongrav
                 + per_arc_cols  # later-arc amplitudes (comet linkage), when per_arc
                 + (obs_hash, nobs_fit)  # obs fingerprint (issue #419)
@@ -1764,6 +1887,8 @@ def _fitresult_to_row(fit, obj_id, obs_hash, nobs_fit, dtypes):
             "BCART_EQ" if success else "NONE",
         )
         + cov
+        # The sequential update does not run the staged pipeline either.
+        + (FitOutcome.from_flag(fit.flag).as_row() if "converged" in dtypes.names else ())
         + (obs_hash, nobs_fit)
     )
     return np.array([row], dtype=dtypes)

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -677,14 +677,18 @@ STAGE_BUILDUP = 3  # reached the incremental build-up to all observations
 STAGE_COMPLETE = 4  # fit the full observation set
 STAGE_INCREMENTAL = 5  # sequential-update bookkeeping rather than a fresh fit
 
-OUTCOME_COLUMNS = ("converged", "stage", "gate_csq", "gate_cov", "gate_physical")
+# Named for their polarity: each is 1 when the fit FAILED that check, so a clean
+# fit is zero across all of them, matching `flag == 0`. A "passed_*" convention
+# would make a never-attempted fit (all zero) indistinguishable from one that
+# failed everything.
+OUTCOME_COLUMNS = ("converged", "stage", "failed_csq", "failed_cov", "failed_physical")
 
-# The fitter's own verdicts, and which gate each one reports. 2 and 6 are both
+# The fitter's own verdicts, and which check each one reports as failed. 2 and 6 are both
 # set *after* the Levenberg-Marquardt loop has converged (orbit_fit.cpp: the
 # reduced-chi-square test reads chi2_final, and the conditioning test is guarded
 # by `flag == 0`), so each means "converged, then rejected" -- which is exactly
 # the fact the driver used to discard.
-_CXX_GATE = {2: "gate_csq", 6: "gate_cov"}
+_CXX_GATE = {2: "failed_csq", 6: "failed_cov"}
 
 
 @dataclass
@@ -698,9 +702,9 @@ class FitOutcome:
 
     converged: bool = False  # the differential correction reached a solution
     stage: int = STAGE_NOT_ATTEMPTED  # how far the pipeline got
-    gate_csq: bool = False  # chi-square per degree of freedom above threshold
-    gate_cov: bool = False  # covariance degenerate, or a variance non-positive
-    gate_physical: bool = False  # hyperbolic excess speed implausible (issue #493)
+    failed_csq: bool = False  # rejected: chi-square per degree of freedom above threshold
+    failed_cov: bool = False  # rejected: covariance degenerate, or a variance non-positive
+    failed_physical: bool = False  # rejected: hyperbolic excess speed implausible (#493)
 
     def record(self, fit):
         """Read the fitter's own verdict, before any driver flag overwrites it."""
@@ -714,9 +718,9 @@ class FitOutcome:
         return (
             int(self.converged),
             int(self.stage),
-            int(self.gate_csq),
-            int(self.gate_cov),
-            int(self.gate_physical),
+            int(self.failed_csq),
+            int(self.failed_cov),
+            int(self.failed_physical),
         )
 
     @classmethod

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -311,7 +311,7 @@ def _get_result_dtypes(primary_id_column_name: str, nongrav_names=(), per_arc=Fa
             ("FORMAT", "O"),  # Orbit format
         ]
         + [(col_name, "f8") for col_name in get_cov_columns()]  # Flat covariance matrix (36 elements)
-        # Fit outcome as independent facts (issues #493, #495, #499). Grouped with
+        # Fit outcome as independent facts. Grouped with
         # the other unconditional columns, before the optional non-grav ones, so
         # that both existing layout invariants still hold: the fingerprint stays
         # last, and the non-grav columns stay immediately before it.
@@ -705,7 +705,7 @@ class FitOutcome:
     stage: int = STAGE_NOT_ATTEMPTED  # how far the pipeline got
     failed_csq: bool = False  # rejected: chi-square per degree of freedom above threshold
     failed_cov: bool = False  # rejected: covariance degenerate, or a variance non-positive
-    failed_physical: bool = False  # rejected: hyperbolic excess speed implausible (#493)
+    failed_physical: bool = False  # rejected: hyperbolic excess speed implausible
 
     def record(self, fit):
         """Read the fitter's own verdict, before any driver flag overwrites it."""
@@ -1084,7 +1084,7 @@ def do_fit(
         )
         # Record the fitter's own verdict first. Assigning 3 here is what used
         # to lose it: a candidate that converged and was then rejected by a gate
-        # was reported as one that never converged (issue #499).
+        # was reported as one that never converged.
         outcome.stage = STAGE_PRIMARY
         outcome.record(x)
         x.flag = FLAG_NO_ROOT_CONVERGED
@@ -1514,7 +1514,7 @@ def _orbitfit(
                     ("BCART_EQ" if success else "NONE"),  # The base format returned by the C++ code
                 )
                 + cov_matrix  # Flat covariance matrix
-                + outcome.as_row()  # independent outcome facts (issue #499)
+                + outcome.as_row()  # the outcome columns
                 + nongrav_cols  # non-grav params + uncertainties (issue #351), when fit_nongrav
                 + per_arc_cols  # later-arc amplitudes (comet linkage), when per_arc
                 + (obs_hash, nobs_fit)  # obs fingerprint (issue #419)

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -33,7 +33,28 @@ except ImportError:  # extension not rebuilt yet
     set_ias15_adaptive_mode = lambda m: None
 # _MU_SUN (= heliocentric GM = k^2) is used by the BK-native fit for the
 # bound-orbit energy prior on gdot; SPEED_OF_LIGHT (au/day) by the radar ingest.
-from layup.constants import MU_SUN as _MU_SUN, SPEED_OF_LIGHT
+from layup.constants import (
+    CONVERGED_FLAGS,
+    CXX_GATE_FLAGS,
+    FLAG_BUILDUP_FAILED,
+    FLAG_CONVERGED,
+    FLAG_CSQ_TOO_LARGE,
+    FLAG_DEGENERATE_COV,
+    FLAG_INCREMENTAL_NO_FULL_OBS,
+    FLAG_NO_ROOT_CONVERGED,
+    FLAG_NO_SOLUTION,
+    FLAG_NOT_ATTEMPTED,
+    FLAG_PRIOR_NOT_POSITIVE_DEFINITE,
+    MU_SUN as _MU_SUN,
+    OUTCOME_COLUMNS,
+    SPEED_OF_LIGHT,
+    STAGE_BUILDUP,
+    STAGE_COMPLETE,
+    STAGE_INCREMENTAL,
+    STAGE_NO_CANDIDATES,
+    STAGE_NOT_ATTEMPTED,
+    STAGE_PRIMARY,
+)
 from layup.convert import convert
 from layup.iod import filter_candidates_by_residual, get_iod, iod_methods
 
@@ -657,38 +678,18 @@ def _build_sequence(jds, sep_dt=90.0):
 
 
 # ---------------------------------------------------------------------------
-# Fit outcome (issues #493, #495, #499)
+# Fit outcome
 #
-# ``flag`` is one integer carrying three unrelated things: whether the estimator
+# `flag` is one integer carrying three unrelated things: whether the estimator
 # converged, how far along the pipeline it stopped, and which post-convergence
-# gate rejected the result. Those are not mutually exclusive, so one integer
-# cannot hold them -- the driver used to write its stage marker over a gate
-# verdict, reporting a fit that *had* reached a solution as one that never did.
+# check rejected it. Those are not mutually exclusive, so one integer cannot
+# hold them -- the driver used to write its stage marker over a check verdict,
+# reporting a fit that *had* reached a solution as one that never did.
 #
 # The columns below report each fact on its own and leave the combining to the
-# reader. ``flag`` is unchanged and remains the summary: 0 if and only if the
-# fit converged and every gate passed.
+# reader. `flag` is unchanged and remains the summary. The values themselves
+# live in constants.py, with the other output-format constants.
 # ---------------------------------------------------------------------------
-
-STAGE_NOT_ATTEMPTED = 0
-STAGE_NO_CANDIDATES = 1  # initial orbit determination produced nothing usable
-STAGE_PRIMARY = 2  # reached the fit over the primary interval
-STAGE_BUILDUP = 3  # reached the incremental build-up to all observations
-STAGE_COMPLETE = 4  # fit the full observation set
-STAGE_INCREMENTAL = 5  # sequential-update bookkeeping rather than a fresh fit
-
-# Named for their polarity: each is 1 when the fit FAILED that check, so a clean
-# fit is zero across all of them, matching `flag == 0`. A "passed_*" convention
-# would make a never-attempted fit (all zero) indistinguishable from one that
-# failed everything.
-OUTCOME_COLUMNS = ("converged", "stage", "failed_csq", "failed_cov", "failed_physical")
-
-# The fitter's own verdicts, and which check each one reports as failed. 2 and 6 are both
-# set *after* the Levenberg-Marquardt loop has converged (orbit_fit.cpp: the
-# reduced-chi-square test reads chi2_final, and the conditioning test is guarded
-# by `flag == 0`), so each means "converged, then rejected" -- which is exactly
-# the fact the driver used to discard.
-_CXX_GATE = {2: "failed_csq", 6: "failed_cov"}
 
 
 @dataclass
@@ -708,8 +709,8 @@ class FitOutcome:
 
     def record(self, fit):
         """Read the fitter's own verdict, before any driver flag overwrites it."""
-        self.converged = fit.flag in (0, 2, 6)
-        gate = _CXX_GATE.get(fit.flag)
+        self.converged = fit.flag in CONVERGED_FLAGS
+        gate = CXX_GATE_FLAGS.get(fit.flag)
         if gate is not None:
             setattr(self, gate, True)
 
@@ -729,19 +730,19 @@ class FitOutcome:
         not run through ``do_fit`` and so never observed the intermediate state.
         Lossy by construction -- a gate verdict that was overwritten is gone."""
         outcome = cls()
-        outcome.converged = flag in (0, 2, 6)
-        gate = _CXX_GATE.get(flag)
+        outcome.converged = flag in CONVERGED_FLAGS
+        gate = CXX_GATE_FLAGS.get(flag)
         if gate is not None:
             setattr(outcome, gate, True)
         outcome.stage = {
-            0: STAGE_COMPLETE,
-            2: STAGE_COMPLETE,
-            6: STAGE_COMPLETE,
-            3: STAGE_PRIMARY,
-            4: STAGE_BUILDUP,
-            5: STAGE_NO_CANDIDATES,
-            7: STAGE_INCREMENTAL,
-            8: STAGE_INCREMENTAL,
+            FLAG_CONVERGED: STAGE_COMPLETE,
+            FLAG_CSQ_TOO_LARGE: STAGE_COMPLETE,
+            FLAG_DEGENERATE_COV: STAGE_COMPLETE,
+            FLAG_NO_ROOT_CONVERGED: STAGE_PRIMARY,
+            FLAG_BUILDUP_FAILED: STAGE_BUILDUP,
+            FLAG_NO_SOLUTION: STAGE_NO_CANDIDATES,
+            FLAG_PRIOR_NOT_POSITIVE_DEFINITE: STAGE_INCREMENTAL,
+            FLAG_INCREMENTAL_NO_FULL_OBS: STAGE_INCREMENTAL,
         }.get(flag, STAGE_NOT_ATTEMPTED)
         return outcome
 
@@ -773,7 +774,7 @@ def create_empty_result(id, dtypes):
                 np.nan,  # epoch
                 0,  # niter
                 np.nan,  # method
-                -1,  # flag
+                FLAG_NOT_ATTEMPTED,  # flag
                 "NONE",  # format
             )
             + (np.nan,) * 36  # Flat covariance matrix
@@ -998,7 +999,7 @@ def do_fit(
         logger.debug(f"IOD {iod!r} returned no candidates")
         x = FitResult()
         outcome.stage = STAGE_NO_CANDIDATES
-        x.flag = 5
+        x.flag = FLAG_NO_SOLUTION
         return x
 
     # Pre-filter the IOD candidates by predicted-vs-observed residual
@@ -1075,7 +1076,7 @@ def do_fit(
             # surface, so return an explicit no-solution sentinel.
             x = FitResult()
             outcome.stage = STAGE_NO_CANDIDATES
-            x.flag = 5
+            x.flag = FLAG_NO_SOLUTION
             return x
         x = min(candidates, key=lambda c: c.csq)
         logger.debug(
@@ -1086,7 +1087,7 @@ def do_fit(
         # was reported as one that never converged (issue #499).
         outcome.stage = STAGE_PRIMARY
         outcome.record(x)
-        x.flag = 3
+        x.flag = FLAG_NO_ROOT_CONVERGED
         return x
 
     # Attempt to fit all the data, given the fit of the primary interval
@@ -1107,7 +1108,7 @@ def do_fit(
             if x.flag != 0:
                 outcome.stage = STAGE_BUILDUP
                 outcome.record(x)
-                x.flag = 4
+                x.flag = FLAG_BUILDUP_FAILED
                 break
             logger.debug(f"Result `state`: {x.state}")
             logger.debug(f"Epoch: {x.epoch}, CSQ: {x.csq}, ndof: {x.ndof}, num obs: {len(obs)}")

--- a/tests/layup/test_bk_everywhere.py
+++ b/tests/layup/test_bk_everywhere.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from layup.orbitfit import _MU_SUN, _run_fit
+from layup.constants import MU_SUN
+from layup.orbitfit import _run_fit
 from layup.routines import (
     FitResult,
     Observation,
@@ -213,7 +214,7 @@ def test_bk_native_ndof_zero_not_spuriously_flagged(case_name):
     assert len(obs) == 3  # guards the premise: this really is the ndof==0 case
     seed = _truth_seed(case)
 
-    result = run_bk_native_fit(ephem, seed, obs, _MU_SUN)
+    result = run_bk_native_fit(ephem, seed, obs, MU_SUN)
     assert result.ndof == 0
     assert result.csq > 0.0  # noisy obs -> nonzero residual, so csq/0 would be +inf
     assert result.flag == 0, f"ndof==0 fit spuriously flagged {result.flag} (csq={result.csq})"

--- a/tests/layup/test_bk_fit.py
+++ b/tests/layup/test_bk_fit.py
@@ -288,7 +288,8 @@ def test_run_fit_dispatch_cartesian():
 def test_run_fit_dispatch_bk_native():
     """orbitfit._run_fit(engine='bk_native') matches direct
     run_bk_native_fit with MU_SUN."""
-    from layup.orbitfit import _MU_SUN, _run_fit
+    from layup.constants import MU_SUN
+    from layup.orbitfit import _run_fit
 
     ephem = get_ephem(CACHE)
     state = [3.0, 0.0, 0.0, 0.0, 0.0102, 0.001]
@@ -297,7 +298,7 @@ def test_run_fit_dispatch_bk_native():
     seed = _seed_from_state(state, epoch)
 
     via_dispatch = _run_fit(ephem, seed, obs, "bk_native")
-    direct = run_bk_native_fit(ephem, seed, obs, _MU_SUN)
+    direct = run_bk_native_fit(ephem, seed, obs, MU_SUN)
     np.testing.assert_array_equal(via_dispatch.state, direct.state)
     assert via_dispatch.method == "bk_native"
 

--- a/tests/layup/test_fit_outcome.py
+++ b/tests/layup/test_fit_outcome.py
@@ -1,0 +1,178 @@
+"""Outcome facts are reported side by side, not collapsed into one flag (#499).
+
+`do_fit` marks where a fit gave up -- 3 when no IOD root converged on the primary
+interval, 4 when the incremental build-up stopped. Both assignments overwrite
+whatever the fitter returned, so a candidate that *converged* and was then
+rejected by a post-convergence gate (2 = reduced chi-square above threshold,
+6 = degenerate covariance) used to be reported as one that never converged.
+
+Rather than arbitrate between the two facts in a single integer, each is now
+reported in its own column. `flag` is unchanged and stays the summary.
+"""
+
+import numpy as np
+import pytest
+
+import layup.orbitfit as orbitfit
+from layup.orbitfit import (
+    OUTCOME_COLUMNS,
+    STAGE_BUILDUP,
+    STAGE_COMPLETE,
+    STAGE_INCREMENTAL,
+    STAGE_NO_CANDIDATES,
+    STAGE_NOT_ATTEMPTED,
+    STAGE_PRIMARY,
+    FitOutcome,
+)
+
+
+class _Fit:
+    """Stand-in for the C++ FitResult, carrying only what do_fit reads."""
+
+    def __init__(self, flag, csq=1.0):
+        self.flag = flag
+        self.csq = csq
+        self.ndof = 1
+        self.state = [1.0, 0.0, 0.0, 0.0, 0.017, 0.0]
+        self.epoch = 2460000.5
+        self.cov = [0.0] * 36
+        self.method = "test"
+        self.niter = 1
+
+
+def _drive(monkeypatch, flags, n_obs=6):
+    """Run do_fit with _run_fit returning `flags` in turn, and no real IOD."""
+    seq = iter(flags)
+    monkeypatch.setattr(orbitfit, "_run_fit", lambda *a, **k: _Fit(next(seq)))
+    monkeypatch.setattr(orbitfit, "get_iod", lambda name: (lambda obs, s: [_Fit(0)]))
+    monkeypatch.setattr(orbitfit, "filter_candidates_by_residual", lambda cands, *a, **k: (list(cands), None))
+    monkeypatch.setattr(orbitfit, "get_ephem", lambda *a, **k: None)
+    outcome = FitOutcome()
+    observations = [object()] * n_obs
+    result = orbitfit.do_fit(
+        observations, [list(range(n_obs))], cache_dir="/tmp", iod="gauss", outcome=outcome
+    )
+    return result, outcome
+
+
+# --------------------------------------------------------------------------
+# The collision the separate columns remove
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("gate_flag,column", [(2, "gate_csq"), (6, "gate_cov")])
+def test_gate_verdict_survives_the_no_root_marker(monkeypatch, gate_flag, column):
+    """flag still reports where it stopped; the gate is reported separately."""
+    result, outcome = _drive(monkeypatch, [gate_flag] * 3)
+    assert result.flag == 3, "the summary flag still marks where the fit stopped"
+    assert getattr(outcome, column) is True, "the gate verdict is no longer lost"
+    assert outcome.converged is True, "flags 2 and 6 are set after convergence"
+    assert outcome.stage == STAGE_PRIMARY
+
+
+@pytest.mark.parametrize("gate_flag,column", [(2, "gate_csq"), (6, "gate_cov")])
+def test_gate_verdict_survives_the_buildup_marker(monkeypatch, gate_flag, column):
+    """First fit converges, the full-set refit is gated, build-up then fails."""
+    result, outcome = _drive(monkeypatch, [0, gate_flag, gate_flag])
+    assert result.flag == 4
+    assert getattr(outcome, column) is True
+    assert outcome.converged is True
+    assert outcome.stage == STAGE_BUILDUP
+
+
+def test_plain_nonconvergence_reports_no_gate(monkeypatch):
+    """A fit that never converged must not look like a gated one."""
+    result, outcome = _drive(monkeypatch, [1] * 3)
+    assert result.flag == 3
+    assert outcome.converged is False
+    assert outcome.gate_csq is False and outcome.gate_cov is False
+    assert outcome.stage == STAGE_PRIMARY
+
+
+def test_clean_fit_is_complete_and_ungated(monkeypatch):
+    result, outcome = _drive(monkeypatch, [0, 0, 0])
+    assert result.flag == 0
+    assert outcome.converged is True
+    assert outcome.stage == STAGE_COMPLETE
+    assert not any((outcome.gate_csq, outcome.gate_cov, outcome.gate_physical))
+
+
+def test_no_iod_candidates_reports_that_stage(monkeypatch):
+    monkeypatch.setattr(orbitfit, "get_iod", lambda name: (lambda obs, s: []))
+    monkeypatch.setattr(orbitfit, "get_ephem", lambda *a, **k: None)
+    outcome = FitOutcome()
+    result = orbitfit.do_fit([object()] * 6, [list(range(6))], "/tmp", iod="gauss", outcome=outcome)
+    assert result.flag == 5
+    assert outcome.stage == STAGE_NO_CANDIDATES
+    assert outcome.converged is False
+
+
+# --------------------------------------------------------------------------
+# The record itself
+# --------------------------------------------------------------------------
+
+
+def test_outcome_is_optional_so_existing_callers_are_unaffected(monkeypatch):
+    """do_fit's contract is unchanged when no record is supplied."""
+    seq = iter([0, 0, 0])
+    monkeypatch.setattr(orbitfit, "_run_fit", lambda *a, **k: _Fit(next(seq)))
+    monkeypatch.setattr(orbitfit, "get_iod", lambda name: (lambda obs, s: [_Fit(0)]))
+    monkeypatch.setattr(orbitfit, "filter_candidates_by_residual", lambda cands, *a, **k: (list(cands), None))
+    monkeypatch.setattr(orbitfit, "get_ephem", lambda *a, **k: None)
+    result = orbitfit.do_fit([object()] * 6, [list(range(6))], "/tmp", iod="gauss")
+    assert result.flag == 0
+
+
+@pytest.mark.parametrize(
+    "flag,converged,stage",
+    [
+        (0, True, STAGE_COMPLETE),
+        (2, True, STAGE_COMPLETE),
+        (6, True, STAGE_COMPLETE),
+        (1, False, STAGE_NOT_ATTEMPTED),
+        (3, False, STAGE_PRIMARY),
+        (4, False, STAGE_BUILDUP),
+        (5, False, STAGE_NO_CANDIDATES),
+        (8, False, STAGE_INCREMENTAL),
+    ],
+)
+def test_from_flag_reconstructs_what_the_summary_still_permits(flag, converged, stage):
+    outcome = FitOutcome.from_flag(flag)
+    assert outcome.converged is converged
+    assert outcome.stage == stage
+
+
+def test_as_row_is_ints_in_column_order():
+    outcome = FitOutcome(converged=True, stage=STAGE_COMPLETE, gate_csq=True)
+    row = outcome.as_row()
+    assert len(row) == len(OUTCOME_COLUMNS)
+    assert all(isinstance(v, int) for v in row)
+    assert row == (1, STAGE_COMPLETE, 1, 0, 0)
+
+
+# --------------------------------------------------------------------------
+# The output schema
+# --------------------------------------------------------------------------
+
+
+def test_columns_respect_the_existing_layout_invariants():
+    """Two layouts are already pinned by test_incremental_fit: the fingerprint
+    columns are last, and the optional non-grav columns sit immediately before
+    them. The outcome columns are unconditional, so they group with the other
+    unconditional columns ahead of both."""
+    dt = orbitfit._get_result_dtypes("ObjID", [])
+    assert dt.names[-2:] == ("obs_hash", "nobs_fit")
+    assert set(OUTCOME_COLUMNS) <= set(dt.names)
+    assert dt.names.index("flag") < dt.names.index("converged")
+
+    dt_ng = orbitfit._get_result_dtypes("ObjID", ("A2",))
+    assert dt_ng.names[-4:] == ("a2", "a2_unc", "obs_hash", "nobs_fit")
+    assert dt_ng.names.index("gate_physical") < dt_ng.names.index("a2")
+
+
+def test_empty_result_reports_not_attempted():
+    dt = orbitfit._get_result_dtypes("ObjID", [])
+    row = orbitfit.create_empty_result("x", dt)
+    assert row["flag"][0] == -1
+    assert row["converged"][0] == 0
+    assert row["stage"][0] == STAGE_NOT_ATTEMPTED

--- a/tests/layup/test_fit_outcome.py
+++ b/tests/layup/test_fit_outcome.py
@@ -60,7 +60,7 @@ def _drive(monkeypatch, flags, n_obs=6):
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("gate_flag,column", [(2, "gate_csq"), (6, "gate_cov")])
+@pytest.mark.parametrize("gate_flag,column", [(2, "failed_csq"), (6, "failed_cov")])
 def test_gate_verdict_survives_the_no_root_marker(monkeypatch, gate_flag, column):
     """flag still reports where it stopped; the gate is reported separately."""
     result, outcome = _drive(monkeypatch, [gate_flag] * 3)
@@ -70,7 +70,7 @@ def test_gate_verdict_survives_the_no_root_marker(monkeypatch, gate_flag, column
     assert outcome.stage == STAGE_PRIMARY
 
 
-@pytest.mark.parametrize("gate_flag,column", [(2, "gate_csq"), (6, "gate_cov")])
+@pytest.mark.parametrize("gate_flag,column", [(2, "failed_csq"), (6, "failed_cov")])
 def test_gate_verdict_survives_the_buildup_marker(monkeypatch, gate_flag, column):
     """First fit converges, the full-set refit is gated, build-up then fails."""
     result, outcome = _drive(monkeypatch, [0, gate_flag, gate_flag])
@@ -85,7 +85,7 @@ def test_plain_nonconvergence_reports_no_gate(monkeypatch):
     result, outcome = _drive(monkeypatch, [1] * 3)
     assert result.flag == 3
     assert outcome.converged is False
-    assert outcome.gate_csq is False and outcome.gate_cov is False
+    assert outcome.failed_csq is False and outcome.failed_cov is False
     assert outcome.stage == STAGE_PRIMARY
 
 
@@ -94,7 +94,7 @@ def test_clean_fit_is_complete_and_ungated(monkeypatch):
     assert result.flag == 0
     assert outcome.converged is True
     assert outcome.stage == STAGE_COMPLETE
-    assert not any((outcome.gate_csq, outcome.gate_cov, outcome.gate_physical))
+    assert not any((outcome.failed_csq, outcome.failed_cov, outcome.failed_physical))
 
 
 def test_no_iod_candidates_reports_that_stage(monkeypatch):
@@ -143,7 +143,7 @@ def test_from_flag_reconstructs_what_the_summary_still_permits(flag, converged, 
 
 
 def test_as_row_is_ints_in_column_order():
-    outcome = FitOutcome(converged=True, stage=STAGE_COMPLETE, gate_csq=True)
+    outcome = FitOutcome(converged=True, stage=STAGE_COMPLETE, failed_csq=True)
     row = outcome.as_row()
     assert len(row) == len(OUTCOME_COLUMNS)
     assert all(isinstance(v, int) for v in row)
@@ -167,7 +167,7 @@ def test_columns_respect_the_existing_layout_invariants():
 
     dt_ng = orbitfit._get_result_dtypes("ObjID", ("A2",))
     assert dt_ng.names[-4:] == ("a2", "a2_unc", "obs_hash", "nobs_fit")
-    assert dt_ng.names.index("gate_physical") < dt_ng.names.index("a2")
+    assert dt_ng.names.index("failed_physical") < dt_ng.names.index("a2")
 
 
 def test_empty_result_reports_not_attempted():

--- a/tests/layup/test_fit_outcome.py
+++ b/tests/layup/test_fit_outcome.py
@@ -119,6 +119,9 @@ def test_clean_fit_is_complete_and_ungated(monkeypatch):
 
 
 def test_no_iod_candidates_reports_that_stage(monkeypatch):
+    """Initial orbit determination returns nothing, so there is no candidate to
+    screen: the fit stops before the pipeline starts, and `stage` says which
+    point that was rather than leaving it to be inferred from the flag."""
     monkeypatch.setattr(orbitfit, "get_iod", lambda name: (lambda obs, s: []))
     monkeypatch.setattr(orbitfit, "get_ephem", lambda *a, **k: None)
     outcome = FitOutcome()
@@ -158,12 +161,20 @@ def test_outcome_is_optional_so_existing_callers_are_unaffected(monkeypatch):
     ],
 )
 def test_from_flag_reconstructs_what_the_summary_still_permits(flag, converged, stage):
+    """Paths that do not run the staged pipeline -- the sequential update, and a
+    fit started from a supplied initial guess -- never observe the intermediate
+    state, so the columns are reconstructed from the summary flag alone. Lossy by
+    construction: a gate verdict that was overwritten cannot be recovered. This
+    pins what each flag value still implies."""
     outcome = FitOutcome.from_flag(flag)
     assert outcome.converged is converged
     assert outcome.stage == stage
 
 
 def test_as_row_is_ints_in_column_order():
+    """The row is written straight into an i1 column per name, so it must be
+    plain ints in OUTCOME_COLUMNS order. A bool or a reordering would be stored
+    without complaint and silently mislabel every fit."""
     outcome = FitOutcome(converged=True, stage=STAGE_COMPLETE, failed_csq=True)
     row = outcome.as_row()
     assert len(row) == len(OUTCOME_COLUMNS)
@@ -192,6 +203,9 @@ def test_columns_respect_the_existing_layout_invariants():
 
 
 def test_empty_result_reports_not_attempted():
+    """A row for an object that was never fit must not read as a failed fit:
+    flag is the not-attempted sentinel, and the columns say the same -- not
+    converged, no stage reached, no check applied."""
     dt = orbitfit._get_result_dtypes("ObjID", [])
     row = orbitfit.create_empty_result("x", dt)
     assert row["flag"][0] == FLAG_NOT_ATTEMPTED

--- a/tests/layup/test_fit_outcome.py
+++ b/tests/layup/test_fit_outcome.py
@@ -50,7 +50,13 @@ class _Fit:
 
 
 def _drive(monkeypatch, flags, n_obs=6):
-    """Run do_fit with _run_fit returning `flags` in turn, and no real IOD."""
+    """Run do_fit with no real IOD, and `_run_fit` returning `flags` in turn.
+
+    do_fit calls `_run_fit` at up to three points, so the list reads as the
+    outcome of each in order: the candidate screen over the primary interval,
+    the refit over all observations, then -- only if that refit did not
+    converge -- the first segment of the incremental build-up.
+    """
     seq = iter(flags)
     monkeypatch.setattr(orbitfit, "_run_fit", lambda *a, **k: _Fit(next(seq)))
     monkeypatch.setattr(orbitfit, "get_iod", lambda name: (lambda obs, s: [_Fit(0)]))
@@ -86,7 +92,7 @@ def test_gate_verdict_survives_the_no_root_marker(monkeypatch, gate_flag, column
 )
 def test_gate_verdict_survives_the_buildup_marker(monkeypatch, gate_flag, column):
     """First fit converges, the full-set refit is gated, build-up then fails."""
-    result, outcome = _drive(monkeypatch, [0, gate_flag, gate_flag])
+    result, outcome = _drive(monkeypatch, [FLAG_CONVERGED, gate_flag, gate_flag])
     assert result.flag == FLAG_BUILDUP_FAILED
     assert getattr(outcome, column) is True
     assert outcome.converged is True
@@ -103,7 +109,9 @@ def test_plain_nonconvergence_reports_no_gate(monkeypatch):
 
 
 def test_clean_fit_is_complete_and_ungated(monkeypatch):
-    result, outcome = _drive(monkeypatch, [0, 0, 0])
+    """The screen and the full-set refit both converge, so no build-up runs and
+    nothing rejects the result: the summary flag and every column agree."""
+    result, outcome = _drive(monkeypatch, [FLAG_CONVERGED] * 3)
     assert result.flag == FLAG_CONVERGED
     assert outcome.converged is True
     assert outcome.stage == STAGE_COMPLETE

--- a/tests/layup/test_fit_outcome.py
+++ b/tests/layup/test_fit_outcome.py
@@ -14,7 +14,16 @@ import numpy as np
 import pytest
 
 import layup.orbitfit as orbitfit
-from layup.orbitfit import (
+from layup.constants import (
+    FLAG_BUILDUP_FAILED,
+    FLAG_CONVERGED,
+    FLAG_CSQ_TOO_LARGE,
+    FLAG_DEGENERATE_COV,
+    FLAG_DID_NOT_CONVERGE,
+    FLAG_INCREMENTAL_NO_FULL_OBS,
+    FLAG_NO_ROOT_CONVERGED,
+    FLAG_NO_SOLUTION,
+    FLAG_NOT_ATTEMPTED,
     OUTCOME_COLUMNS,
     STAGE_BUILDUP,
     STAGE_COMPLETE,
@@ -22,8 +31,8 @@ from layup.orbitfit import (
     STAGE_NO_CANDIDATES,
     STAGE_NOT_ATTEMPTED,
     STAGE_PRIMARY,
-    FitOutcome,
 )
+from layup.orbitfit import FitOutcome
 
 
 class _Fit:
@@ -60,21 +69,25 @@ def _drive(monkeypatch, flags, n_obs=6):
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("gate_flag,column", [(2, "failed_csq"), (6, "failed_cov")])
+@pytest.mark.parametrize(
+    "gate_flag,column", [(FLAG_CSQ_TOO_LARGE, "failed_csq"), (FLAG_DEGENERATE_COV, "failed_cov")]
+)
 def test_gate_verdict_survives_the_no_root_marker(monkeypatch, gate_flag, column):
     """flag still reports where it stopped; the gate is reported separately."""
     result, outcome = _drive(monkeypatch, [gate_flag] * 3)
-    assert result.flag == 3, "the summary flag still marks where the fit stopped"
+    assert result.flag == FLAG_NO_ROOT_CONVERGED, "the summary flag still marks where the fit stopped"
     assert getattr(outcome, column) is True, "the gate verdict is no longer lost"
     assert outcome.converged is True, "flags 2 and 6 are set after convergence"
     assert outcome.stage == STAGE_PRIMARY
 
 
-@pytest.mark.parametrize("gate_flag,column", [(2, "failed_csq"), (6, "failed_cov")])
+@pytest.mark.parametrize(
+    "gate_flag,column", [(FLAG_CSQ_TOO_LARGE, "failed_csq"), (FLAG_DEGENERATE_COV, "failed_cov")]
+)
 def test_gate_verdict_survives_the_buildup_marker(monkeypatch, gate_flag, column):
     """First fit converges, the full-set refit is gated, build-up then fails."""
     result, outcome = _drive(monkeypatch, [0, gate_flag, gate_flag])
-    assert result.flag == 4
+    assert result.flag == FLAG_BUILDUP_FAILED
     assert getattr(outcome, column) is True
     assert outcome.converged is True
     assert outcome.stage == STAGE_BUILDUP
@@ -82,8 +95,8 @@ def test_gate_verdict_survives_the_buildup_marker(monkeypatch, gate_flag, column
 
 def test_plain_nonconvergence_reports_no_gate(monkeypatch):
     """A fit that never converged must not look like a gated one."""
-    result, outcome = _drive(monkeypatch, [1] * 3)
-    assert result.flag == 3
+    result, outcome = _drive(monkeypatch, [FLAG_DID_NOT_CONVERGE] * 3)
+    assert result.flag == FLAG_NO_ROOT_CONVERGED
     assert outcome.converged is False
     assert outcome.failed_csq is False and outcome.failed_cov is False
     assert outcome.stage == STAGE_PRIMARY
@@ -91,7 +104,7 @@ def test_plain_nonconvergence_reports_no_gate(monkeypatch):
 
 def test_clean_fit_is_complete_and_ungated(monkeypatch):
     result, outcome = _drive(monkeypatch, [0, 0, 0])
-    assert result.flag == 0
+    assert result.flag == FLAG_CONVERGED
     assert outcome.converged is True
     assert outcome.stage == STAGE_COMPLETE
     assert not any((outcome.failed_csq, outcome.failed_cov, outcome.failed_physical))
@@ -102,7 +115,7 @@ def test_no_iod_candidates_reports_that_stage(monkeypatch):
     monkeypatch.setattr(orbitfit, "get_ephem", lambda *a, **k: None)
     outcome = FitOutcome()
     result = orbitfit.do_fit([object()] * 6, [list(range(6))], "/tmp", iod="gauss", outcome=outcome)
-    assert result.flag == 5
+    assert result.flag == FLAG_NO_SOLUTION
     assert outcome.stage == STAGE_NO_CANDIDATES
     assert outcome.converged is False
 
@@ -120,20 +133,20 @@ def test_outcome_is_optional_so_existing_callers_are_unaffected(monkeypatch):
     monkeypatch.setattr(orbitfit, "filter_candidates_by_residual", lambda cands, *a, **k: (list(cands), None))
     monkeypatch.setattr(orbitfit, "get_ephem", lambda *a, **k: None)
     result = orbitfit.do_fit([object()] * 6, [list(range(6))], "/tmp", iod="gauss")
-    assert result.flag == 0
+    assert result.flag == FLAG_CONVERGED
 
 
 @pytest.mark.parametrize(
     "flag,converged,stage",
     [
-        (0, True, STAGE_COMPLETE),
-        (2, True, STAGE_COMPLETE),
-        (6, True, STAGE_COMPLETE),
-        (1, False, STAGE_NOT_ATTEMPTED),
-        (3, False, STAGE_PRIMARY),
-        (4, False, STAGE_BUILDUP),
-        (5, False, STAGE_NO_CANDIDATES),
-        (8, False, STAGE_INCREMENTAL),
+        (FLAG_CONVERGED, True, STAGE_COMPLETE),
+        (FLAG_CSQ_TOO_LARGE, True, STAGE_COMPLETE),
+        (FLAG_DEGENERATE_COV, True, STAGE_COMPLETE),
+        (FLAG_DID_NOT_CONVERGE, False, STAGE_NOT_ATTEMPTED),
+        (FLAG_NO_ROOT_CONVERGED, False, STAGE_PRIMARY),
+        (FLAG_BUILDUP_FAILED, False, STAGE_BUILDUP),
+        (FLAG_NO_SOLUTION, False, STAGE_NO_CANDIDATES),
+        (FLAG_INCREMENTAL_NO_FULL_OBS, False, STAGE_INCREMENTAL),
     ],
 )
 def test_from_flag_reconstructs_what_the_summary_still_permits(flag, converged, stage):
@@ -173,6 +186,6 @@ def test_columns_respect_the_existing_layout_invariants():
 def test_empty_result_reports_not_attempted():
     dt = orbitfit._get_result_dtypes("ObjID", [])
     row = orbitfit.create_empty_result("x", dt)
-    assert row["flag"][0] == -1
+    assert row["flag"][0] == FLAG_NOT_ATTEMPTED
     assert row["converged"][0] == 0
     assert row["stage"][0] == STAGE_NOT_ATTEMPTED

--- a/tests/layup/test_fit_outcome.py
+++ b/tests/layup/test_fit_outcome.py
@@ -1,4 +1,4 @@
-"""Outcome facts are reported side by side, not collapsed into one flag (#499).
+"""Outcome facts are reported side by side, not collapsed into one flag.
 
 `do_fit` marks where a fit gave up -- 3 when no IOD root converged on the primary
 interval, 4 when the incremental build-up stopped. Both assignments overwrite


### PR DESCRIPTION
Adds five columns reporting the fit outcome as independent facts: `converged`, `stage`, `failed_csq`, `failed_cov`, `failed_physical`. `do_fit` takes an optional record to fill, so its return type and every existing caller are unchanged.

`flag` is untouched and stays the summary: 0 if and only if the fit converged and every check passed. No existing filter or column changes meaning.

Supersedes #507. #497 becomes one line setting `failed_physical`.