### PR TITLE
Propagate fitted non-gravitational parameters in predict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@ residual rows they contribute, not in the code path they take.
 - Ephemeris-quality integrations through ASSIST and REBOUND, using the IAS15
   integrator.
 - Predictions that integrate once and interpolate to many epochs and observatory
-  locations.
+  locations, propagating any non-gravitational acceleration the fit solved for, so
+  a predicted position and its uncertainty ellipse are consistent with the orbit
+  that produced them.
 
 ### Interfaces
 

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -362,6 +362,23 @@ def parse_fit_result(
             cov[i] = 0.0
     res.cov = cov
 
+    # Carry the fitted non-gravitational parameters back onto the FitResult
+    # (issue #522). The a1/a2/a3 columns exist only when a non-gravitational fit
+    # ran, so their presence is what identifies which were active. Without this
+    # the parameters are silently dropped at the Python boundary and every
+    # downstream propagation -- predict, residuals_at_state, sequential_update --
+    # runs gravity-only on a state that was fitted with non-gravs.
+    names = getattr(fit_result_row, "dtype", None)
+    names = set(names.names) if names is not None and names.names else set()
+    mask = 0
+    for bit, col in ((1, "a1"), (2, "a2"), (4, "a3")):
+        if col in names:
+            val = float(fit_result_row[col])
+            if np.isfinite(val) and val != 0.0:
+                setattr(res, col, val)
+                mask |= bit
+    res.nongrav_mask = mask
+
     return res
 
 

--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -672,11 +672,17 @@ namespace orbit_fit
                          reverse_in_seq, reverse_out_seq,
                          forward_in_seq, forward_out_seq);
 
+        // issue #522: pass the fitted non-gravitational parameters through, or the
+        // residuals are those of a gravity-only trajectory started from a state
+        // that was fitted WITH non-gravs -- which is not the fit's residual.
+        const double a123[3] = {fit.a1, fit.a2, fit.a3};
         compute_residuals(ephem, p0, epoch,
                           detections,
                           resid_vec, partials_vec,
                           forward_in_seq, forward_out_seq,
-                          reverse_in_seq, reverse_out_seq);
+                          reverse_in_seq, reverse_out_seq,
+                          fit.nongrav_mask,
+                          fit.nongrav_mask ? a123 : nullptr);
 
         std::vector<std::array<double, 6>> out(N);
         for (size_t i = 0; i < N; ++i)

--- a/src/lib/orbit_fit/predict.cpp
+++ b/src/lib/orbit_fit/predict.cpp
@@ -202,11 +202,41 @@ namespace orbit_fit
         return result;
     }
 
+    // Enable ASSIST's Marsden non-gravitational force on a prediction simulation,
+    // mirroring what the fit does (orbit_fit.cpp, issue #351). Without this a
+    // prediction propagates gravity-only even when the fit solved for A1/A2/A3,
+    // so the predicted position -- and the covariance mapped about it -- are wrong
+    // for any non-gravitationally fitted object (issue #522).
+    //
+    // `pp` must outlive every integration on this simulation: ASSIST holds the
+    // pointer, it does not copy. The caller owns it.
+    //
+    // Only the real particle's [A1,A2,A3] are set. Prediction needs no parameter
+    // variational particles: the fit's covariance is already 6x6 in the state, and
+    // d(state)/dA is not propagated here.
+    static void apply_nongrav_from_fit(struct assist_extras *ax,
+                                       const FitResult &fit,
+                                       std::vector<double> &pp,
+                                       size_t n_particles)
+    {
+        if (fit.nongrav_mask == 0)
+            return;
+        ax->forces = (enum ASSIST_FORCES)(ax->forces | ASSIST_FORCE_NON_GRAVITATIONAL);
+        // Same default g(r) as the fit: the asteroidal inverse square (r/r0)^-2.
+        ax->alpha = 1.0; ax->nm = 2.0; ax->nk = 0.0; ax->nn = 1.0; ax->r0 = 1.0;
+        pp.assign(3 * n_particles, 0.0);
+        pp[0] = (fit.nongrav_mask & 1) ? fit.a1 : 0.0;
+        pp[1] = (fit.nongrav_mask & 2) ? fit.a2 : 0.0;
+        pp[2] = (fit.nongrav_mask & 4) ? fit.a3 : 0.0;
+        ax->particle_params = pp.data();
+    }
+
     PredictResult predict(struct assist_ephem *ephem,
                           struct reb_particle p0, double epoch,
                           Observation this_det,
                           Eigen::MatrixXd &cov,
-                          Eigen::MatrixXd &obs_cov)
+                          Eigen::MatrixXd &obs_cov,
+                          const FitResult *fit = nullptr)
     {
 
         // Takes an ephemeris object, a simulation,
@@ -232,6 +262,12 @@ namespace orbit_fit
         int var;
         add_variational_particles(r, 0, &var);
 
+        // issue #522: propagate with the fitted non-gravitational acceleration if
+        // one was supplied. pp must outlive the integration below.
+        std::vector<double> pp;
+        if (fit)
+            apply_nongrav_from_fit(ax, *fit, pp, 1 + (size_t)r->N_var);
+
         PredictResult result = compute_single_predict(ephem, ax, var, this_det, cov, obs_cov);
 
         assist_free(ax);
@@ -239,6 +275,7 @@ namespace orbit_fit
 
         return result;
     }
