### PR TITLE
Try every single non-grav parameter, and take the best in a tier

### DIFF
--- a/src/layup/orbitfit.py
+++ b/src/layup/orbitfit.py
@@ -214,7 +214,29 @@ def _parse_nongrav(fit_nongrav):
 # increasing complexity, and the first that converges, is well-conditioned
 # (flag 0), and is statistically warranted (see NongravAutoThresholds) is adopted;
 # otherwise the gravity-only fit is kept.
-_AUTO_NONGRAV_LADDER = (("A2",), ("A1", "A2"), ("A1", "A2", "A3"))
+#
+# Every SINGLE parameter is tried before any pair (issue #544). The ladder began
+# as A2 -> A1A2 -> A1A2A3, which can only find a radial or out-of-plane
+# acceleration by way of a rung that is already fitting A2 alongside it -- and
+# that is not a detour, it is fatal, because the parameters are strongly
+# correlated over a single apparition. Measured on 1I/'Oumuamua (222
+# observations, Veres weights):
+#
+#     A1 alone      reduced chi2 0.217   A1 = 2.06e-07   8.7 sigma
+#     A2 alone                   0.372   A2 = -2.36e-08  2.8 sigma
+#     A3 alone                   0.389   A3 = -6.06e-09  0.8 sigma
+#     A1 + A2                    0.218   A1 8.2 sigma, A2 0.1 sigma
+#     A1 + A2 + A3               0.218   A1 0.9 sigma  <-- from 8.7
+#
+# The triplet does not fit better -- reduced chi2 is unchanged to three
+# decimals -- it just divides one detection between three parameters and
+# inflates the uncertainty tenfold. A2 is kept first so that an asteroid with a
+# Yarkovsky signal still selects the model it selected before.
+_AUTO_NONGRAV_LADDER = (
+    (("A2",), ("A1",), ("A3",)),
+    (("A1", "A2"),),
+    (("A1", "A2", "A3"),),
+)
 
 
 @dataclass(frozen=True)
@@ -230,6 +252,20 @@ class NongravAutoThresholds:
     accept_reduced_chi2 : float
         A gravity-only fit whose reduced chi-square is at or below this is kept
         as-is; non-grav models are tried only above it. Default 1.5.
