### PR TITLE
Decode the obs80 star-catalog code before the Veres sigma lookup

### DIFF
--- a/src/layup/utilities/astrometric_uncertainty.py
+++ b/src/layup/utilities/astrometric_uncertainty.py
@@ -1,3 +1,30 @@
+# obs80 supplies the single-character MPC star-catalog CODE (column 72); ADES
+# supplies the NAME. The branches below are keyed on names, so a code has to be
+# decoded first or every name-keyed test is unreachable and the observation
+# falls through to the station's `else` -- silently, and by up to a factor of 15
+# (issue #548). `debias()` already normalises both spellings; this is the same
+# treatment for the sigma path.
+#
+# This map is deliberately SEPARATE from `debiasing.MPC_CATALOGS` rather than
+# derived from it. That one exists to key the Farnocchia bias tables, which have
+# no column for Gaia DR2, Gaia EDR3, UCAC-5 or ATLAS-2 -- correctly, since
+# Gaia-referenced astrometry needs no bias correction. The Veres model does
+# distinguish them, so borrowing the debiasing map would leave `V` and `X`, the
+# two most common catalogs in the modern archive, undecodable.
+#
+# Only the names the model actually branches on need an entry. Anything else
+# passes through unchanged and reaches the same generic branch it does today.
+_CODE_TO_CATALOG_NAME = {
+    "o": "USNOB1",  # USNO-B1.0
+    "s": "USNOB2",  # USNO-B2.0 -- resolves the "unsure of the abbreviation" note below
+    "q": "UCAC4",  # UCAC-4
+    "t": "PPMXL",  # PPM-XL
+    "U": "Gaia1",  # Gaia DR1
+    "V": "Gaia2",  # Gaia DR2
+    "W": "Gaia3",  # Gaia DR3
+    "X": "Gaia3E",  # Gaia EDR3
+}
+
 EARLY_703_JD = 2456658.5
 EARLY_691_JD = 2452640.5
 EARLY_644_JD = 2452883.5
