### PR TITLE
Obs80Reader: pair two-line records on the designation, not columns 1-14

### DIFF
--- a/src/layup/utilities/file_io/Obs80Reader.py
+++ b/src/layup/utilities/file_io/Obs80Reader.py
@@ -46,14 +46,17 @@ def two_line_row_continuation(line):
 def two_line_rows_match(first_line, second_line):
     """Checks that ``second_line`` is the continuation line belonging to
     ``first_line``: it is a continuation line, repeats the same designation
-    (columns 1-14) and reports the same observatory code (columns 78-80).
+    (columns 1-12) and reports the same observatory code (columns 78-80).
+
+    Columns 13-14 are the discovery asterisk and note 1; the MPC does not
+    repeat either on a continuation line, so they are outside the comparison.
 
     This guards against a desynchronised file (an orphan continuation line, or
     a first line whose continuation is missing) silently mis-pairing.
     """
     if not two_line_row_continuation(second_line):
         return False
-    if first_line[0:14] != second_line[0:14]:
+    if first_line[0:12] != second_line[0:12]:
         return False
     return first_line[77:80] == second_line[77:80]
 

--- a/tests/layup/test_Obs80Reader.py
+++ b/tests/layup/test_Obs80Reader.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from layup.utilities.data_utilities_for_tests import get_test_filepath
-from layup.utilities.file_io.Obs80Reader import Obs80DataReader
+from layup.utilities.file_io.Obs80Reader import Obs80DataReader, two_line_rows_match
 
 # A well-formed satellite two-line record (S astrometry line + its lower-case s
 # observer-position line) and a second distinct one, plus a normal ground-based
@@ -284,3 +284,35 @@ def test_desync_count_matches_read_and_objects(tmp_path):
     # read_objects over every id present returns exactly the same rows.
     all_ids = list(set(data["provID"]))
     assert len(reader.read_objects(all_ids)) == len(data)
+
+
+# Two real records whose continuation line does not repeat columns 13-14. The
+# MPC repeats only the designation (columns 1-12) on a continuation line: it
+# carries neither the discovery asterisk (column 13) nor note 1 (column 14).
+# A pairing rule that compared columns 1-14 dropped both lines of every such
+# record -- 13,118 observations over 12,731 objects across the numbered and
+# unnumbered archives, with zero genuine desyncs among them.
+_DISC_SAT_S = 'R7020K10EF0O* S2010 03 10.51885 05 36 45.64 +37 12 34.2                L~0JaDC51'
+_DISC_SAT_s = 'R7020K10EF0O  s2010 03 10.51885 1 + 1932.5539 + 5273.3610 + 4018.4484   ~0JaDC51'
+_ROVING_V = '00009        KV2025 06 03.15975 14 45 01.27 -13 37 10.8           9.9 rZ~8vs0247'
+_ROVING_v = '00009         v2025 06 03.15975 1 278.4806   +40.8400     303           ~8vs0247'
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [(_DISC_SAT_S, _DISC_SAT_s), (_ROVING_V, _ROVING_v)],
+    ids=["discovery_asterisk_col13", "roving_observer_note1_col14"],
+)
+def test_continuation_line_need_not_repeat_cols_13_14(first, second):
+    """Columns 13-14 are outside the designation and are not repeated on a
+    continuation line, so they must not take part in the pairing match."""
+    assert two_line_rows_match(first, second)
+
+
+def test_pairing_still_rejects_a_different_designation():
+    """The relaxation is confined to columns 13-14: columns 1-12 and the
+    observatory code must still agree."""
+    other_desig = _DISC_SAT_s.replace("R7020K10EF0O", "R7020K10EF0P", 1)
+    assert not two_line_rows_match(_DISC_SAT_S, other_desig)
+    other_obscode = _DISC_SAT_s[:77] + "500"
+    assert not two_line_rows_match(_DISC_SAT_S, other_obscode)

--- a/tests/layup/test_Obs80Reader.py
+++ b/tests/layup/test_Obs80Reader.py
@@ -292,10 +292,10 @@ def test_desync_count_matches_read_and_objects(tmp_path):
 # A pairing rule that compared columns 1-14 dropped both lines of every such
 # record -- 13,118 observations over 12,731 objects across the numbered and
 # unnumbered archives, with zero genuine desyncs among them.