+
+        This is a COST control, not a statistical one, and it is worth knowing
+        when it will not do what it looks like it does. It assumes that omitting
+        a real non-gravitational acceleration pushes the gravity-only reduced
+        chi-square above the threshold. That holds only when the astrometric
+        uncertainties are calibrated. Where they are conservative -- which is
+        most of the archive, since the majority of modern astrometry is weighted
+        by the Veres et al. (2017) catch-all rather than a per-station value --
+        the reduced chi-square sits well below 1 whether or not the acceleration
+        is there, and no non-grav model is ever tried. 1I/'Oumuamua fits
+        gravity-only at 0.263 and carries an 8.7-sigma A1 (issue #544).
+
+        Set this to 0.0 to disable the early accept and always walk the ladder,
+        at the cost of up to five extra fits per object.
     delta_chi2_per_param : float
         Minimum chi-square drop required per added non-grav parameter to adopt a
         model (9.0 ~ 3-sigma). Default 9.0.
@@ -292,13 +328,25 @@ def _select_nongrav_auto(
     if _gravity_fit_acceptable(res_grav.csq, res_grav.ndof, thresholds):
         return res_grav  # gravity-only fit is acceptable; no non-gravs needed
     gr = _gofr_arg(gofr)
-    for names in _AUTO_NONGRAV_LADDER:
-        mask = sum(_NONGRAV_BITS[n] for n in names)
-        res_ng = run_from_vector_with_initial_guess(
-            assist_ephem, res_grav, observations, nongrav_mask=mask, gofr=gr
-        )
-        if res_ng.flag == 0 and _nongrav_warranted(res_grav.csq, res_ng, names, thresholds):
-            return res_ng  # parsimonious, well-determined non-grav model
+    for tier in _AUTO_NONGRAV_LADDER:
+        # Within a tier every model costs the same number of parameters, so
+        # parsimony cannot choose between them and the largest chi-square drop
+        # does. Taking the FIRST warranted model instead would make the answer
+        # depend on the order the tier happens to be written in: on
+        # 1I/'Oumuamua both A2 (3.7 sigma, dchi2 13.9) and A1 (10.9 sigma,
+        # dchi2 119.0) are warranted, and A2 wins on position alone (#544).
+        best = None
+        for names in tier:
+            mask = sum(_NONGRAV_BITS[n] for n in names)
+            res_ng = run_from_vector_with_initial_guess(
+                assist_ephem, res_grav, observations, nongrav_mask=mask, gofr=gr
+            )
+            if res_ng.flag != 0 or not _nongrav_warranted(res_grav.csq, res_ng, names, thresholds):
+                continue
+            if best is None or res_ng.csq < best.csq:
+                best = res_ng
+        if best is not None:
+            return best  # best warranted model at the lowest workable complexity
     return res_grav  # no non-grav model is warranted
 
 

--- a/tests/layup/test_nongrav_auto.py
+++ b/tests/layup/test_nongrav_auto.py
@@ -81,9 +81,22 @@ def test_select_auto_escalates_when_a2_alone_insufficient(monkeypatch):
     grav = _res(csq=1000.0, ndof=100)
 
     def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
-        # A2 alone is insignificant; A1+A2 both land significant with a big drop.
-        if nongrav_mask == O._NONGRAV_BITS["A2"]:
-            return _res(csq=995.0, flag=0, nongrav_mask=nongrav_mask, a2=1e-15, a2_unc=1e-15)
+        # No SINGLE parameter is warranted on its own -- each is insignificant --
+        # but A1+A2 together land significant with a big drop, so the selector
+        # has to escalate past the whole one-parameter tier to find it.
+        singles = {O._NONGRAV_BITS[n] for n in ("A1", "A2", "A3")}
+        if nongrav_mask in singles:
+            return _res(
+                csq=995.0,
+                flag=0,
+                nongrav_mask=nongrav_mask,
+                a1=1e-15,
+                a1_unc=1e-15,
+                a2=1e-15,
+                a2_unc=1e-15,
+                a3=1e-15,
+                a3_unc=1e-15,
+            )
         return _res(
             csq=10.0, flag=0, nongrav_mask=nongrav_mask, a1=1e-13, a1_unc=1e-15, a2=1e-13, a2_unc=1e-15
         )
@@ -143,3 +156,107 @@ def test_select_auto_threshold_suppresses_nongrav(monkeypatch):
     lenient = O.NongravAutoThresholds(accept_reduced_chi2=20.0)
     out = O._select_nongrav_auto(None, grav, None, thresholds=lenient)
     assert out is grav and not tried
+
+
+# --- #544: single-parameter rungs, and best-in-tier selection --- #
+
+
+def _significant(mask, csq, **kw):
+    """A converged, well-conditioned fit with every requested parameter at 100 sigma."""
+    vals = {}
+    for name, bit in O._NONGRAV_BITS.items():
+        if mask & bit:
+            vals[name.lower()] = 1e-13
+            vals[name.lower() + "_unc"] = 1e-15
+    vals.update(kw)
+    return _res(csq=csq, flag=0, nongrav_mask=mask, **vals)
+
+
+def test_a1_alone_is_reachable(monkeypatch):
+    """The ladder ran A2 -> A1A2 -> A1A2A3, so a radial-only acceleration could
+    only be found through a rung already fitting A2 beside it. On 1I/'Oumuamua
+    that is fatal: A1 alone is 10.9 sigma and A1+A2+A3 puts it at 0.9."""
+    grav = _res(csq=1000.0, ndof=100)
+    A1, A2, A3 = (O._NONGRAV_BITS[n] for n in ("A1", "A2", "A3"))
+
+    def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
+        if nongrav_mask == A1:
+            return _significant(A1, csq=100.0)
+        return _res(
+            csq=999.0,
+            flag=0,
+            nongrav_mask=nongrav_mask,
+            a1=1e-15,
+            a1_unc=1e-15,
+            a2=1e-15,
+            a2_unc=1e-15,
+            a3=1e-15,
+            a3_unc=1e-15,
+        )
+
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)
+    assert O._select_nongrav_auto(None, grav, None).nongrav_mask == A1
+
+
+def test_a3_alone_is_reachable(monkeypatch):
+    """The dark comets are the A3 case -- A3 significant, A2 not."""
+    grav = _res(csq=1000.0, ndof=100)
+    A3 = O._NONGRAV_BITS["A3"]
+
+    def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
+        if nongrav_mask == A3:
+            return _significant(A3, csq=100.0)
+        return _res(
+            csq=999.0,
+            flag=0,
+            nongrav_mask=nongrav_mask,
+            a1=1e-15,
+            a1_unc=1e-15,
+            a2=1e-15,
+            a2_unc=1e-15,
+            a3=1e-15,
+            a3_unc=1e-15,
+        )
+
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)
+    assert O._select_nongrav_auto(None, grav, None).nongrav_mask == A3
+
+
+def test_best_in_tier_not_first_in_tier(monkeypatch):
+    """Two warranted one-parameter models must be separated by fit quality, not
+    by the order the tier is written in.
+
+    This is the 1I case: A2 is warranted at 3.7 sigma with dchi2 13.9, A1 at
+    10.9 sigma with dchi2 119.0, and A2 is tried first. Returning the first
+    warranted model makes the answer an artifact of the tuple's order.
+    """
+    grav = _res(csq=1000.0, ndof=100)
+    A1, A2 = O._NONGRAV_BITS["A1"], O._NONGRAV_BITS["A2"]
+
+    def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
+        if nongrav_mask == A2:
+            return _significant(A2, csq=986.0)  # warranted, but barely
+        if nongrav_mask == A1:
+            return _significant(A1, csq=881.0)  # warranted, and far better
+        return _res(csq=1000.0, flag=1, nongrav_mask=nongrav_mask)
+
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)
+    out = O._select_nongrav_auto(None, grav, None)
+    assert out.nongrav_mask == A1, "should take the better warranted single, not the first"
+
+
+def test_parsimony_still_beats_quality_across_tiers(monkeypatch):
+    """A warranted single is preferred to a warranted pair even when the pair
+    fits better -- tiers are searched in order, so parsimony is not traded away."""
+    grav = _res(csq=1000.0, ndof=100)
+    A1, A2 = O._NONGRAV_BITS["A1"], O._NONGRAV_BITS["A2"]
+
+    def fake_fit(ephem, res, obs, nongrav_mask=0, **kwargs):
+        if nongrav_mask == A1:
+            return _significant(A1, csq=900.0)
+        if nongrav_mask == (A1 | A2):
+            return _significant(A1 | A2, csq=10.0)  # much better, but two parameters
+        return _res(csq=1000.0, flag=1, nongrav_mask=nongrav_mask)
+
+    monkeypatch.setattr(O, "run_from_vector_with_initial_guess", fake_fit)
+    assert O._select_nongrav_auto(None, grav, None).nongrav_mask == A1


