### PR TITLE
Stop the comet fallback guard permitting out-of-bounds ASSIST calls

### DIFF
--- a/src/layup/comet.py
+++ b/src/layup/comet.py
@@ -16,9 +16,24 @@ from layup.utilities.data_processing_utilities import (
     resolve_num_workers,
 )
 
-# These are the maximum and minimum dates that the ASSIST ephemeris file allows for
+# Bounds of the ASSIST planetary ephemeris, outside which the integration falls
+# back to a pure REBOUND simulation. layup ships linux_p1550p2650.440, which
+# covers 1550-01-01 to 2650-01-01, i.e. MJD -112815 to 288952.
+#
+# The lower bound previously read -163545 (1411-02-09), 139 years EARLIER than the
+# file begins, so a backward integration kept calling ASSIST for 139 years outside
+# its coverage. That matters here: a near-parabolic comet takes of order a
+# thousand years to reach the 250 au reference distance, so backward integrations
+# reach the 1400s routinely. ASSIST's out-of-bounds interpolation leaves
+# current_state stale rather than raising, so the result is plausible numbers
+# rather than a failure.
+#
+# These should come from assist_ephem_time_bounds() rather than being hardcoded.
+# That entry point is in ASSIST main but not in any release -- the pinned
+# assist 1.2.3 exports neither the Python attribute nor the C symbol -- so the
+# constants stand until a release carries it.
 ASSIST_TIMEFRAME_MAX_MJD = 236455
-ASSIST_TIMEFRAME_MIN_MJD = -163545
+ASSIST_TIMEFRAME_MIN_MJD = -112815
 
 # Heliocentric distance (au) at which a comet's "original"/"future" barycentric
 # orbit is evaluated. Far enough from the Sun that planetary perturbations are

--- a/tests/layup/test_comet.py
+++ b/tests/layup/test_comet.py
@@ -235,3 +235,15 @@ def test_comet_output(tmpdir):
     assert np.allclose(output_data["ao_barycentric"], known_data["ao_barycentric"], rtol=2e-4)
     assert np.allclose(output_data["d_ao"], known_data["d_ao"])
     assert np.allclose(output_data["e_ao"], known_data["e_ao"])
+
+
+def test_ephemeris_bounds_lie_within_the_shipped_ephemeris():
+    """The fallback guard must not permit calls outside the ASSIST planetary
+    ephemeris. layup ships linux_p1550p2650.440, covering MJD -112815 to 288952;
+    ASSIST's out-of-bounds interpolation returns stale state rather than raising,
+    so a guard that is too permissive fails silently."""
+    from layup.comet import ASSIST_TIMEFRAME_MAX_MJD, ASSIST_TIMEFRAME_MIN_MJD
+
+    EPHEM_FIRST_MJD, EPHEM_LAST_MJD = -112815, 288952
+    assert ASSIST_TIMEFRAME_MIN_MJD >= EPHEM_FIRST_MJD
+    assert ASSIST_TIMEFRAME_MAX_MJD <= EPHEM_LAST_MJD


### PR DESCRIPTION
`ASSIST_TIMEFRAME_MIN_MJD` was `-163545`, which is **1411-02-09**. layup ships `linux_p1550p2650.440`, which begins in **1550**. So a backward integration kept calling ASSIST for 139 years outside the ephemeris it was given, instead of falling back to the pure REBOUND path.

**That range is reached routinely.** `comet.py` integrates backwards to a barycentric distance of 250 au, and a near-parabolic comet takes of order a thousand years to get there — so an integration starting from a modern epoch lands in the 1400s as a matter of course.

**And it fails silently.** ASSIST's out-of-bounds interpolation leaves `current_state` stale rather than raising, so the integration continues against frozen perturber positions and returns plausible numbers.

| | before | after | ephemeris |
|---|---:|---:|---:|
| lower | −163545 (1411) | **−112815 (1550)** | 1550 |
| upper | 236455 (2506) | 236455 (2506) | 2650 |

The upper bound is left alone: it is conservative against the file's 288952 and therefore safe, though equally not derived from the file.

Both should come from `assist_ephem_time_bounds()` rather than being hardcoded. That entry point is in ASSIST `main` but **not in any release** — the pinned `assist 1.2.3` exports neither the Python attribute nor the C symbol — so the constants stand until a release carries it. The comment now says so, and this PR is the interim fix rather than the intended one.

The test asserts the guard lies inside the shipped ephemeris in both directions and needs no ephemeris file to run. `tests/layup/test_comet.py`: 17 passed. `black` clean.

Found while checking a sentence in the methods paper that claimed the code detects the ephemeris file's range — it doesn't, and after this it at least agrees with the file it ships.