-_DISC_SAT_S = 'R7020K10EF0O* S2010 03 10.51885 05 36 45.64 +37 12 34.2                L~0JaDC51'
-_DISC_SAT_s = 'R7020K10EF0O  s2010 03 10.51885 1 + 1932.5539 + 5273.3610 + 4018.4484   ~0JaDC51'
-_ROVING_V = '00009        KV2025 06 03.15975 14 45 01.27 -13 37 10.8           9.9 rZ~8vs0247'
-_ROVING_v = '00009         v2025 06 03.15975 1 278.4806   +40.8400     303           ~8vs0247'
+_DISC_SAT_S = "R7020K10EF0O* S2010 03 10.51885 05 36 45.64 +37 12 34.2                L~0JaDC51"
+_DISC_SAT_s = "R7020K10EF0O  s2010 03 10.51885 1 + 1932.5539 + 5273.3610 + 4018.4484   ~0JaDC51"
+_ROVING_V = "00009        KV2025 06 03.15975 14 45 01.27 -13 37 10.8           9.9 rZ~8vs0247"
+_ROVING_v = "00009         v2025 06 03.15975 1 278.4806   +40.8400     303           ~8vs0247"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What's wrong

`two_line_rows_match` decides whether a continuation line belongs to the first line above it.
It compares **columns 1-14** of the two lines:

```python
if first_line[0:14] != second_line[0:14]:
    return False
```

The obs80 designation is columns **1-12**. Column 13 is the discovery asterisk and column 14
is note 1, and the MPC repeats **neither** on a continuation line:

```
R7020K10EF0O* S2010 03 10.51885 05 36 45.64 +37 12 34.2                L~0JaDC51
R7020K10EF0O  s2010 03 10.51885 1 + 1932.5539 + 5273.3610 + 4018.4484   ~0JaDC51
            ^ col 13 (discovery asterisk), col 14 (note 1)
```

So a satellite / radar / roving-observer **discovery** observation fails the match, and
`_iter_records` discards **both** of its lines. The function's own docstring already said it
compares "the same designation (columns 1-14)" — the code and the docstring disagreed about
what a designation is.

## How much it costs

Measured over both MPC archives (numbered + unnumbered, 2,000 shards):

| | mismatches | col-13 (asterisk) | col-14 (roving) | orphan | unpaired first line |
|---|---:|---:|---:|---:|---:|
| numbered | 9,616 | 9,386 | 230 | 0 | 0 |
| unnumbered | 3,502 | 3,502 | 0 | 0 | 0 |
| **total** | **13,118** | 12,888 | 230 | **0** | **0** |

**13,118 observations across 12,731 objects are dropped, and every one of them is a false
drop.** Orphan 0 and unpaired 0 across both archives means the over-strict range caught
nothing real — there is no genuine desynchronisation anywhere in either file that these two
columns detected.

The 230 that are not the discovery asterisk are the **column-14** case: roving-observer
records (note 2 `V`) whose first line carries a note 1 while the continuation line leaves it
blank. The invariant is the blank continuation-line note 1, not any particular obscode.

These are discovery observations, so the loss is not spread evenly — it removes the *first*
observation of an object's arc, which is the one that anchors it in time.

## The fix

Compare columns 1-12. The observatory-code check (78-80) and the note-2 continuation check
are untouched, so the desync guard the function exists to provide still works: an orphan
continuation line, or a first line whose continuation is missing, is still rejected.

## Tests

Run against this branch (18 pre-existing + 3 new):

```
21 passed
```

The four desync regressions that this function exists for — `duplicate_continuation_line`,
`leading_orphan_continuation`, `first_line_missing_continuation`, `deleted_observation` — all
still pass; they turn on note 2 and line order, not on columns 13-14.

Three tests are added, built from **real archive records** rather than synthesised ones:

- `test_continuation_line_need_not_repeat_cols_13_14[discovery_asterisk_col13]`
- `test_continuation_line_need_not_repeat_cols_13_14[roving_observer_note1_col14]`
- `test_pairing_still_rejects_a_different_designation`

**Negative control.** Reverting only the one-line source change and keeping the new tests:

```
2 failed, 19 passed
```

The two failures are exactly the two pairing cases; the third new test — the guard that a
differing designation or obscode still fails to match — keeps passing. So the new tests
exercise the fix rather than restating current behaviour.

Separately, the 230 real roving mismatches extracted from the archive were replayed through
the corrected rule: **230/230 now match.**

## Effect on downstream fits

We found this while auditing an MPC catalogue build. For the objects affected, the fitted
orbit is computed from an arc missing its discovery observation. Our correction runs are still under
way -- the numbered section has completed, the unnumbered is in its tail -- and a controlled
gate on one shard of each section confirmed the change does exactly what is claimed and
nothing else:

- where the producing reader had **no** pairing rule, the fix restores the records and the
  fits converge back onto the shipped catalogue (13 objects, +14 observations, and every
  other object bit-identical);
- where the producing reader **had** the rule, the fix gives the missing records back and the
  fits deliberately diverge from what shipped — the intended improvement.

Neither gate showed any object changing for a reason other than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXE5Y1rt7nBieTt8BcByju
