### PR TITLE
Correct _radar_observation's docstring: bistatic is modelled

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -429,14 +429,20 @@ def _radar_observation(objID, d, epoch_jd, column_names):
     """Build a radar ``Observation`` from a row, converting JPL units to the
     fitter's internal units.
 
-    Monostatic only: an ``Observation`` carries a single station, used for both
-    the transmit and the receive leg. A bistatic measurement -- transmitted from
-    one antenna and received at another -- has no way to express its second site
-    here, and passing one silently evaluates the receive leg at the transmitting
-    antenna. On real Goldstone bistatic pairs that is a ~4% Doppler error, which
-    against a 0.1 Hz uncertainty is of order a hundred sigma. Filter such
-    observations out before fitting (see ISSUE_146_RADAR_DESIGN.md, where bistatic
-    is listed as a refinement).
+    Bistatic measurements are modelled. An ``Observation`` carries the receiving
+    station and, separately, the transmitting antenna's state at the transmit
+    epoch (``tx_pos``/``tx_vel``, gated by ``has_tx``), so the up leg uses the
+    antenna that actually transmitted rather than the receiver extrapolated
+    backwards. ``_append_transmitter_state`` resolves it from ``trx`` -- the ADES
+    field -- or the ``stnTx`` alias; without either, the receiving station is used
+    and the monostatic case is unchanged.
+
+    The one case that still falls back is an object with **no delay row at all**.
+    The transmit epoch is ``t_receive - tau``, and a Doppler-only row takes tau
+    interpolated from the object's own delay rows; with none to interpolate from,
+    the model extrapolates the receive station. So the criterion for a usable
+    bistatic fit is that the object carries at least one delay measurement, not
+    that the measurement is monostatic.
 
     delay (us, round-trip) -> days; Doppler (Hz) -> round-trip range-rate
     (au/day) via the per-observation transmit frequency ``freqTx``. The


### PR DESCRIPTION
## What's wrong

`_radar_observation`'s docstring says:

> Monostatic only: an `Observation` carries a single station ... A bistatic measurement has no
> way to express its second site here ... Filter such observations out before fitting.

Forty lines below it, the same function passes `tx_pos`, `tx_vel` and `has_tx` into
`Observation.from_radar_with_id`, and `_append_transmitter_state` (#528) resolves the
transmitting antenna from `trx` or `stnTx` at the transmit epoch. The docstring predates that
work and contradicts the code it heads.

## Why it matters

It is being acted on. Catalogue work downstream scoped a radar arm from this docstring and
excluded **29 objects as "entirely bistatic, no usable radar"**, with 147 rows counted as
unmodelled -- both from a limitation that no longer exists.

## What the limitation actually is

An object with **no delay row at all**. The transmit epoch is `t_receive - tau`, and a
Doppler-only row takes tau interpolated from the object's own delay rows; with none, the model
falls back to extrapolating the receive station. So the criterion for a usable bistatic fit is
at least one delay measurement, not monostatic geometry.

Docstring only, no behaviour change. The 14 radar tests pass.

*Drafted with Claude Opus 5.*