### PR DESCRIPTION
Closes #544.

## Three defects, not two — and the third is why the first two are not enough

The issue names the missing A1 rung and the absolute-quality gate. Working through it turned up a third, and **fixing only the first two does not fix 1I** — I checked.

**3. Within a tier, the FIRST warranted model won, not the best.** "Most parsimonious" cannot discriminate between equally-complex models, so the tie was broken by the order the tuple happened to be written in.

## Measured on 1I/'Oumuamua

222 observations, Veres weights, every fit through the same entry point so the chi-squares are comparable:

| model | Δχ² | significance | warranted |
|---|---:|---|---|
| gravity only | — | reduced χ² **0.762** | gate fires |
| A2 | 13.877 | A2 **3.7σ** | ✅ |
| **A1** | **118.969** | A1 **10.9σ** | ✅ |
| A3 | 2.246 | A3 1.5σ | — |
| A1+A2 | 119.182 | A1 10.3σ, A2 **0.5σ** | — |
| A1+A2+A3 | 119.324 | A1 **0.9σ** | — |

Both A2 and A1 are warranted, so the old ladder took **A2 — the 3.7σ one — over A1 at 10.9σ and 8.6× the χ² drop**, purely on position. The triplet does not fit better (χ² unchanged to three decimals); it divides one detection between three parameters and inflates the uncertainty tenfold, exactly as the issue describes.

## The change

The ladder is tiered by parameter count. Within a tier, the warranted model with the lowest χ² wins; parsimony still decides *between* tiers, so a warranted single is preferred to a better-fitting pair.

1I now selects **A1 alone at 1.965e-07 ± 1.80e-08**, about 2σ from the published 2.790e-07 ± 3.57e-08.

A2 is still first in the tier, so an asteroid with a Yarkovsky signal and no competing model selects what it selected before.

## The gate is documented, not changed

🔴 Its failure mode is now precise. It assumes that omitting a real non-grav pushes reduced χ² above 1.5 — which holds only if the astrometric uncertainties are calibrated. Where they are conservative, which is most of the archive since the majority of modern astrometry takes the Veres catch-all rather than a per-station value, reduced χ² sits well below 1 whether or not the acceleration is there. 1I fits gravity-only at **0.762** and carries a 10.9σ A1.

`accept_reduced_chi2=0.0` already disables it. I did not change the default: doing so costs up to five extra fits per object, which is a survey-cost decision rather than a bug fix.

## Tests

Four new, all failing on revert: A1 alone reachable, A3 alone reachable (the dark-comet case), best-in-tier rather than first-in-tier, and parsimony still winning across tiers.

⚠️ One existing test needed correcting rather than accommodating. `test_select_auto_escalates_when_a2_alone_insufficient` stubbed the same significant result for every mask but A2, so under best-in-tier **A1 alone legitimately won** — the stub said it fit equally well with one parameter. It now makes no single parameter warranted, so it still tests what it was written to test: escalation past the whole one-parameter tier.

Full suite: **583 passed, 1 skipped**. `black` clean.

(AI-assisted implementation and analysis, reported by me.)