+
 
     PredictResult predict_from_fit_result(struct assist_ephem *ephem,
                                           FitResult fit,
@@ -260,7 +297,8 @@ namespace orbit_fit
             fit.epoch,
             obs_position,
             cov,
-            obs_cov);
+            obs_cov,
+            &fit);
 
         return res;
     }
@@ -277,7 +315,8 @@ namespace orbit_fit
                                Eigen::MatrixXd &cov,
                                std::vector<PredictResult> &results,
                                std::vector<size_t> &in_seq,
-                               std::vector<size_t> &out_seq)
+                               std::vector<size_t> &out_seq,
+                               const FitResult &fit)
     {
         if (in_seq.empty())
             return;
@@ -291,6 +330,10 @@ namespace orbit_fit
         reb_simulation_add(r, p0);
         int var;
         add_variational_particles(r, 0, &var);
+        // issue #522: propagate with the fitted non-gravitational acceleration,
+        // not gravity-only. pp must outlive the integrations below.
+        std::vector<double> pp;
+        apply_nongrav_from_fit(ax, fit, pp, 1 + (size_t)r->N_var);
 
         Eigen::MatrixXd obs_cov(2, 2);
         for (size_t i = 0; i < in_seq.size(); ++i)
@@ -336,9 +379,9 @@ namespace orbit_fit
                          forward_in_seq, forward_out_seq);
 
         predict_sequence_pass(ephem, p0, epoch, detections, cov, results,
-                              forward_in_seq, forward_out_seq);
+                              forward_in_seq, forward_out_seq, fit);
         predict_sequence_pass(ephem, p0, epoch, detections, cov, results,
-                              reverse_in_seq, reverse_out_seq);
+                              reverse_in_seq, reverse_out_seq, fit);
 
         return results;
     }

