### PR TITLE
Fill in the PyPI metadata before the first real release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 
 [project]
 name = "layup"
+description = "Orbit fitting at LSST scale"
 license = {file = "LICENSE"}
 readme = "README.md"
+keywords = ["orbit determination", "astrometry", "asteroids", "solar system", "ephemeris"]
 authors = [
     { name = "Matthew Holman", email = "mholman@cfa.harvard.edu" }
 ]
@@ -13,6 +15,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dynamic = ["version"]
 requires-python = ">=3.11"
@@ -46,7 +53,10 @@ layup-demo = "layup_cmdline.demo:main"
 layup-unpack = "layup_cmdline.unpack:main"
 
 [project.urls]
+Homepage = "https://github.com/Smithsonian/layup"
+Documentation = "https://layup.readthedocs.io"
 "Source Code" = "https://github.com/Smithsonian/layup"
+Issues = "https://github.com/Smithsonian/layup/issues"
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]


### PR DESCRIPTION
The package has never been published, so the metadata that renders on a PyPI page was never exercised. There was no `description`, so a first release would have listed no summary at all; no keywords; no Documentation or Issues link; and the classifiers named neither the supported Python versions nor the subject area.

The description and keywords follow `CITATION.cff` and the README so the three agree.

This is the half of #436 that is still outstanding. The bootstrap leftover (item 2) is already fixed on `main` -- it went in with #482, which removes the ~156 MB tarball after untar and sweeps it from older caches, with tests. The other half of #436 needs your PyPI credentials: the `layup` name still holds a 1,303-byte `0.0.1` stub uploaded 2025-01-09, and its `requires_python >=3.8` means pip will not filter it out.

Two things I did not touch, both judgement calls:

- `pip install '.[dev]'` installs black 26.5.1 while the pre-commit hook enforces 25.1.0, untouched since April 2025. Dependabot bumps the first and not the second, so a contributor who formats locally uses a different black than the one gating their PR.
- `requires-python` says `>=3.11` and I wrote classifiers to match, but CI only runs 3.13 and 3.14.

Closes nothing on its own; part of #436.