### PR TITLE
Ship the Marsden and asteroidal g(r) laws as named constants

### DIFF
--- a/src/layup/constants.py
+++ b/src/layup/constants.py
@@ -95,6 +95,35 @@ STAGE_BUILDUP = 3  # reached the incremental build-up to all observations
 STAGE_COMPLETE = 4  # fit the full observation set
 STAGE_INCREMENTAL = 5  # sequential-update bookkeeping rather than a fresh fit
 
+# ---------------------------------------------------------------------------
+# Non-gravitational g(r) laws
+#
+# ASSIST parameterizes the sublimation law as
+#
+#     g(r) = alpha * (r/r0)^-nm * (1 + (r/r0)^nn)^-nk
+#
+# which is the form of Marsden, Sekanina & Yeomans (1973), AJ 78, 211, and is
+# reproduced in ASSIST's own paper (Holman et al. 2023, section III.4). Both
+# presets below are in the ``[alpha, nm, nn, nk, r0]`` order that ``orbitfit``'s
+# ``nongrav_gr`` argument takes.
+# ---------------------------------------------------------------------------
+
+# The standard water-ice sublimation law for comets. alpha normalizes the law so
+# that g(1 au) = 1; with these values it does so to ten decimal places.
+# Values as tabulated by Attree et al. (2019), A&A 625, A19, Table 2.
+MARSDEN_1973_GOFR = (0.1112620426, 2.15, 5.093, 4.6142, 2.808)
+
+# The asteroidal law, g(r) = (1 au / r)^2. This is what a Yarkovsky A2 fit wants,
+# it is what JPL reports for asteroids with a detected drift (their ALN=1, NM=2,
+# NK=0, R0=1), and it is what layup uses when ``nongrav_gr`` is left at None. It
+# is spelled out here so it can be passed explicitly and compared against.
+#
+# nn is irrelevant whenever nk is zero, since the bracket is then raised to the
+# power 0. It is set to 0.0 rather than left at ASSIST's default of 5.093 -- that
+# default is Marsden's cometary n sitting inert, and anyone who sets nk without
+# also setting nn would silently get their own k with Marsden's n.
+ASTEROIDAL_GOFR = (1.0, 2.0, 0.0, 0.0, 1.0)
+
 # The fit outcome as independent facts, one output column each. Named for their
 # polarity: each ``failed_*`` is 1 when the fit failed that check, so a clean fit
 # is zero across all of them, matching ``flag == FLAG_CONVERGED``. A ``passed_*``

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -1651,8 +1651,8 @@ def orbitfit(
         The non-gravitational g(r) sublimation law as ``[alpha, nm, nn, nk, r0]`` in
         ASSIST's parameterization ``g(r) = alpha*(r/r0)^-nm*(1+(r/r0)^nn)^-nk``.
         Default (``None``) is the asteroidal inverse-square law ``(r/r0)^-2`` used by
-        Yarkovsky A2 fits; pass a cometary law (e.g. Marsden water-ice) to fit a
-        comet's non-gravs. Applies to any non-grav fit (explicit or ``"auto"``).
+        Yarkovsky A2 fits. For a comet, pass ``constants.MARSDEN_1973_GOFR``, the
+        standard water-ice law. Applies to any non-grav fit (explicit or ``"auto"``).
     per_arc : bool, optional
         Fit piecewise-constant *per-apparition* non-grav amplitudes (comet
         linkage). The state and ``g(r)`` are shared, but observations before the

--- a/tests/layup/test_gofr_presets.py
+++ b/tests/layup/test_gofr_presets.py
@@ -1,0 +1,89 @@
+"""The g(r) sublimation laws, checked against their own definitions.
+
+A non-gravitational fit takes five numbers describing how the acceleration falls
+off with heliocentric distance:
+
+    g(r) = alpha * (r/r0)^-nm * (1 + (r/r0)^nn)^-nk
+
+Before these presets existed a caller had to supply all five by hand, which is
+how a wrong law reaches a fit without anyone noticing -- the fit still converges,
+it just answers a different question. The tests below check the constants against
+the properties that define them rather than against themselves.
+"""
+
+import numpy as np
+import pytest
+
+from layup.constants import ASTEROIDAL_GOFR, MARSDEN_1973_GOFR
+from layup.orbitfit import _gofr_arg
+
+
+def g_of_r(r, law):
+    """The law as ASSIST evaluates it, written out from the definition."""
+    alpha, nm, nn, nk, r0 = law
+    return alpha * (r / r0) ** (-nm) * (1.0 + (r / r0) ** nn) ** (-nk)
+
+
+def test_both_laws_are_normalized_at_one_au():
+    """alpha exists to make g(1 au) = 1. That is what makes A1/A2/A3 accelerations
+    at 1 au rather than arbitrary scalings, so it is the property to check.
+
+    The Marsden law misses by 2.4e-9, which is not an error in the constants: it
+    is where alpha's ten published significant figures run out. Exact
+    normalization would want 0.111262042338 against the tabulated 0.1112620426.
+    The bound is set from that, so a genuine transcription error in any of the
+    five numbers would still be caught by orders of magnitude.
+    """
+    for name, law in (("Marsden", MARSDEN_1973_GOFR), ("asteroidal", ASTEROIDAL_GOFR)):
+        assert g_of_r(1.0, law) == pytest.approx(1.0, abs=1e-8), name
+
+
+def test_the_asteroidal_law_is_the_inverse_square():
+    """JPL reports ALN=1, NM=2, NK=0, R0=1 for asteroids with a measured Yarkovsky
+    drift, which is (1 au / r)^2. ASSIST's own paper says the same."""
+    for r in (0.5, 1.0, 2.0, 5.0, 30.0):
+        assert g_of_r(r, ASTEROIDAL_GOFR) == pytest.approx(r**-2.0, rel=1e-12)
+
+
+def test_the_marsden_law_falls_off_faster_than_inverse_square():
+    """Water ice stops sublimating past a few au, so the cometary law must drop
+    away from the asteroidal one beyond r0 -- and must not be confused with it."""
+    assert g_of_r(2.0, MARSDEN_1973_GOFR) < g_of_r(2.0, ASTEROIDAL_GOFR)
+    assert g_of_r(5.0, MARSDEN_1973_GOFR) < 1e-3 * g_of_r(5.0, ASTEROIDAL_GOFR)
+    # inside 1 au the ice is more active, not less
+    assert g_of_r(0.5, MARSDEN_1973_GOFR) > g_of_r(1.0, MARSDEN_1973_GOFR)
+
+
+def test_the_marsden_law_is_monotonically_decreasing():
+    r = np.geomspace(0.1, 50.0, 400)
+    g = np.array([g_of_r(x, MARSDEN_1973_GOFR) for x in r])
+    assert np.all(np.diff(g) < 0.0)
+
+
+def test_r0_is_where_the_bracket_turns_over():
+    """r0 is the sublimation scale, so at r = r0 the bracket contributes a factor
+    2^-nk exactly. This pins r0 to its meaning rather than to a number."""
+    alpha, nm, nn, nk, r0 = MARSDEN_1973_GOFR
+    assert g_of_r(r0, MARSDEN_1973_GOFR) == pytest.approx(alpha * 2.0**-nk, rel=1e-12)
+
+
+def test_the_presets_are_accepted_by_the_fitting_interface():
+    """They exist to be passed to orbitfit's nongrav_gr, so check they survive it
+    in order and unchanged."""
+    for law in (MARSDEN_1973_GOFR, ASTEROIDAL_GOFR):
+        assert _gofr_arg(law) == [float(v) for v in law]
+        assert len(_gofr_arg(law)) == 5
+    assert _gofr_arg(None) == []  # the default asteroidal path
+    with pytest.raises(ValueError):
+        _gofr_arg((1.0, 2.0, 3.0))
+
+
+def test_nn_is_inert_for_the_asteroidal_law():
+    """nk = 0 makes the bracket unity whatever nn is. ASSIST defaults nn to
+    Marsden's 5.093, so a caller who sets nk without setting nn gets their own k
+    with Marsden's n -- this records that the preset does not rely on the default."""
+    alpha, nm, nn, nk, r0 = ASTEROIDAL_GOFR
+    assert nk == 0.0
+    for other_nn in (0.0, 5.093, 1.0):
+        law = (alpha, nm, other_nn, nk, r0)
+        assert g_of_r(2.0, law) == pytest.approx(g_of_r(2.0, ASTEROIDAL_GOFR), rel=1e-12)


### PR DESCRIPTION
A non-gravitational fit takes its sublimation law as five bare numbers, `[alpha, nm, nn, nk, r0]`, and `orbitfit`'s docstring already told callers to pass a cometary law without saying what one is. So fitting a comet meant knowing five magic numbers, and getting one wrong gives a fit that converges and answers a different question.

`MARSDEN_1973_GOFR` is the standard water-ice law of Marsden, Sekanina & Yeomans (1973), AJ 78, 211, in the form ASSIST uses (Holman et al. 2023, section III.4), with the values tabulated by Attree et al. (2019), A&A 625, A19, Table 2.

`ASTEROIDAL_GOFR` spells out the inverse-square law a Yarkovsky A2 fit wants. It is already the default when `nongrav_gr` is None, but naming it lets a caller state the choice and compare the two. Its `nn` is set to 0.0 rather than left at ASSIST's default of 5.093 — that default is Marsden's cometary *n* sitting inert, harmless only because `nk` is zero. Set `nk` without also setting `nn` and you silently get your own *k* with Marsden's *n*, which is reachable from the API since all five are exposed as a raw list.

The tests check the laws against the properties that define them rather than against the numbers: normalization at 1 au, the asteroidal case reducing to (1 au/r)^2, the cometary case falling away faster beyond r0, and r0 being where the bracket contributes 2^-nk. A transcription error in any of the five would be caught by the physics.

One detail worth knowing: the Marsden law normalizes to 1 within 2.4e-9 rather than exactly, which is where alpha's ten published significant figures run out. The tolerance is set from that and the reason is stated in the test.