--- a/tests/layup/test_predict_nongrav.py
+++ b/tests/layup/test_predict_nongrav.py
@@ -1,0 +1,115 @@
+"""Predictions must carry the fitted non-gravitational acceleration (issue #522).
+
+`predict` and `residuals_at_state` build their own simulations from the fitted
+state. Before this fix neither enabled ASSIST's Marsden non-gravitational force,
+so both propagated gravity-only even when the fit had solved for A1/A2/A3 -- and
+`parse_fit_result` did not carry the amplitudes across the Python boundary at
+all, so the information never reached the C++ in the first place.
+
+The symptom was silent: a predicted position, and the uncertainty ellipse mapped
+about it, were simply wrong for any non-gravitationally fitted object, with no
+warning. On (152563) 1992 BF over its 71-year arc the error reached ~15 arcsec.
+
+The invariant asserted here is the one that caught it: at the fitted state, the
+chi-square implied by `residuals_at_state` must equal the chi-square the fit
+reports. It does for a gravity-only fit whether or not the bug is present, and
+only for a non-gravitational fit once the parameters are actually propagated.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pooch
+import pytest
+
+from layup.orbitfit import orbitfit
+from layup.routines import get_ephem, numpy_to_eigen, residuals_at_state
+from layup.utilities.data_processing_utilities import parse_fit_result
+
+from test_nongrav_a2 import _build_arc_array, _TRUE_A2  # noqa: E402
+
+CACHE = str(pooch.os_cache("layup"))
+_EPHEM = ("linux_p1550p2650.440", "sb441-n16.bsp")
+pytestmark = pytest.mark.skipif(
+    not all(os.path.exists(os.path.join(CACHE, f)) for f in _EPHEM),
+    reason="ASSIST ephemeris not in layup cache; run `layup bootstrap`",
+)
+
+ARCSEC = 180.0 * 3600.0 / np.pi
+
+
+def _observations(data):
+    """Build the Observation list the fit itself would build from `data`."""
+    import numpy.lib.recfunctions as rfn
+    import spiceypy as spice
+
+    from layup.routines import Observation
+    from layup.utilities.data_processing_utilities import (
+        LayupObservatory,
+        layup_furnish_spiceypy,
+    )
+    from layup.utilities.datetime_conversions import convert_tdb_date_to_julian_date
+
+    layup_furnish_spiceypy(CACHE)
+    obsv = LayupObservatory(cache_dir=CACHE)
+    et = np.array([spice.str2et(t) for t in data["obsTime"]], dtype="<f8")
+    d = rfn.append_fields(data, "et", et, usemask=False, asrecarray=True)
+    d = rfn.merge_arrays([d, obsv.obscodes_to_barycentric(d)], flatten=True, asrecarray=True, usemask=False)
+    jd = [float(convert_tdb_date_to_julian_date(t)) for t in d["obsTime"]]
+    return [
+        Observation.from_astrometry_with_id(
+            str(row["provID"]) if "provID" in d.dtype.names else str(row["ObjID"]),
+            float(np.radians(row["ra"])),
+            float(np.radians(row["dec"])),
+            float(t),
+            [float(row["x"]), float(row["y"]), float(row["z"])],
+            [float(row["vx"]), float(row["vy"]), float(row["vz"])],
+        )
+        for row, t in zip(d, jd)
+    ]
+
+
+def _chi2_from_residuals(row, observations):
+    """Sum of squared weighted residuals at the fitted state."""
+    fit = parse_fit_result(row, orbit_colm_flag=False)
+    res = residuals_at_state(get_ephem(CACHE), fit, observations, numpy_to_eigen(fit.cov, 6, 6))
+    return float(sum(r[0] ** 2 + r[1] ** 2 for r in res)), fit
+
+
+def test_parse_fit_result_carries_the_nongrav_parameters():
+    """Without this the amplitudes never reach the C++ propagation at all."""
+    data, guess = _build_arc_array()
+    row = orbitfit(data, cache_dir=CACHE, initial_guess=guess, fit_nongrav="A2")[0]
+    fit = parse_fit_result(row, orbit_colm_flag=False)
+    assert fit.nongrav_mask == 2, f"A2 fit should set bit 1; got mask {fit.nongrav_mask}"
+    assert fit.a2 == pytest.approx(
+        float(row["a2"]), rel=1e-12
+    ), "the fitted A2 must survive the round trip through parse_fit_result"
+
+
+def test_residuals_at_the_fitted_state_are_small_for_a_nongrav_fit():
+    """The arc is noise-free and generated WITH a known A2, so a correct
+    7-parameter fit reproduces it essentially exactly. Propagating the fitted
+    state gravity-only instead -- the defect -- leaves the whole A2 along-track
+    drift in the residuals, which on this four-year arc is arcseconds rather than
+    milliarcseconds.
+
+    Asserting on the residual size rather than on chi-square keeps the test
+    meaningful: the noise-free chi-square is ~0, so a relative comparison against
+    it is degenerate.
+    """
+    data, guess = _build_arc_array()
+    observations = _observations(data)
+
+    row = orbitfit(data, cache_dir=CACHE, initial_guess=guess, fit_nongrav="A2")[0]
+    fit = parse_fit_result(row, orbit_colm_flag=False)
+    assert fit.nongrav_mask == 2, "A2 must survive parse_fit_result (issue #522)"
+
+    res = residuals_at_state(get_ephem(CACHE), fit, observations, numpy_to_eigen(fit.cov, 6, 6))
+    worst = max(max(abs(r[0]), abs(r[1])) for r in res) * ARCSEC
+    assert worst < 0.05, (
+        f"worst residual at the fitted state is {worst:.3f} arcsec; the "
+        "propagation is dropping the fitted A2 (issue #522)"
+    )


### PR DESCRIPTION
Fixes #522.

`predict` re-integrated a fitted orbit under gravity alone, discarding any A1/A2/A3 the fit had solved for. For a comet, or an asteroid with a detected Yarkovsky acceleration, the prediction drifted away from the orbit that produced it.

Two halves were missing. `predict.cpp` never enabled `ASSIST_FORCE_NON_GRAVITATIONAL` or set `particle_params`, and `parse_fit_result` dropped the `a1`/`a2`/`a3` columns on the way from the fit table back into a `FitResult` — so fixing either one alone leaves the bug in place. `residuals_at_state` now passes the parameters through as well.

Verified on 152563 (1992 BF), whose A2 is well determined over a 1953–2016 arc: residuals at the fitted state drop from 15" to 2" in 1953, and the predicted-to-fitted agreement is 1.000 for both gravity-only and A2 fits. Two regression tests, each confirmed to fail when either half of the fix is reverted.