### PR TITLE
Orphan process bug fixes: adding SIGTERM handler

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -180,8 +180,8 @@ def _init_worker():
 
 def _terminate(signum, frame):
     """
-    Handler for SIGTERM while using multiprocessing.
-    Any SIGTERM (signal terminate) will be treated as a
+    Handler for SIGTERM and SIGHUP while using multiprocessing.
+    Any SIGTERM (signal terminate) or SIGHUP will be treated as a
     KeyboardInterrupt in _run_pool()
     """
     raise KeyboardInterrupt
@@ -225,8 +225,9 @@ def _run_pool(tuple_task_list, n_workers):
     on_main_thread = threading.current_thread() is threading.main_thread()
     _prev_term = None
     if on_main_thread:
-        # _prev_term stores the previous way SIGTERM was handled.
-        _prev_term = signal.signal(signal.SIGTERM, _terminate)
+        # _prev_term stores the previous way SIGTERM and SIGHUP was handled.
+        _prev_term_SIGTERM = signal.signal(signal.SIGTERM, _terminate)
+        _prev_term_SIGHUP = signal.signal(signal.SIGHUP, _terminate)
     else:
         logger.warning(
             "layup is being called not on the main thread, SIGTERM will not be handled. Therefore orbitfitting may leave orphaned processes if terminated. Use: \n`ps -eo pid,ppid,args -ww | awk '$2==1' | grep -i \"multiprocessing.spawn\\|layup\"`\n to check for layup orphan processes, and `kill <pid>` to remove them."
@@ -238,7 +239,7 @@ def _run_pool(tuple_task_list, n_workers):
                 # and iterates through all the chunked data. (chunks are queued waiting for a free core.)
                 results = pool.starmap(_apply_func_with_kwargs, tuple_task_list, chunksize=1)
             except KeyboardInterrupt:
-                # if keyboard interrupt or SIGTERM (signal terminate) stop all pool processes
+                # if keyboard interrupt, SIGTERM (signal terminate) or SIGHUP stop all pool processes
                 if on_main_thread:
                     # ignore additional signal terminates until all pools are terminated.
                     signal.signal(signal.SIGTERM, signal.SIG_IGN)
@@ -253,8 +254,12 @@ def _run_pool(tuple_task_list, n_workers):
 
     finally:
         if on_main_thread:
-            # resets SIGTERM to previous handler from _prev_term before exiting function.
-            signal.signal(signal.SIGTERM, _prev_term)
+            if _prev_term_SIGTERM is not None:
+                # resets SIGTERM to previous handler from _prev_term_SIGTERM before exiting function.
+                signal.signal(signal.SIGTERM, _prev_term_SIGTERM)
+            if _prev_term_SIGHUP is not None:
+                # resets SIGHUP to previous handler from _prev_term_SIGHUP before exiting function.
+                signal.signal(signal.SIGHUP, _prev_term_SIGHUP)
 
 
 def process_data(data, n_workers, func, **kwargs):

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -3,9 +3,9 @@ import json
 import logging
 import multiprocessing
 import os
-import sys
 import signal
 import tempfile
+import threading
 from importlib.resources import files
 
 import numpy as np
@@ -167,8 +167,8 @@ def write_fallback_obscodes():
 
 def _init_worker():
     """
-    This removes signal error for the subprocesses that are parallised.
-    Therefore the main process is the only thing in control of a keyboard error
+    This ignores (SIG_IGN) signal interrupts (SIGINT) for the subprocesses that are paralleled.
+    Therefore the main process is the only thing in control of a signal interrupt (KeyboardInterrupt)
     and terminates the subprocesses.
 
     Copyright (c) Amethyst Reese
@@ -176,6 +176,15 @@ def _init_worker():
     Adapted from Amethyst Reese's blog, [https://noswap.com/blog/python-multiprocessing-keyboardinterrupt]
     """
     signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def _terminate(signum, frame):
+    """
+    Handler for SIGTERM while using multiprocessing.
+    Any SIGTERM (signal terminate) will be treated as a
+    KeyboardInterrupt in _run_pool()
+    """
+    raise KeyboardInterrupt
 
 
 def _apply_func_with_kwargs(func, data, kwargs):
@@ -211,21 +220,41 @@ def _run_pool(tuple_task_list, n_workers):
     results : np.array
         The concatenated results of all the cores/workers.
     """
-    with _MP_CONTEXT.Pool(processes=n_workers, initializer=_init_worker) as pool:  # parallel across n_workers
-        try:
-            # starmaps takes a function and an iterable parameter (in this casue the list)
-            # and iterates through all the chunked data. (each chunk is given a core)
-            results = pool.starmap(_apply_func_with_kwargs, tuple_task_list, chunksize=1)
-        except KeyboardInterrupt:
-            # if keyboard interupt stop all processes
-            pool.terminate()
-            pool.join()
-            logger.error("Processing canceled due to keyboard exit.")
-            raise
-        else:
-            pool.close()
-            pool.join()
-    return np.concatenate(results)
+
+    # checks if thread is main thread. If its not the main thread signal.signal will not work
+    on_main_thread = threading.current_thread() is threading.main_thread()
+    _prev_term = None
+    if on_main_thread:
+        # _prev_term stores the previous way SIGTERM was handled.
+        _prev_term = signal.signal(signal.SIGTERM, _terminate)
+    else:
+        logger.warning(
+            "layup is being called not on the main thread, SIGTERM will not be handled. Therefore orbitfitting may leave orphaned processes if terminated. Use `ps -eo pid,ppid,args -ww | awk '$2==1' | grep -i \"multiprocessing.spawn\\|layup\"` to check for layup orphan processes, and `kill <pid>` to remove them."
+        )
+    try:
+        with _MP_CONTEXT.Pool(processes=n_workers, initializer=_init_worker) as pool:
+            try:
+                # starmaps takes a function and an iterable parameter (in this case the list)
+                # and iterates through all the chunked data. (chunks are queued waiting for a free core.)
+                results = pool.starmap(_apply_func_with_kwargs, tuple_task_list, chunksize=1)
+            except KeyboardInterrupt:
+                # if keyboard interrupt or SIGTERM (signal terminate) stop all pool processes
+                if on_main_thread:
+                    # ignore additional signal terminates until all pools are terminated.
+                    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+                pool.terminate()
+                pool.join()
+                logger.error("Processing canceled due to keyboard or SIGTERM (signal terminate) exit.")
+                raise
+            else:
+                pool.close()
+                pool.join()
+                return np.concatenate(results)
+
+    finally:
+        if on_main_thread:
+            # resets SIGTERM to previous handler from _prev_term before exiting function.
+            signal.signal(signal.SIGTERM, _prev_term)
 
 
 def process_data(data, n_workers, func, **kwargs):

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -229,7 +229,7 @@ def _run_pool(tuple_task_list, n_workers):
         _prev_term = signal.signal(signal.SIGTERM, _terminate)
     else:
         logger.warning(
-            "layup is being called not on the main thread, SIGTERM will not be handled. Therefore orbitfitting may leave orphaned processes if terminated. Use `ps -eo pid,ppid,args -ww | awk '$2==1' | grep -i \"multiprocessing.spawn\\|layup\"` to check for layup orphan processes, and `kill <pid>` to remove them."
+            "layup is being called not on the main thread, SIGTERM will not be handled. Therefore orbitfitting may leave orphaned processes if terminated. Use: \n`ps -eo pid,ppid,args -ww | awk '$2==1' | grep -i \"multiprocessing.spawn\\|layup\"`\n to check for layup orphan processes, and `kill <pid>` to remove them."
         )
     try:
         with _MP_CONTEXT.Pool(processes=n_workers, initializer=_init_worker) as pool:


### PR DESCRIPTION
Fixes #562  .

Added a SIGTERM (siganl terminate) handler so _run_pool properly terminates subprocesses from keyboardInterrupt and SIGTERM cases now.

I did this using the suggestions from #562. I also added guards for if a user is not using the main thread. 

If a user is not using the main thread, then a logger.warning will warn a user that orphan processes can occur and also includes a command to check for said processes.

Also cleaned up my previous comments and docstrings with better descriptions and spelling fixes. 


## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Layup run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
