### PR TITLE
Name the ASSIST coverage guards for the units they use

### DIFF
--- a/src/layup/comet.py
+++ b/src/layup/comet.py
@@ -16,9 +16,26 @@ from layup.utilities.data_processing_utilities import (
     resolve_num_workers,
 )
 
-# These are the maximum and minimum dates that the ASSIST ephemeris file allows for
-ASSIST_TIMEFRAME_MAX_MJD = 236455
-ASSIST_TIMEFRAME_MIN_MJD = -163545
+# Coverage limits of the ASSIST planetary ephemeris, in the units the guards
+# below actually compare against: **TDB days from J2000**, not MJD.
+# ``generate_simulations`` sets ``sim.t = epoch - ephem.jd_ref`` with
+# ``ephem.jd_ref = 2451545.0``, so ``sim.t`` is days from J2000 and these
+# constants have to be in the same units to be meaningful.
+#
+#   +236455 -> JD 2688000.0 -> 2647-05-24
+#   -163545 -> JD 2288000.0 -> 1552-03-25
+#
+# which is ``linux_p1550p2650.440`` (1550-2650) with a margin at each end.
+#
+# WARNING: these are hardcoded to the DEFAULT kernel. A run configured with a
+# different planetary ephemeris -- the ``de440.bsp`` swap that lets observations
+# before 1849 be reduced, for instance -- has different coverage, and these
+# guards would then be wrong in whichever direction the kernel is narrower.
+# ASSIST gained ``assist_ephem_time_bounds()`` upstream, which would let these
+# be queried from the loaded ephemeris instead; it is not in a released
+# ``assist`` yet (1.2.3 does not export the symbol), so they stay hardcoded.
+ASSIST_TIMEFRAME_MAX_J2000_DAYS = 236455
+ASSIST_TIMEFRAME_MIN_J2000_DAYS = -163545
 
 # Heliocentric distance (au) at which a comet's "original"/"future" barycentric
 # orbit is evaluated. Far enough from the Sun that planetary perturbations are
@@ -146,9 +163,9 @@ def _direction_of_integration(sim, ex, step, ephem, Mtot, include_assist=True):
         dt = -abs(step)
         oi, of, sim = _assist_integrate(sim, ex, dt, ephem, Mtot, include_assist=include_assist)
 
-        while of.d < oi.d and sim.t > ASSIST_TIMEFRAME_MIN_MJD:  # Returns to its perihelion
+        while of.d < oi.d and sim.t > ASSIST_TIMEFRAME_MIN_J2000_DAYS:  # Returns to its perihelion
             oi, of, sim = _assist_integrate(sim, ex, dt, ephem, Mtot, include_assist=include_assist)
-        if sim.t < ASSIST_TIMEFRAME_MIN_MJD:
+        if sim.t < ASSIST_TIMEFRAME_MIN_J2000_DAYS:
             convert_to_rebound = True
 
     else:
@@ -213,14 +230,14 @@ def _apply_comet(data, args, aux=None, cache_dir=None, primary_id_column_name=No
         )  # Decide whether to go backwards in time or forwards
 
         if dt > 0:
-            while of.d > REFERENCE_DISTANCE_AU and oi.d > of.d and sim.t < ASSIST_TIMEFRAME_MAX_MJD:
+            while of.d > REFERENCE_DISTANCE_AU and oi.d > of.d and sim.t < ASSIST_TIMEFRAME_MAX_J2000_DAYS:
                 oi, of, sim = _assist_integrate(sim, ex, dt, ephem, Mtot, include_assist=True)
 
         else:
-            while of.d < REFERENCE_DISTANCE_AU and oi.d < of.d and sim.t > ASSIST_TIMEFRAME_MIN_MJD:
+            while of.d < REFERENCE_DISTANCE_AU and oi.d < of.d and sim.t > ASSIST_TIMEFRAME_MIN_J2000_DAYS:
                 oi, of, sim = _assist_integrate(sim, ex, dt, ephem, Mtot, include_assist=True)
 
-        if sim.t >= ASSIST_TIMEFRAME_MAX_MJD or sim.t <= ASSIST_TIMEFRAME_MIN_MJD:
+        if sim.t >= ASSIST_TIMEFRAME_MAX_J2000_DAYS or sim.t <= ASSIST_TIMEFRAME_MIN_J2000_DAYS:
             # If comet goes outside assist timeframe, continue the simulation in pure rebound
             rebound_only.append(comet)
             logger.warning(f"{comet} has exceeded the timeframe of the ASSIST Ephemeris")

--- a/tests/layup/test_comet.py
+++ b/tests/layup/test_comet.py
@@ -235,3 +235,67 @@ def test_comet_output(tmpdir):
     assert np.allclose(output_data["ao_barycentric"], known_data["ao_barycentric"], rtol=2e-4)
     assert np.allclose(output_data["d_ao"], known_data["d_ao"])
     assert np.allclose(output_data["e_ao"], known_data["e_ao"])