@@ -27,6 +54,9 @@ def astrometric_uncertainty_Veres2017(obsCode, jd_tdb, catalog=None, program=Non
     float
         Astrometric uncertainty in arcseconds
     """
+
+    # Accept either spelling: a code becomes its name, a name passes through.
+    catalog = _CODE_TO_CATALOG_NAME.get(catalog, catalog)
 
     sigma_arcsec = 1.5
     if obsCode == "703":
@@ -102,7 +132,7 @@ def astrometric_uncertainty_Veres2017(obsCode, jd_tdb, catalog=None, program=Non
             sigma_arcsec = 1.5
     elif obsCode == "568":
         if catalog:
-            if catalog in ["USNOB1", "USNOB2"]:  # TODO Unsure if "USNOB2" is correct abbreviation!!!
+            if catalog in ["USNOB1", "USNOB2"]:  # MPC codes o and s
                 sigma_arcsec = 0.5
             elif catalog in ["Gaia1", "Gaia2", "Gaia3", "Gaia3E"]:
                 sigma_arcsec = 0.1

--- a/tests/layup/test_astrometric_uncertainty.py
+++ b/tests/layup/test_astrometric_uncertainty.py
@@ -1,0 +1,90 @@
+"""The Veres (2017) sigma model must accept both catalog spellings (#548).
+
+obs80 supplies the single-character MPC star-catalog CODE in column 72; ADES
+supplies the NAME. The branches in `astrometric_uncertainty_Veres2017` are keyed
+on names, so before #548 every name-keyed test was unreachable for obs80 input
+and the observation fell through to the station's `else` value -- silently, and
+by up to a factor of 15 in sigma, 225 in the weight.
+
+`debias()` already normalised both spellings (#409). These pin the same
+behaviour for the sigma path, and pin that the two spellings agree, which is the
+property that actually matters: the same observation must be weighted the same
+whether it arrived as obs80 or as ADES.
+"""
+
+import pytest
+
+from layup.utilities.astrometric_uncertainty import (
+    _CODE_TO_CATALOG_NAME,
+    astrometric_uncertainty_Veres2017,
+)
+from layup.utilities.debiasing import MPC_CATALOGS
+
+JD = 2458000.0
+
+# (obsCode, program) for every station whose sigma depends on the catalog.
+CATALOG_SENSITIVE_STATIONS = [
+    ("G83", "2"),
+    ("Y28", None),
+    ("568", None),
+    ("T09", None),
+    ("T12", None),
+    ("T14", None),
+    ("309", "&"),
+]
+
+
+def sigma(stn, catalog, program=None):
+    return astrometric_uncertainty_Veres2017(obsCode=stn, jd_tdb=JD, catalog=catalog, program=program)
+
+
+@pytest.mark.parametrize("code,name", sorted(_CODE_TO_CATALOG_NAME.items()))
+@pytest.mark.parametrize("stn,program", CATALOG_SENSITIVE_STATIONS)
+def test_code_and_name_agree(stn, program, code, name):
+    """The same observation must weigh the same from obs80 and from ADES."""
+    assert sigma(stn, code, program) == sigma(stn, name, program)
+
+
+def test_the_case_from_the_issue():
+    """A Gaia-referenced observation from 568 was weighted 15x too loosely."""
+    assert sigma("568", "Gaia1") == pytest.approx(0.1)
+    assert sigma("568", "U") == pytest.approx(0.1)  # was 1.5
+
+
+@pytest.mark.parametrize("code", ["V", "X"])
+def test_the_modern_gaia_codes_decode(code):
+    """Gaia DR2 and EDR3 are the two commonest catalogs in the archive and have
+    no entry in the debiasing map, so a fix that borrowed it would miss them."""
+    assert code not in MPC_CATALOGS.values(), "if this fails, borrow the debiasing map instead"
+    assert sigma("568", code) == pytest.approx(0.1)
+
+
+def test_usnob2_is_reachable():
+    """Resolves the 'unsure of the abbreviation' note: MPC code s is USNO-B2.0."""
+    assert sigma("568", "s") == pytest.approx(0.5)
+    assert sigma("568", "USNOB2") == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize("code", ["L", "N", "R", "S"])
+def test_an_undistinguished_code_is_unchanged(code):
+    """Codes the model does not branch on must reach the same generic value they
+    always did -- the decode must not perturb anything it was not aimed at."""
+    assert sigma("568", code) == pytest.approx(1.5)
+    assert sigma("703", code) == pytest.approx(0.8)
+
+
+def test_no_catalog_still_takes_the_unknown_branch():
+    assert sigma("568", None) == pytest.approx(1.5)
+    assert sigma("999", None) == pytest.approx(1.5)
+
+
+def test_every_name_the_model_branches_on_is_decodable():
+    """Guards the map against the branches drifting away from it."""
+    import re
+
+    src = open("src/layup/utilities/astrometric_uncertainty.py").read()
+    body = src.split("def astrometric_uncertainty_Veres2017", 1)[1]
+    names = {m for m in re.findall(r'"([A-Za-z][A-Za-z0-9]{2,})"', body) if not m[0].isdigit()}
+    branched = {n for n in names if n.startswith(("Gaia", "UCAC", "PPM", "USNO"))}
+    missing = branched - set(_CODE_TO_CATALOG_NAME.values())
+    assert not missing, f"catalog names with no code to decode from: {sorted(missing)}"


### PR DESCRIPTION
Closes #548.

## The defect

The branches in `astrometric_uncertainty_Veres2017` are keyed on catalog **names** (`"Gaia1"`, `"UCAC4"`, …), which is what ADES supplies. obs80 supplies the single-character MPC **code** in column 72, so for obs80 input every name-keyed test was unreachable and the observation fell through to the station's `else` value — silently, and by up to a factor of **15 in sigma, 225 in the weight**.

`debias()` already normalised both spellings; that was #409, and its comment says so explicitly. The sigma path never got the same treatment.

## Measured impact

1-in-7 sample of the MPC archive, **3,942,528 CCD observations**:

| | |
|---|---:|
| sigma changes | **1,103 (0.028%)** |

| station | n | | transition | n |
|---|---:|---|---|---:|
| 568 | 1,013 | | 1.50 → 0.50 | 817 |
| T12 | 56 | | 1.50 → 0.10 | 182 |
| T14 | 13 | | 1.50 → 0.20 | 104 |
| T09 | 11 | | | |
| 309 | 10 | | | |

Small, and worth stating as small. But every one of them is wrong today, and only seven observatory codes branch on catalog at all, so this is the whole exposure rather than a sample of it.

## The two decisions the issue left open

**1. The map is its own, not `debiasing.MPC_CATALOGS`.** That map keys the Farnocchia bias tables, which have no column for Gaia DR2, Gaia EDR3, UCAC-5 or ATLAS-2 — correctly, since Gaia-referenced astrometry needs no bias correction. But `V` and `X` are the two commonest catalogs in the modern archive, so borrowing it would leave exactly those undecodable. A test asserts they are absent from the debiasing map, so a later "simplification" that borrows it **fails** rather than silently reverting this fix.

**2. `USNOB2` is correct** — MPC code `s` is USNO-B2.0, so the existing branch was right and merely unreachable. The `# TODO Unsure if "USNOB2" is correct abbreviation!!!` is resolved rather than left standing. It is also the **largest contributor**: 817 of the 1,103 changes are 568 via codes `o` and `s`, not the Gaia cases.

## Tests

New `tests/layup/test_astrometric_uncertainty.py`, 66 cases. The central one is parameterised over every mapped catalog × every catalog-sensitive station and asserts the **two spellings agree** — the property that actually matters, since the same observation must weigh the same whether it arrived as obs80 or as ADES.

Also pinned: the case from the issue (568 + Gaia goes 1.5 → 0.1); that codes the model does *not* branch on are unperturbed; that a missing catalog still takes the unknown branch; and a guard that every catalog name appearing in the branches has a code to decode from, so the map cannot drift away from the code it serves.

**35 of the 66 fail on revert.** Full suite: 645 passed, 1 skipped (pre-existing). `black` clean.

(AI-assisted implementation and analysis, reported by me.)