### PR TITLE
Read the obs80 star catalogue under its ADES name

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -1339,6 +1339,14 @@ def _orbitfit(
 
         # bias_dict will be a dictionary when the debias flag is set to True.
         if bias_dict is not None:
+            if not astcat_column_present:
+                # Without a star catalog per observation there is no bias to look
+                # up, so debiasing would quietly do nothing. Say so rather than
+                # return astrometry the caller believes was corrected.
+                logger.warning(
+                    "Debiasing was requested but the data has no astCat column, so no "
+                    "star-catalog bias can be applied. The astrometry is unchanged."
+                )
             for d in data:
                 if radar_columns_present and _is_radar(d, column_names):
                     continue  # debiasing is an astrometric (ra/dec) correction

--- a/src/layup/utilities/file_io/Obs80Reader.py
+++ b/src/layup/utilities/file_io/Obs80Reader.py
@@ -152,8 +152,8 @@ class Obs80DataReader(ObjectDataReader):
             ("mag", "f4"),
             ("filt", "U1"),
             ("stn", "U3"),
-            ("cat", "U1"),
-            ("prg", "U1"),
+            ("astCat", "U1"),
+            ("program", "U1"),
             ("sys", "U7"),
             ("ctr", "i4"),
             ("pos1", "f8"),
@@ -165,13 +165,13 @@ class Obs80DataReader(ObjectDataReader):
         self.col_names = {
             "ObjID": slice(0, 5),
             "provID": slice(5, 12),
-            "prg": slice(13, 14),
+            "program": slice(13, 14),
             "obsTime": slice(15, 32),
             "ra": slice(32, 44),
             "dec": slice(44, 56),
             "mag": slice(65, 70),
             "filt": slice(70, 71),
-            "cat": slice(71, 72),
+            "astCat": slice(71, 72),
             "obs_code": slice(77, 80),
         }
 
@@ -441,13 +441,13 @@ class Obs80DataReader(ObjectDataReader):
         # Extract the relevant fields from the first mpc obs80 line.
         # obj_name = line[self.col_names["obj_name"]].strip()
         # prov_id = line[self.col_names["prov_id"]].strip()
-        prg = line[self.col_names["prg"]].strip()
+        prg = line[self.col_names["program"]].strip()
         obstime = line[self.col_names["obsTime"]].strip()
         ra = line[self.col_names["ra"]].strip()
         dec = line[self.col_names["dec"]].strip()
         mag = line[self.col_names["mag"]].strip()
         filt = line[self.col_names["filt"]].strip()
-        cat = line[self.col_names["cat"]].strip()
+        cat = line[self.col_names["astCat"]].strip()
         obs_code = line[self.col_names["obs_code"]].strip()
 
         # Use the object name as object ID if provided, otherwise use the provisional ID.

--- a/tests/layup/test_obs80_debiasing.py
+++ b/tests/layup/test_obs80_debiasing.py
@@ -1,0 +1,125 @@
+"""Debiasing an MPC 80-column file has to actually debias it.
+
+The 80-column format carries the star catalogue in column 72. Everything
+downstream reads it under its ADES name, ``astCat`` -- the Farnocchia/Chesley
+debiasing and the Veres (2017) weighting both key off it. The reader emitted it
+as ``cat``, so ``astCat`` was absent, ``astcat_column_present`` was False, and
+``catalog=None`` went to the bias lookup: the correction quietly did nothing and
+the caller got back astrometry it believed had been corrected (#521).
+
+Nothing raised, and nothing was logged, which is what made it worth a test
+rather than a one-line rename. The tests below check the rename, that the value
+read is the catalogue code and not some adjacent column, and that debiasing now
+changes the astrometry it is given.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.utilities.file_io.Obs80Reader import Obs80DataReader
+
+# 03666.txt carries a wide spread of catalogue codes; newy6_tiny.txt has none,
+# which is the "historical astrometry" case that must stay working.
+WITH_CATALOGS = "03666.txt"
+WITHOUT_CATALOGS = "newy6_tiny.txt"
+
+
+def _rows(filename, n=40):
+    return Obs80DataReader(get_test_filepath(filename)).read_rows(block_start=0, block_size=n)
+
+
+def test_the_reader_uses_the_ades_column_names():
+    """Every other reader emits ``astCat``. This one emitting ``cat`` is what
+    made the whole pipeline silently skip the correction."""
+    names = _rows(WITH_CATALOGS).dtype.names
+    assert "astCat" in names, "the star catalogue is not under its ADES name"
+    assert "program" in names
+    assert "cat" not in names, "the old name is still emitted; consumers will disagree"
+    assert "prg" not in names
+
+
+def test_the_catalogue_code_comes_from_column_72():
+    """A rename that quietly picked up a neighbouring column would still pass
+    the test above, so the values are checked against the column they must come
+    from. The reader skips lines it cannot use, so the raw file and the returned
+    rows do not line up positionally -- the alphabets are compared instead, and
+    column 14 (the observing programme) is checked as the near miss it would be.
+    """
+    with open(get_test_filepath(WITH_CATALOGS)) as f:
+        lines = [line.rstrip("\n") for line in f]
+    col72 = {ln[71:72].strip() for ln in lines if len(ln) > 71} - {""}
+    col14 = {ln[13:14].strip() for ln in lines if len(ln) > 13} - {""}
+
+    got = {c.strip() for c in _rows(WITH_CATALOGS, 400)["astCat"]} - {""}
+    assert got, "no catalogue codes were read at all"
+    assert got <= col72, f"astCat holds codes absent from column 72: {sorted(got - col72)}"
+    assert not got <= col14, "astCat is indistinguishable from column 14, the programme code"
+
+
+def test_the_catalogue_codes_are_not_all_blank():
+    """If they were, the end-to-end test below would pass without debiasing
+    anything."""
+    codes = {c for c in _rows(WITH_CATALOGS, 200)["astCat"] if c.strip()}
+    assert len(codes) >= 2, f"expected a spread of catalogue codes, got {codes}"
+
+
+def test_a_file_without_catalogue_codes_still_reads():
+    """Historical astrometry has no catalogue. It must read cleanly and simply
+    go undebiased, which is different from silently failing to debias data that
+    does carry one."""
+    rows = _rows(WITHOUT_CATALOGS)
+    assert "astCat" in rows.dtype.names
+    assert all(not c.strip() for c in rows["astCat"])
+
+
+@pytest.mark.skipif(
+    not os.path.exists(
+        os.path.join(
+            os.environ.get("LAYUP_CACHE_DIR", os.path.expanduser("~/Library/Caches/layup")),
+            "bias.dat",
+        )
+    ),
+    reason="the debiasing table (bias.dat) is not in the cache",
+)
+def test_debiasing_changes_obs80_astrometry():
+    """The bug itself: with the catalogue column present the correction is
+    applied, and the astrometry that comes back differs from what went in."""
+    from layup.utilities.debiasing import debias, generate_bias_dict
+    from layup.utilities.datetime_conversions import convert_tdb_date_to_julian_date
+
+    rows = _rows(WITH_CATALOGS, 200)
+    catalogued = rows[[bool(c.strip()) for c in rows["astCat"]]]
+    assert len(catalogued) > 0, "no catalogued observations to debias"
+
+    bias_dict = generate_bias_dict()
+    moved = 0
+    for d in catalogued[:25]:
+        ra, dec = debias(
+            ra=float(d["ra"]),
+            dec=float(d["dec"]),
+            epoch_jd_tdb=convert_tdb_date_to_julian_date(d["obsTime"]),
+            catalog=d["astCat"],
+            bias_dict=bias_dict,
+        )
+        if ra != float(d["ra"]) or dec != float(d["dec"]):
+            moved += 1
+    assert moved > 0, "debiasing left every observation unchanged; it is still a no-op"
+
+
+def test_an_uncatalogued_observation_comes_back_unchanged():
+    """A missing catalogue is normal -- historical astrometry has none -- so the
+    lookup must return the astrometry untouched rather than raise. This is the
+    behaviour that made the bug invisible: correct on its own, wrong only
+    because the column was absent for data that did have a catalogue.
+
+    The warning `_orbitfit` now logs in this situation is not covered here; it
+    sits inside the fitting entry point, which needs ephemeris-prepared input,
+    and is exercised through the CLI rather than by this module.
+    """
+    from layup.utilities.debiasing import debias
+
+    out = debias(ra=10.0, dec=20.0, epoch_jd_tdb=2460000.5, catalog=None, bias_dict={})
+    assert np.allclose(out, (10.0, 20.0)), "an uncatalogued observation should be unchanged"


### PR DESCRIPTION
Closes #521.

The MPC 80-column format carries the star catalogue in column 72, and the reader emitted it as `cat`. Everything downstream reads it as `astCat` -- the Farnocchia/Chesley debiasing and the Veres (2017) weighting both key off that name -- so `astcat_column_present` was False, `catalog=None` went to the bias lookup, and the correction quietly did nothing. Nothing raised and nothing was logged, so a caller asking for debiased astrometry got undebiased astrometry back with no way to tell.

The reader now emits `astCat` and `program`, matching every other reader. Nothing outside the reader referenced the old names, and no fixture carries them.

Also logs a warning when debiasing is requested and no `astCat` column is present, so any other input path fails loudly instead of silently.

Worth knowing: the catalogue and Rubin results are unaffected. Every harness that enabled debiasing did this rename by hand first, and the runs that did not enable it were undebiased by choice. This is a defect for anyone using the CLI on 80-column input, which is the most likely way to reach the feature.