### PR TITLE
Thread primary_id_column_name through the sequential path

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -1829,7 +1829,9 @@ def orbitfit(
     return fitted
 
 
-def _observations_for_update(data, cache_dir, weight_data=False, bias_dict=None):
+def _observations_for_update(
+    data, cache_dir, weight_data=False, bias_dict=None, primary_id_column_name="provID"
+):
     """Augment one object's observations with the observer barycentric state and
     build the C++ ``Observation`` list, mirroring ``orbitfit()``'s preprocessing.
 
@@ -1871,7 +1873,7 @@ def _observations_for_update(data, cache_dir, weight_data=False, bias_dict=None)
                 streak_rate_unc["ra_rate_unc"] = abs(d["rmsRArate"]) * ARCSEC_PER_HOUR_TO_RAD_PER_DAY
                 streak_rate_unc["dec_rate_unc"] = abs(d["rmsDecrate"]) * ARCSEC_PER_HOUR_TO_RAD_PER_DAY
             o = Observation.from_streak_with_id(
-                str(d["provID"]),
+                str(d[primary_id_column_name]),
                 d["ra"] * DEG,
                 d["dec"] * DEG,
                 d["raRate"] * ARCSEC_PER_HOUR_TO_RAD_PER_DAY,
@@ -1883,7 +1885,7 @@ def _observations_for_update(data, cache_dir, weight_data=False, bias_dict=None)
             )
         else:
             o = Observation.from_astrometry_with_id(
-                str(d["provID"]),
+                str(d[primary_id_column_name]),
                 d["ra"] * DEG,
                 d["dec"] * DEG,
                 jd,
@@ -1928,6 +1930,7 @@ def sequential_update(
     debias_data=False,
     max_update_sigma=4.0,
     iter_max=100,
+    primary_id_column_name="provID",
 ):
     """Sequential / information-filter update of a prior orbit fit (issue #419).
 
@@ -1971,13 +1974,15 @@ def sequential_update(
     ephem = get_ephem(kernels_loc)
     bias_dict = generate_bias_dict(cache_dir) if debias_data else None
 
-    new_obs = _observations_for_update(new_data, cache_dir, weight_data, bias_dict)
+    new_obs = _observations_for_update(new_data, cache_dir, weight_data, bias_dict, primary_id_column_name)
     seq = run_sequential_update(ephem, prior_fit, new_obs, iter_max)
 
     def _full_refit():
         if all_data is None:
             return None
-        all_obs = _observations_for_update(all_data, cache_dir, weight_data, bias_dict)
+        all_obs = _observations_for_update(
+            all_data, cache_dir, weight_data, bias_dict, primary_id_column_name
+        )
         return run_from_vector_with_initial_guess(ephem, prior_fit, all_obs, iter_max)
 
     # The information update did not converge (e.g. a non-positive-definite prior,
@@ -2146,6 +2151,7 @@ def incremental_orbitfit(
                     weight_data=weight_data,
                     debias_data=debias,
                     max_update_sigma=max_update_sigma,
+                    primary_id_column_name=primary_id_column_name,
                 )
                 routing["sequential" if seq.method == "sequential_update" else "sequential_fallback"] += 1
                 seq_rows.append(_fitresult_to_row(seq, oid, obs_hash, nobs, out_dtype))

--- a/tests/layup/test_incremental_id_column.py
+++ b/tests/layup/test_incremental_id_column.py
@@ -1,0 +1,86 @@
+"""The incremental path must honour the id column it is given (#515).
+
+``incremental_orbitfit`` takes ``primary_id_column_name``, but it was not
+threaded through ``sequential_update`` to ``_observations_for_update``, which
+read ``d["provID"]`` directly. So the sequential-update path worked only when
+the id column happened to carry the default name, and raised otherwise -- on
+data that ``orbitfit`` itself reads without complaint, since every other entry
+point already threads the name.
+
+The property pinned here is that the column NAME is not allowed to change the
+ANSWER: the same observations under a different id column must produce the same
+fit, not merely avoid raising.
+"""
+
+import numpy as np
+import pytest
+
+from layup.orbitfit import orbitfit, sequential_update
+from layup.utilities.data_utilities_for_tests import get_test_filepath
+from layup.utilities.file_io.CSVReader import CSVDataReader
+
+ALT_ID = "objectName"  # anything that is not the default
+
+
+@pytest.fixture(scope="module")
+def split():
+    """One object's observations, split old/new, with a prior fit over the old."""
+    data = CSVDataReader(
+        get_test_filepath("1_random_mpc_ADES_provIDs_no_sats_micro.csv"),
+        "csv",
+        primary_id_column_name="provID",
+    ).read_rows()
+    data = np.sort(data, order="obsTime", kind="mergesort")
+    cut = (2 * len(data)) // 3
+    seed = orbitfit(data, cache_dir=None)
+    assert seed[0]["flag"] == 0, "seed fit did not converge"
+    prior = orbitfit(data[:cut], cache_dir=None, initial_guess=seed)
+    assert prior[0]["flag"] == 0, "prior fit did not converge"
+    return {"prior": prior, "new": data[cut:], "all": data}
+
+
+def _renamed(arr):
+    """Same rows, one field renamed.
+
+    Built field by field rather than with ``recfunctions.rename_fields``, which
+    raises "Cannot change data-type for array of references" on the object-dtype
+    columns these readers produce.
+    """
+    old = arr.dtype.names
+    new = [ALT_ID if n == "provID" else n for n in old]
+    out = np.empty(arr.shape, dtype=np.dtype([(nn, arr.dtype[n]) for nn, n in zip(new, old)]))
+    for nn, n in zip(new, old):
+        out[nn] = arr[n]
+    return out
+
+
+def test_update_runs_under_a_non_default_id_column(split):
+    res = sequential_update(
+        split["prior"],
+        _renamed(split["new"]),
+        cache_dir=None,
+        all_data=_renamed(split["all"]),
+        primary_id_column_name=ALT_ID,
+    )
+    assert res.flag == 0
+
+
+def test_the_id_column_name_does_not_change_the_answer(split):
+    """The fit is a function of the observations, not of what the column is called."""
+    default = sequential_update(split["prior"], split["new"], cache_dir=None, all_data=split["all"])
+    renamed = sequential_update(
+        split["prior"],
+        _renamed(split["new"]),
+        cache_dir=None,
+        all_data=_renamed(split["all"]),
+        primary_id_column_name=ALT_ID,
+    )
+    assert renamed.flag == default.flag
+    np.testing.assert_allclose(list(renamed.state), list(default.state), rtol=0, atol=0)
+    np.testing.assert_allclose(list(renamed.cov), list(default.cov), rtol=0, atol=0)
+
+
+def test_the_default_is_still_the_default(split):
+    """Callers that never pass the argument must be unaffected."""
+    res = sequential_update(split["prior"], split["new"], cache_dir=None, all_data=split["all"])
+    assert res.flag == 0


### PR DESCRIPTION
Closes #515.

## The defect

`incremental_orbitfit` takes `primary_id_column_name`, but it was never passed to `sequential_update`, which did not accept it, and `_observations_for_update` read `d["provID"]` directly. So the sequential-update path worked only when the id column happened to carry the default name and raised otherwise — on data that `orbitfit()` itself reads without complaint.

`_orbitfit` (line 1283) has threaded the name correctly all along. The sequential path was the sole exception, which is why it went unnoticed.

## The change

Nine lines: `_observations_for_update` and `sequential_update` gain the parameter, the two call sites forward it, and `incremental_orbitfit` passes its own value through. Callers that never pass the argument are unaffected — the default is still `"provID"`.

## Tests

`tests/layup/test_incremental_id_column.py` pins something stronger than "does not raise": the same observations under a different id column must give the **same state and covariance, bit for bit** (`atol=0, rtol=0`). A column name is not allowed to change the answer.

Two of the three fail on revert; the third guards that the default path is unchanged.

⚠️ Note for anyone writing a similar test: `recfunctions.rename_fields` raises *"Cannot change data-type for array of references"* on the object-dtype columns these readers produce, so the helper builds the renamed array field by field. My first version of the test failed for that reason rather than for the reason under test.

Full suite: 582 passed, 1 skipped (pre-existing). `black` clean.

(AI-assisted implementation and analysis, reported by me.)