### PR TITLE
Zero-initialise FitResult::cov so a flagged fit is deterministic

### DIFF
--- a/src/lib/orbit_fit/fit_result.cpp
+++ b/src/lib/orbit_fit/fit_result.cpp
@@ -18,7 +18,13 @@ namespace orbit_fit
         double epoch;                  // Epoch
         double root;                   // Root value (gauss)
         std::array<double, 6> state;   // State vector
-        std::array<double, 36> cov;    // Covariance matrix
+        // Zero-initialised: `orbit_fit` fills `cov` only when the fit converges
+        // cleanly, so without this every `flag != 0` result would hand back
+        // uninitialised stack memory as its covariance -- differing between
+        // processes, so the same object could score differently on two machines.
+        // Done at the declaration rather than after each `FitResult result;`
+        // (the `bk_fit.cpp` pattern) so every construction site is covered.
+        std::array<double, 36> cov{};  // Covariance matrix
         int niter;                     // Number of iterations
         std::string method;            // Method used for fitting
         int flag;                      // Flag indicating the success of the fit

--- a/tests/layup/test_fit_result_cov_init.py
+++ b/tests/layup/test_fit_result_cov_init.py
@@ -1,0 +1,72 @@
+"""A flagged fit must return a deterministic covariance (#547).
+
+``orbit_fit`` fills ``FitResult::cov`` only inside ``if (flag == 0)``, and
+``run_sequential_update`` returns early at the non-positive-definite prior check
+without reaching its fill either. ``FitResult::cov`` had no initialiser, so
+those paths handed back whatever was on the stack: measured on the flag-7 path
+before the fix, 31 to 32 of the 36 entries were non-zero denormals around
+1.9e-313, and **the count differed between identical calls** -- so the same
+object could score differently on two machines, and a consumer could not tell an
+absent covariance from a real one.
+
+``bk_fit`` already did the right thing (``result.cov.fill(0.0)``), but a
+per-site fill only covers the sites someone remembered. The fix is a default
+member initialiser on the declaration in ``fit_result.cpp``, which covers every
+construction site including ones added later.
+
+Zero rather than NaN, matching the convention ``bk_fit`` established. The flag,
+not the covariance, is what says whether a fit is usable.
+
+⚠️ These must run against the C++ path. A Python-constructed ``FitResult()`` is
+value-initialised by pybind11's ``py::init<>()`` and reads as all-zero **with or
+without** the fix, so a test built on one passes either way and proves nothing.
+"""
+
+import numpy as np
+import pytest
+
+from layup.routines import FitResult, get_ephem, run_sequential_update
+
+from _bk_guards import EPHEM_CACHE, requires_ephem
+
+pytestmark = requires_ephem
+
+CACHE = str(EPHEM_CACHE)
+STATE = [40.0, 10.0, 5.0, -8e-4, 9e-4, 1e-4]
+EPOCH = 2460000.5
+
+# Prior covariance not positive-definite, so the LLT check fails and
+# run_sequential_update returns before it would populate `cov`. The docstring on
+# the binding states this contract: "Fails (flag != 0) if the prior covariance is
+# not positive-definite."
+FLAG_PRIOR_NOT_POSITIVE_DEFINITE = 7
+
+
+def _degenerate_prior():
+    prior = FitResult()
+    prior.state = STATE
+    prior.epoch = EPOCH
+    prior.cov = [0.0] * 36
+    return prior
+
+
+def test_early_return_path_yields_a_zeroed_covariance():
+    result = run_sequential_update(get_ephem(CACHE), _degenerate_prior(), [])
+    assert result.flag == FLAG_PRIOR_NOT_POSITIVE_DEFINITE
+    cov = np.asarray(list(result.cov), dtype=float)
+    assert np.all(cov == 0.0), f"{int((cov != 0).sum())} of 36 entries are non-zero"
+
+
+def test_the_zeroed_covariance_is_reproducible():
+    """The symptom was non-determinism, not merely non-zero values: repeated
+    identical calls returned different numbers of dirty entries."""
+    ephem = get_ephem(CACHE)
+    seen = {tuple(run_sequential_update(ephem, _degenerate_prior(), []).cov) for _ in range(8)}
+    assert seen == {(0.0,) * 36}, "covariance differs between identical calls"
+
+
+def test_the_returned_covariance_is_finite():
+    """A consumer that inverts or averages a returned covariance must not be
+    handed a trap value."""
+    result = run_sequential_update(get_ephem(CACHE), _degenerate_prior(), [])
+    assert np.all(np.isfinite(np.asarray(list(result.cov), dtype=float)))


### PR DESCRIPTION
Closes #547.

## The defect

`orbit_fit` fills `FitResult::cov` only inside `if (flag == 0)`, and `run_sequential_update` returns early at the non-positive-definite prior check without reaching its fill either. `cov` had no initialiser, so those paths returned whatever was on the stack.

Measured on the flag-7 path before the fix, over repeated identical calls in one process:

| | |
|---|---|
| non-zero entries | **31 to 32 of 36** |
| values seen | `1.9e-313` denormals on one run; `6.0e-154` and `1.78e+21` on another |
| between identical calls | **the count differed** |

So the same object could score differently on two machines, and a consumer could not tell an absent covariance from a real one.

## The fix

A default member initialiser on the declaration:

```diff
-        std::array<double, 36> cov;    // Covariance matrix
+        std::array<double, 36> cov{};  // Covariance matrix
```

On the declaration rather than after each `FitResult result;`. `bk_fit.cpp:42` already does the per-site fill correctly, and that is precisely why the other sites were missed — a per-site fill only covers the sites someone remembered. On the declaration it is a property of the type, so every construction site is covered, including ones added later (`orbit_fit.cpp` has two, and `gauss.h` returns a `vector<FitResult>`).

**Zero rather than NaN.** NaN is more informative in principle — it propagates and cannot be mistaken for a real covariance — but zero matches the convention `bk_fit` established, and the requirement here is determinism. What says whether a covariance is meaningful is the `flag`, or the `accepted` column. NaN would also change behaviour for consumers that currently treat a zeroed `cov` as "absent".

**Converged fits are untouched**: both fill sites are downstream of this.

## Tests

`tests/layup/test_fit_result_cov_init.py` — three cases against `run_sequential_update` with a non-positive-definite prior, which takes the flag-7 early return at `orbit_fit.cpp:1643`. They assert the covariance is zero, is *the same* across repeated identical calls, and is finite. The middle one is the point, since the symptom was non-determinism rather than merely non-zero values.

⚠️ **The tests exercise the C++ path deliberately, and the file says why.** A Python-constructed `FitResult()` is value-initialised by pybind11's `py::init<>()` and reads as all-zero **with or without** the fix — my first version of this test did that and passed against the unfixed build, proving nothing.

Verified by reverting the one-line change, rebuilding, and re-running: 2 of the 3 fail, with the garbage values above. (The third, the finiteness check, is a weaker assertion and can pass by luck.)

Full suite locally: **582 passed, 1 skipped** in 13m36s, the skip pre-existing.

## Why it matters beyond hygiene

The MPC full-catalogue harness works around this by zeroing the covariance whenever the fit is flagged. That guard is what makes its Carpino et al. (2003) outlier statistic — which normalises by the post-fit residual covariance `Γ_ν = W⁻¹ − BΓBᵀ` — silently collapse to plain `W⁻¹` on flagged fits, so the rejection criterion changes definition mid-loop as the flag flips. Once this lands, that guard can be removed.

(AI-assisted implementation and analysis, reported by me.)