+
+
+# --- Ephemeris coverage guards: units (#563) --- #
+#
+# The guards in comet.py compare against `sim.t`, which `generate_simulations`
+# sets to `epoch - ephem.jd_ref` with `jd_ref = 2451545.0`. So the constants are
+# TDB days from J2000, not MJD, and the old `_MJD` names said otherwise. These
+# pin the units: read as MJD the same integers land in the wrong millennium.
+
+JD_REF = 2451545.0  # ephem.jd_ref, the J2000 epoch `sim.t` is measured from
+MJD_OFFSET = 2400000.5
+
+
+def _jd_to_year(jd):
+    """Gregorian year of a Julian date, good to a day -- enough to pin a unit."""
+    z = int(jd + 0.5)
+    alpha = int((z - 1867216.25) / 36524.25)
+    a = z + 1 + alpha - int(alpha / 4)
+    b = a + 1524
+    c = int((b - 122.1) / 365.25)
+    e = int((b - int(365.25 * c)) / 30.6001)
+    month = e - 1 if e < 14 else e - 13
+    return c - 4716 if month > 2 else c - 4715
+
+
+def test_timeframe_constants_are_days_from_j2000():
+    """They must convert to the coverage of `linux_p1550p2650.440` (1550-2650)."""
+    from layup.comet import (
+        ASSIST_TIMEFRAME_MAX_J2000_DAYS,
+        ASSIST_TIMEFRAME_MIN_J2000_DAYS,
+    )
+
+    assert _jd_to_year(JD_REF + ASSIST_TIMEFRAME_MIN_J2000_DAYS) == 1552
+    assert _jd_to_year(JD_REF + ASSIST_TIMEFRAME_MAX_J2000_DAYS) == 2647
+
+
+def test_timeframe_constants_are_not_mjd():
+    """The unit error this guards against: read as MJD they are absurd, and the
+    lower bound is not even representable as a date."""
+    from layup.comet import (
+        ASSIST_TIMEFRAME_MAX_J2000_DAYS,
+        ASSIST_TIMEFRAME_MIN_J2000_DAYS,
+    )
+
+    assert ASSIST_TIMEFRAME_MIN_J2000_DAYS < 0, "an MJD cannot be negative here"
+    as_mjd_year = _jd_to_year(MJD_OFFSET + ASSIST_TIMEFRAME_MAX_J2000_DAYS)
+    assert as_mjd_year != 2647, "reading the constant as an MJD must not give the kernel's end"
+
+
+def test_timeframe_constants_match_sim_t_units():
+    """`sim.t` is `epoch - jd_ref`, so a date inside coverage must fall inside
+    the guards when expressed the same way -- the comparison the code makes."""
+    from layup.comet import (
+        ASSIST_TIMEFRAME_MAX_J2000_DAYS,
+        ASSIST_TIMEFRAME_MIN_J2000_DAYS,
+    )
+
+    for jd in (2288001.0, 2451545.0, 2687999.0):  # just inside, J2000, just inside
+        sim_t = jd - JD_REF
+        assert ASSIST_TIMEFRAME_MIN_J2000_DAYS < sim_t < ASSIST_TIMEFRAME_MAX_J2000_DAYS
+
+    for jd in (2287999.0, 2688001.0):  # just outside each end
+        sim_t = jd - JD_REF
+        assert not (ASSIST_TIMEFRAME_MIN_J2000_DAYS < sim_t < ASSIST_TIMEFRAME_MAX_J2000_DAYS)


### PR DESCRIPTION
Closes #563.

## The defect

`comet.py` named these `ASSIST_TIMEFRAME_MAX_MJD` / `_MIN_MJD`, but they are not MJDs. They are compared against `sim.t`, which `generate_simulations` sets to `epoch - ephem.jd_ref` with `jd_ref = 2451545.0` — so they are **TDB days from J2000**:

| constant | `sim.t` | JD | date |
|---|---:|---:|---|
| MAX | +236455 | 2688000.0 | 2647-05-24 |
| MIN | −163545 | 2288000.0 | 1552-03-25 |

which is `linux_p1550p2650.440` (1550–2650) with a margin at each end.

**The values were always right; only the names said otherwise.** A negative "MJD" is the tell. The risk was that someone would eventually reconcile the name with the number in the wrong direction and narrow the guard by three millennia.

## The change

Renamed to `ASSIST_TIMEFRAME_MAX_J2000_DAYS` / `_MIN_J2000_DAYS`, with the derivation recorded beside them. The constants are used only in `comet.py`, so nothing else moves.

Three tests pin the units, in `test_comet.py`:

- the constants convert through `jd_ref` to 1552 and 2647;
- reading the same integers **as MJD** does *not* reproduce the kernel coverage — so a future "fix" toward MJD fails instead of silently narrowing the guard;
- dates just inside and just outside coverage fall on the right side of the comparison the code actually makes.

## What is NOT fixed, and why

🔴 These stay **hardcoded to the default kernel**. A run configured with a different planetary ephemeris has different coverage and these guards would then be wrong — which is not hypothetical: #543 just closed on exactly that swap, pointing `planet_ephemeris` at `de440.bsp` so that pre-1849 observations can be reduced.

The real remedy is upstream and exists: ASSIST has `assist_ephem_time_bounds()` (`assist.c:524`), which would let the bounds be queried from the loaded ephemeris. **It is not in a released `assist`** — 1.2.3 does not export the symbol (`hasattr(clibassist, "assist_ephem_time_bounds")` is `False`), and 1.2.3 is the latest on PyPI. So the swap is blocked on an assist release, not on this repo, and the warning is recorded next to the constants until then.

Full `test_comet.py`: 19 passed. `black --check` clean.

(AI-assisted implementation and analysis, reported by me.)