### PR TITLE
Score IOD candidates in one pass instead of one per observation

### DIFF
--- a/src/layup/iod.py
+++ b/src/layup/iod.py
@@ -37,7 +37,7 @@ import math
 from typing import Callable, Optional, Sequence
 
 from layup.constants import GMtotal, SPEED_OF_LIGHT
-from layup.routines import FitResult, Observation, gauss
+from layup.routines import FitResult, Observation, gauss, residuals_at_state
 
 logger = logging.getLogger(__name__)
 
@@ -224,25 +224,54 @@ def _passes_physical_bounds(candidate, min_r_au: float = _MIN_R_AU, max_r_au: fl
     return True
 
 
-def _predict_rho_hat(ephem, state, state_epoch, obs):
-    """Propagate `state` to `obs.epoch` via full ASSIST and return the
-    predicted apparent unit direction (no light-time correction; coarse
-    filter only).
+def _candidate_residuals_sigma(ephem, candidate, observations):
+    """Per-observation residual of `candidate`, in units of sigma, over the
+    whole arc.
+
+    One ``residuals_at_state`` call does the entire set in a single
+    forward+backward pass over the sorted times, reusing one simulation.
+    The predecessor built a fresh ``rebound.Simulation`` plus
+    ``assist.Extras`` per observation and integrated from the seed epoch
+    each time -- 587 observations x 2 candidates took 29.7 s, against
+    0.255 s here, a factor of 116 (issue #555).
+
+    Two differences from that predecessor are improvements rather than
+    side effects. ``residuals_at_state`` sets IAS15 ``adaptive_mode = 2``
+    after attaching ASSIST, which is what fixed the close-Earth grind in
+    #324 and which the per-observation path never did. And its residuals
+    carry the light-time correction, where the old ones were explicitly
+    uncorrected ("coarse filter only"); the correct root therefore scores
+    slightly better than it used to, which is the safe direction for a
+    filter whose job is to not discard it.
+
+    Parameters
+    ----------
+    ephem : assist_ephem
+        The C ephemeris handle from ``layup.routines.get_ephem``.
+    candidate : FitResult
+        An IOD candidate; its ``state`` and ``epoch`` are used.
+    observations : sequence[Observation]
+        The full observation set.
+
+    Returns
+    -------
+    list[float]
+        One residual per observation, in sigma, in input order.
     """
-    import rebound, assist
     import numpy as np
 
-    sim = rebound.Simulation()
-    sim.t = float(state_epoch) - ephem.jd_ref
-    sim.add(x=state[0], y=state[1], z=state[2], vx=state[3], vy=state[4], vz=state[5])
-    extras = assist.Extras(sim, ephem)
-    extras.integrate_or_interpolate(float(obs.epoch) - ephem.jd_ref)
-    p = sim.particles[0]
-    rx = p.x - obs.observer_position[0]
-    ry = p.y - obs.observer_position[1]
-    rz = p.z - obs.observer_position[2]
-    rho = math.sqrt(rx * rx + ry * ry + rz * rz)
-    return np.array([rx / rho, ry / rho, rz / rho])
+    # The mapped covariance is returned alongside the residual and is not
+    # used here; a zero matrix keeps the call cheap and well defined.
+    zero_cov = np.zeros((6, 6))
+    rows = residuals_at_state(ephem, candidate, list(observations), zero_cov)
+
+    out = []
+    for obs, row in zip(observations, rows):
+        sigma_ra = float(obs.ra_unc if obs.ra_unc is not None else 1.0 / 206265)
+        sigma_dec = float(obs.dec_unc if obs.dec_unc is not None else 1.0 / 206265)
+        sigma = max(sigma_ra, sigma_dec)
+        out.append(math.hypot(float(row[0]), float(row[1])) / sigma)
+    return out
 
 
 def _inertial_min_geocentric_AU(state, state_epoch, observations) -> float:
@@ -344,14 +373,23 @@ def filter_candidates_by_residual(
     tracklet groups is not waved through.
 
     Candidates whose inertial trajectory passes within `close_earth_AU`
-    of the observer at any obs time are passed through unfiltered. Full
-    ASSIST integration gets stuck on close Earth encounters (tens of
-    seconds per propagation), and replacing it with a 2-body
-    approximation would silently mishandle the real physics of NEO close
-    passes — those are valid science targets that need a different
-    solution. Until that solution exists, we just skip the filter for
-    such candidates and let LM handle them (slowly, on the same close
-    encounters, but that's a separate known issue).
+    of the observer at any obs time are passed through unfiltered,
+    because full ASSIST integration used to get stuck on close Earth
+    encounters -- tens of seconds per propagation.
+
+    That is no longer the cost it was. The residual pass now runs through
+    ``residuals_at_state``, which sets IAS15 ``adaptive_mode = 2``, the
+    setting that fixed the close-Earth grind in #324 and which the old
+    per-observation path never applied. Measured on five objects carrying
+    a near-Earth candidate, disabling the pass-through costs about 0.1 s
+    and correctly rejects the candidate the guard waves through.
+
+    The guard is kept anyway. Those five are main-belt objects whose
+    *phantom* roots happen to approach the Earth; the case the guard
+    exists for is a genuine near-Earth object, where the *correct* root
+    is the close one, and that has not been tested. Removing it changes
+    which candidates survive rather than how fast they are scored, so it
+    wants its own measurement on near-Earth objects.
 
     Parameters
     ----------
@@ -408,25 +446,15 @@ def filter_candidates_by_residual(
             survivors.append(c)
             continue
 
-        resids_sigma = []
-        integrable = True
-        for obs in observations:
-            try:
-                pred = _predict_rho_hat(ephem, c.state, c.epoch, obs)
-            except Exception:
-                # ASSIST refused to integrate (e.g. state walked outside
-                # the kernel time range). Treat as a failed candidate.
-                integrable = False
-                break
-            actual = np.asarray(obs.rho_hat).flatten()
-            cos_sep = float(np.clip(pred @ actual, -1.0, 1.0))
-            sep_rad = math.acos(cos_sep)
-            sigma_ra = float(obs.ra_unc if obs.ra_unc is not None else 1.0 / 206265)
-            sigma_dec = float(obs.dec_unc if obs.dec_unc is not None else 1.0 / 206265)
-            sigma = max(sigma_ra, sigma_dec)
-            resids_sigma.append(sep_rad / sigma)
+        try:
+            resids_sigma = _candidate_residuals_sigma(ephem, c, observations)
+        except Exception:
+            # The integration failed for this candidate -- most often because
+            # the state walked outside the ephemeris time range. Treat it as a
+            # failed candidate rather than letting it take the whole call down.
+            continue
 
-        if not integrable or not resids_sigma:
+        if not resids_sigma:
             continue
         # Robust per-candidate metric: a high percentile of the per-obs
         # residuals rather than the single worst point, so a minority of

--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -986,25 +986,6 @@ _PICKER_IAS15_ADAPTIVE_MODE = 2
 # from layup.routines returns the C struct; the Python residual filter
 # needs the rebound/assist Python wrapper instead, so we cache one per
 # cache_dir.
-_assist_python_ephem_cache: dict = {}
-
-
-def _get_python_ephem(cache_dir):
-    """Lazy-load and cache the Python-side assist.Ephem for the filter."""
-    key = str(cache_dir)
-    if key in _assist_python_ephem_cache:
-        return _assist_python_ephem_cache[key]
-    try:
-        import assist
-    except ImportError:
-        return None
-    try:
-        eph = assist.Ephem(os.path.join(key, "linux_p1550p2650.440"), os.path.join(key, "sb441-n16.bsp"))
-    except Exception as e:
-        logger.warning(f"assist.Ephem load failed for {cache_dir}: {e}")
-        return None
-    _assist_python_ephem_cache[key] = eph
-    return eph
 
 
 def _pick_best_root(candidates, min_r_au):
@@ -1116,11 +1097,10 @@ def do_fit(
     # the picker loop down to 1-2 LM fits per case in the common
     # case (vs up to 8 brute-force LMs). Loose threshold (default
     # 1000σ) so the right root is never rejected.
-    py_ephem = _get_python_ephem(cache_dir)
-    if py_ephem is not None and len(solns) > 1:
+    if len(solns) > 1:
         before = len(solns)
         solns = filter_candidates_by_residual(
-            solns, observations, py_ephem, threshold_sigma=prefilter_threshold_sigma
+            solns, observations, get_ephem(cache_dir), threshold_sigma=prefilter_threshold_sigma
         )
         if len(solns) < before:
             logger.debug(

--- a/tests/layup/test_iod_picker.py
+++ b/tests/layup/test_iod_picker.py
@@ -68,12 +68,16 @@ def _prefilter_setup(monkeypatch, residual_sigma_by_state, n_obs=5):
         idx_of[id(o)] = j
         obs.append(o)
 
-    def fake_pred(ephem, state, epoch, o):
-        rs = residual_sigma_by_state(state, idx_of[id(o)]) if per_obs else residual_sigma_by_state(state)
-        ang = rs * sigma  # rad
-        return np.array([np.cos(ang), np.sin(ang), 0.0])
+    def fake_residuals(ephem, candidate, obss):
+        """Stub the whole-arc residual call (#555 replaced the per-observation
+        predictor with one `residuals_at_state` pass per candidate)."""
+        state = candidate.state
+        return [
+            (residual_sigma_by_state(state, idx_of[id(o)]) if per_obs else residual_sigma_by_state(state))
+            for o in obss
+        ]
 
-    monkeypatch.setattr(iod, "_predict_rho_hat", fake_pred)
+    monkeypatch.setattr(iod, "_candidate_residuals_sigma", fake_residuals)
 
     def cand(r):
         return SimpleNamespace(state=np.array([r, 0.0, 0.0, 0.0, 0.0, 0.0]), epoch=0.0)


### PR DESCRIPTION
Closes #555.

## The change

`filter_candidates_by_residual` called `_predict_rho_hat` once per (candidate, observation), and each call built a fresh `rebound.Simulation` plus `assist.Extras` and integrated from the seed epoch. `residuals_at_state` does the whole set in a single forward+backward pass over the sorted times, reusing one simulation — and IOD candidates are already `FitResult` objects, so it can be called directly.

## Measured

| object | obs | before | after | factor |
|---|---:|---:|---:|---:|
| 119839 | 587 | 29.73 s | 0.260 s | **114x** |
| 134367 | 627 | 17.44 s | 0.129 s | **135x** |
| 137749 | 848 | 19.37 s | 0.110 s | **176x** |
| 144605 | 686 | 44.59 s | 0.287 s | **155x** |
| 146058 | 1669 | 23.70 s | 0.108 s | **219x** |

**Survivor counts identical in every case.** The full test suite drops from **13m37s to 7m17s**.

## Two differences that are improvements, not side effects

- `residuals_at_state` sets IAS15 `adaptive_mode = 2` after attaching ASSIST — the setting that fixed the close-Earth grind in #324, which the per-observation path never applied.
- Its residuals carry the **light-time correction**, where the old ones were explicitly uncorrected ("coarse filter only"). The correct root therefore scores slightly better than it used to, which is the safe direction for a filter whose job is not to discard it.

The caller now passes the C ephemeris, which leaves `_get_python_ephem` and its module-level cache dead. Both removed.

## The close-Earth guard is KEPT, and the issue was right about it

Disabling the pass-through now costs about **0.1 s** and **correctly rejects** the candidate it waves through — so it was indeed working around the missing `adaptive_mode` rather than an intrinsic limit.

🔴 I did not remove it. The five cases above are main-belt objects whose **phantom** roots approach the Earth. The case the guard exists for is a genuine near-Earth object, where the **correct** root is the close one, and that is untested. Removing it changes which candidates survive rather than how fast they are scored, so it wants its own measurement on NEOs. The docstring now records the measurement and that reasoning rather than the stale "tens of seconds per propagation".

## Tests

The stub in `test_iod_picker.py` moves from the per-observation seam to the new whole-arc one, so the 609631 regression guard — a valid Gauss root at ~9500σ that was once silently dropped — still exercises the invariant it was written for. 11 passed.

Full suite: **579 passed, 1 skipped** (pre-existing). `black` clean.

⚠️ One unrelated observation while testing: an earlier full-suite run hung at 0.9% CPU with only a multiprocessing resource-tracker alive, and did not reproduce on re-run or when the multiprocessing suites were run in isolation (44 s, 15 passed). Flagging it rather than attributing it — it has the shape of #562.

(AI-assisted implementation and analysis, reported by me.)