### PR TITLE
Report the chi-square on fits that were rejected rather than accepted

### DIFF
--- a/src/layup/constants.py
+++ b/src/layup/constants.py
@@ -109,3 +109,9 @@ CXX_GATE_FLAGS = {FLAG_CSQ_TOO_LARGE: "failed_csq", FLAG_DEGENERATE_COV: "failed
 
 # The flags that mean the differential correction reached a solution.
 CONVERGED_FLAGS = (FLAG_CONVERGED, FLAG_CSQ_TOO_LARGE, FLAG_DEGENERATE_COV)
+
+# The flags for which no chi-square exists to report: one where no fit was ever
+# run, and one where no initial-orbit candidate was found to score. Every other
+# flag carries a chi-square -- including the stage markers, since ``do_fit``
+# returns the lowest-chi-square candidate it tried.
+NO_CSQ_FLAGS = (FLAG_NOT_ATTEMPTED, FLAG_NO_SOLUTION)

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -49,6 +49,7 @@ from layup.constants import (
     KM_S_IN_AU_PER_DAY,
     MAX_EXCESS_SPEED_KM_S,
     MU_SUN,
+    NO_CSQ_FLAGS,
     OUTCOME_COLUMNS,
     SPEED_OF_LIGHT,
     STAGE_BUILDUP,
@@ -1512,6 +1513,11 @@ def _orbitfit(
 
         # Populate our output structured array with the orbit fit results
         success = res.flag == 0
+        # The chi-square is reported whenever the fitter produced one, not only
+        # when the fit was accepted. A fit rejected *on* chi-square otherwise
+        # discards the number that explains the rejection, and a stage marker
+        # (3, 4) hides the lowest chi-square do_fit reached.
+        has_csq = res.flag not in NO_CSQ_FLAGS
         if not success:
             _warn_if_short_arc(jds, data[primary_id_column_name][0])
         cov_matrix = tuple(res.cov[i] for i in range(36)) if success else (np.nan,) * 36
@@ -1553,7 +1559,7 @@ def _orbitfit(
             [
                 (
                     data[primary_id_column_name][0],
-                    (res.csq if success else np.nan),
+                    (res.csq if has_csq else np.nan),
                     res.ndof,
                 )
                 + (tuple(res.state[i] for i in range(6)) if success else (np.nan,) * 6)  # Flat state vector

--- a/tests/layup/test_csq_reporting.py
+++ b/tests/layup/test_csq_reporting.py
@@ -1,0 +1,83 @@
+"""The chi-square is reported whenever the fitter produced one.
+
+A fit that converged and was then rejected -- on reduced chi-square, or on a
+degenerate covariance -- used to report ``csq = NaN``, discarding the number
+that explains the rejection exactly when it is wanted. The stage markers hid it
+too: ``do_fit`` returns the lowest-chi-square candidate it tried, so a fit
+labelled 3 or 4 still carries a meaningful score.
+
+Only two flags have no chi-square to report: a row that was never fit, and one
+where no initial-orbit candidate was found to score.
+"""
+
+import numpy as np
+import pytest
+
+from layup.constants import (
+    FLAG_BUILDUP_FAILED,
+    FLAG_CONVERGED,
+    FLAG_CSQ_TOO_LARGE,
+    FLAG_DEGENERATE_COV,
+    FLAG_DID_NOT_CONVERGE,
+    FLAG_IMPLAUSIBLE_ORBIT,
+    FLAG_INCREMENTAL_NO_FULL_OBS,
+    FLAG_NO_ROOT_CONVERGED,
+    FLAG_NO_SOLUTION,
+    FLAG_NOT_ATTEMPTED,
+    FLAG_PRIOR_NOT_POSITIVE_DEFINITE,
+    NO_CSQ_FLAGS,
+)
+
+
+# The condition `_orbitfit` applies, stated once so the test exercises the rule
+# rather than a copy of it.
+def _reports_csq(flag):
+    return flag not in NO_CSQ_FLAGS
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        FLAG_CONVERGED,
+        FLAG_DID_NOT_CONVERGE,
+        FLAG_CSQ_TOO_LARGE,
+        FLAG_NO_ROOT_CONVERGED,
+        FLAG_BUILDUP_FAILED,
+        FLAG_DEGENERATE_COV,
+        FLAG_PRIOR_NOT_POSITIVE_DEFINITE,
+        FLAG_INCREMENTAL_NO_FULL_OBS,
+        FLAG_IMPLAUSIBLE_ORBIT,
+    ],
+)
+def test_every_flag_that_ran_a_fit_reports_its_chi_square(flag):
+    assert _reports_csq(flag)
+
+
+@pytest.mark.parametrize("flag", [FLAG_NOT_ATTEMPTED, FLAG_NO_SOLUTION])
+def test_the_two_flags_with_nothing_to_score_report_nan(flag):
+    assert not _reports_csq(flag)
+
+
+def test_the_rejection_flags_are_the_point():
+    """A fit rejected *on* chi-square must report the chi-square it was
+    rejected for; the same holds for the covariance check, which also fires
+    only after the differential correction converged."""
+    assert _reports_csq(FLAG_CSQ_TOO_LARGE)
+    assert _reports_csq(FLAG_DEGENERATE_COV)
+
+
+def test_the_stage_markers_report_a_chi_square_too():
+    """`do_fit` returns the lowest-chi-square candidate it tried, so 3 and 4
+    carry the least-bad score rather than nothing. These are the flags the
+    cold-start failures actually carry."""
+    assert _reports_csq(FLAG_NO_ROOT_CONVERGED)
+    assert _reports_csq(FLAG_BUILDUP_FAILED)
+
+
+def test_reporting_a_chi_square_is_not_a_claim_that_the_fit_is_usable():
+    """The state stays NaN for anything but a clean fit, so a finite csq on a
+    rejected row cannot be mistaken for an accepted orbit."""
+    from layup.constants import CONVERGED_FLAGS
+
+    assert FLAG_NO_ROOT_CONVERGED not in CONVERGED_FLAGS
+    assert FLAG_BUILDUP_FAILED not in CONVERGED_FLAGS


### PR DESCRIPTION
`csq` is now written for every flag except -1 (never attempted) and 5 (no
candidate found to score). The state, covariance and epoch stay gated on
`flag == 0`, so a finite chi-square on a rejected row cannot be read as an
accepted orbit.

This makes the stage markers diagnosable. On ten main-belt objects a cold start
cannot fit -- all flag 3 or 4, all previously NaN -- the chi-squares separate
into two groups the flags could not distinguish: four between 22 and 2652, and
six between 5e7 and 2e10. The first group is a weighting or outlier problem on a
good orbit; the second is a wrong orbit.

Closes #518.