### PR TITLE
Let a run finish when one object never converges

### DIFF
--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -186,7 +186,7 @@ def _apply_func_with_kwargs(func, data, kwargs):
     return func(data, **kwargs)
 
 
-def _run_pool(tuple_task_list, n_workers):
+def _run_pool(tuple_task_list, n_workers, per_task_budget_s=None, task_labels=None):
     """
     General function to run multi_processing.Pool.
     This function spawns (_MP_CONTEXT) a pool of n_workers and
@@ -205,17 +205,43 @@ def _run_pool(tuple_task_list, n_workers):
         list of tuples containing arguments used for the _apply_with_kwargs function.
     n_workers : int
         Number of workers/cores used.
+    per_task_budget_s : float, optional
+        Wall-clock budget per task, in seconds. ``None`` (the default) keeps the
+        original behaviour exactly: ``starmap``, which returns only once every
+        task has finished.
+
+        When set, the pool is given an overall deadline of
+        ``per_task_budget_s * ceil(n_tasks / n_workers)`` -- the time the whole
+        batch should take if every task used its full budget. Tasks still
+        running at the deadline are abandoned, the pool is terminated, and the
+        results of everything that finished are returned (issue #492).
+
+        The budget is enforced against the batch rather than against each task
+        because a worker cannot report when its task *started*: the parent sees
+        only submission and completion. A per-task deadline would need a fresh
+        pool per wave of ``n_workers`` tasks, which is exact but respawns a
+        worker (~80 ms) every wave.
+    task_labels : sequence, optional
+        One label per task, used only to name the abandoned ones in the warning.
+        Without it they are reported by index.
 
     Returns
     --------
     results : np.array
-        The concatenated results of all the cores/workers.
+        The concatenated results of all the cores/workers. With a budget set,
+        this omits any abandoned task -- which is the point: one object that
+        never converges used to hold every other result in the run.
     """
     with _MP_CONTEXT.Pool(processes=n_workers, initializer=_init_worker) as pool:  # parallel across n_workers
         try:
-            # starmaps takes a function and an iterable parameter (in this casue the list)
-            # and iterates through all the chunked data. (each chunk is given a core)
-            results = pool.starmap(_apply_func_with_kwargs, tuple_task_list, chunksize=1)
+            if per_task_budget_s is None:
+                # starmaps takes a function and an iterable parameter (in this casue the list)
+                # and iterates through all the chunked data. (each chunk is given a core)
+                results = pool.starmap(_apply_func_with_kwargs, tuple_task_list, chunksize=1)
+            else:
+                results = _collect_within_budget(
+                    pool, tuple_task_list, n_workers, per_task_budget_s, task_labels
+                )
         except KeyboardInterrupt:
             # if keyboard interupt stop all processes
             pool.terminate()
@@ -225,7 +251,63 @@ def _run_pool(tuple_task_list, n_workers):
         else:
             pool.close()
             pool.join()
+    if not results:
+        return np.empty(0)
     return np.concatenate(results)
+
+
+def _collect_within_budget(pool, tuple_task_list, n_workers, per_task_budget_s, task_labels=None):
+    """Submit every task, and return the results of those that finish in time.
+
+    ``starmap`` returns only once the slowest task has finished, so a single
+    object that never converges withholds every other result in the run --
+    fitting 108 short arcs took over an hour with no output, where the same 108
+    fitted one at a time took under a minute, because two of them ground
+    indefinitely (issue #492).
+
+    Nothing here interrupts a running task. A fit that has entered the C
+    integrator cannot be preempted from Python -- a signal handler runs only at
+    a bytecode boundary -- so the budget is enforced by abandoning the task and
+    terminating the pool, not by unwinding the call. The worker is killed with
+    it.
+    """
+    import math
+    import time
+
+    pending = {}
+    for i, task in enumerate(tuple_task_list):
+        pending[pool.apply_async(_apply_func_with_kwargs, task)] = i
+
+    waves = math.ceil(len(tuple_task_list) / max(n_workers, 1))
+    deadline = time.monotonic() + per_task_budget_s * waves
+
+    results = []
+    while pending:
+        for async_result in [a for a in pending if a.ready()]:
+            results.append(async_result.get())
+            del pending[async_result]
+        if not pending:
+            break
+        if time.monotonic() >= deadline:
+            abandoned = sorted(pending.values())
+            names = [str(task_labels[i]) if task_labels is not None else f"#{i}" for i in abandoned]
+            logger.warning(
+                "Abandoned %d of %d objects after the %.0f s budget "
+                "(%.0f s per object x %d waves of %d workers): %s. "
+                "Results for the other %d are returned.",
+                len(abandoned),
+                len(tuple_task_list),
+                per_task_budget_s * waves,
+                per_task_budget_s,
+                waves,
+                n_workers,
+                ", ".join(names[:10]) + (" ..." if len(names) > 10 else ""),
+                len(results),
+            )
+            pool.terminate()
+            break
+        time.sleep(0.05)
+    return results
 
 
 def process_data(data, n_workers, func, **kwargs):
@@ -266,7 +348,7 @@ def process_data(data, n_workers, func, **kwargs):
     return _run_pool(tuple_task_list, n_workers)
 
 
-def process_data_by_id(data, n_workers, func, primary_id_column_name, **kwargs):
+def process_data_by_id(data, n_workers, func, primary_id_column_name, per_object_budget_s=None, **kwargs):
     """
     Process a structured numpy array in parallel for a given function and
     keyword arguments. Instead of distributing the data across all available workers
@@ -288,7 +370,9 @@ def process_data_by_id(data, n_workers, func, primary_id_column_name, **kwargs):
     Returns
     -------
     res : numpy structured array
-        The processed data concatenated from each function result
+        The processed data concatenated from each function result. With a budget
+        set, objects abandoned at the deadline are omitted and named in a
+        warning, rather than every result being withheld by the slowest (#492).
     """
     if n_workers < 1:
         raise ValueError(f"n_workers must be greater than 0, {n_workers} was provided.")
@@ -301,11 +385,13 @@ def process_data_by_id(data, n_workers, func, primary_id_column_name, **kwargs):
 
     kwargs["primary_id_column_name"] = primary_id_column_name
     # list of pids
-    pid_list = [data[data[primary_id_column_name] == id] for id in np.unique(data[primary_id_column_name])]
+    ids = np.unique(data[primary_id_column_name])
+    pid_list = [data[data[primary_id_column_name] == id] for id in ids]
     # tuple list of function, data (pid chunked) and args used
     tuple_task_list = [(func, pid_chunked_data, kwargs) for pid_chunked_data in pid_list]
 
-    return _run_pool(tuple_task_list, n_workers)
+    # Each task is ONE object here, so a per-task budget is a per-object budget.
+    return _run_pool(tuple_task_list, n_workers, per_task_budget_s=per_object_budget_s, task_labels=ids)
 
 
 def get_cov_columns():

--- a/src/layup/utilities/data_processing_utilities.py
+++ b/src/layup/utilities/data_processing_utilities.py
@@ -178,6 +178,11 @@ def _init_worker():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
+def _pool_is_up(_=None):
+    """A no-op task, used only to wait for a worker to finish starting."""
+    return True
+
+
 def _apply_func_with_kwargs(func, data, kwargs):
     """
     Utility function that unpacks the tuple to run the function and
@@ -273,6 +278,14 @@ def _collect_within_budget(pool, tuple_task_list, n_workers, per_task_budget_s, 
     """
     import math
     import time
+
+    # Wait for every worker to finish starting BEFORE the clock starts. Worker
+    # startup is not task time, and it is not small or predictable: spawning a
+    # process and importing Layup into it took 80 ms on a warm developer
+    # machine and longer than a 2 s budget on a cold CI runner, where it
+    # consumed the whole budget and every task was abandoned before it began.
+    for warm in [pool.apply_async(_pool_is_up) for _ in range(n_workers)]:
+        warm.get()
 
     pending = {}
     for i, task in enumerate(tuple_task_list):

--- a/tests/layup/test_per_object_budget.py
+++ b/tests/layup/test_per_object_budget.py
@@ -1,0 +1,92 @@
+"""One object that never returns must not withhold every other result (#492).
+
+``_run_pool`` used ``starmap``, which returns only once the slowest task has
+finished. Fitting 108 short arcs in a single call ran over an hour with no
+output while the same 108 fitted individually took under a minute, because two
+of them ground indefinitely and nothing interrupted them. The measured
+pathological rate on short MPC arcs is 1.9 per cent at seven days and 7.2 at
+fourteen, so at catalogue scale this is the difference between a run finishing
+and not.
+
+Nothing here interrupts a running task -- a fit inside the C integrator cannot
+be preempted from Python, since a signal handler runs only at a bytecode
+boundary. The budget abandons the task and terminates the pool instead.
+
+The module-level helpers exist because the spawn start method pickles the
+callable by reference, so a function defined inside a test cannot be sent to a
+worker.
+"""
+
+import time
+
+import numpy as np
+import pytest
+
+from layup.utilities.data_processing_utilities import _run_pool, process_data_by_id
+
+
+def _quick(data, **kwargs):
+    return np.asarray([len(data)])
+
+
+def _slow(data, **kwargs):
+    time.sleep(30)
+    return np.asarray([len(data)])
+
+
+def _quick_by_id(data, primary_id_column_name=None, **kwargs):
+    return np.asarray([len(data)])
+
+
+def _slow_for_b(data, primary_id_column_name=None, **kwargs):
+    """Grind forever on one particular object, return promptly for the rest."""
+    if str(data[primary_id_column_name][0]) == "b":
+        time.sleep(30)
+    return np.asarray([len(data)])
+
+
+ROWS = np.array([("a",), ("b",), ("c",)], dtype=[("provID", "U4")])
+
+
+def test_without_a_budget_the_behaviour_is_unchanged():
+    out = _run_pool([(_quick, np.zeros(3), {}), (_quick, np.zeros(5), {})], 2)
+    assert sorted(out.tolist()) == [3, 5]
+
+
+def test_a_hung_task_no_longer_withholds_the_others():
+    """The point of the issue: the fast results come back."""
+    tasks = [(_quick, np.zeros(3), {}), (_slow, np.zeros(9), {}), (_quick, np.zeros(5), {})]
+    t0 = time.monotonic()
+    out = _run_pool(tasks, 3, per_task_budget_s=2.0)
+    elapsed = time.monotonic() - t0
+    assert sorted(out.tolist()) == [3, 5], "the two quick tasks must survive"
+    assert elapsed < 25, f"returned in {elapsed:.1f}s; must not wait out the hung task"
+
+
+def test_the_abandoned_object_is_named(caplog):
+    """It must say which object was dropped, not silently omit it."""
+    tasks = [(_quick, np.zeros(3), {}), (_slow, np.zeros(9), {})]
+    with caplog.at_level("WARNING"):
+        _run_pool(tasks, 2, per_task_budget_s=2.0, task_labels=["alpha", "beta"])
+    assert "Abandoned 1 of 2" in caplog.text
+    assert "beta" in caplog.text, "the abandoned task must be identified"
+
+
+def test_a_generous_budget_abandons_nothing():
+    tasks = [(_quick, np.zeros(3), {}), (_quick, np.zeros(5), {})]
+    out = _run_pool(tasks, 2, per_task_budget_s=60.0)
+    assert sorted(out.tolist()) == [3, 5]
+
+
+def test_process_data_by_id_threads_the_budget():
+    """The per-object entry point: one object grinds, the other two return."""
+    t0 = time.monotonic()
+    out = process_data_by_id(ROWS, 3, _slow_for_b, "provID", per_object_budget_s=2.0)
+    elapsed = time.monotonic() - t0
+    assert out.tolist() == [1, 1], "objects a and c must come back"
+    assert elapsed < 25, f"returned in {elapsed:.1f}s"
+
+
+def test_process_data_by_id_is_unchanged_without_a_budget():
+    out = process_data_by_id(ROWS, 3, _quick_by_id, "provID")
+    assert sorted(out.tolist()) == [1, 1, 1]

--- a/tests/layup/test_per_object_budget.py
+++ b/tests/layup/test_per_object_budget.py
@@ -30,7 +30,7 @@ def _quick(data, **kwargs):
 
 
 def _slow(data, **kwargs):
-    time.sleep(30)
+    time.sleep(60)
     return np.asarray([len(data)])
 
 
@@ -41,9 +41,15 @@ def _quick_by_id(data, primary_id_column_name=None, **kwargs):
 def _slow_for_b(data, primary_id_column_name=None, **kwargs):
     """Grind forever on one particular object, return promptly for the rest."""
     if str(data[primary_id_column_name][0]) == "b":
-        time.sleep(30)
+        time.sleep(60)
     return np.asarray([len(data)])
 
+
+# Generous against a cold CI worker: _run_pool now waits for every worker to
+# start before the clock begins, but the first task in a child still pays the
+# import of this module. The hung tasks sleep 60 s, so the assertions below
+# remain decisive at any budget well under that.
+BUDGET = 10.0
 
 ROWS = np.array([("a",), ("b",), ("c",)], dtype=[("provID", "U4")])
 
@@ -57,17 +63,17 @@ def test_a_hung_task_no_longer_withholds_the_others():
     """The point of the issue: the fast results come back."""
     tasks = [(_quick, np.zeros(3), {}), (_slow, np.zeros(9), {}), (_quick, np.zeros(5), {})]
     t0 = time.monotonic()
-    out = _run_pool(tasks, 3, per_task_budget_s=2.0)
+    out = _run_pool(tasks, 3, per_task_budget_s=BUDGET)
     elapsed = time.monotonic() - t0
     assert sorted(out.tolist()) == [3, 5], "the two quick tasks must survive"
-    assert elapsed < 25, f"returned in {elapsed:.1f}s; must not wait out the hung task"
+    assert elapsed < 45, f"returned in {elapsed:.1f}s; must not wait out the hung task"
 
 
 def test_the_abandoned_object_is_named(caplog):
     """It must say which object was dropped, not silently omit it."""
     tasks = [(_quick, np.zeros(3), {}), (_slow, np.zeros(9), {})]
     with caplog.at_level("WARNING"):
-        _run_pool(tasks, 2, per_task_budget_s=2.0, task_labels=["alpha", "beta"])
+        _run_pool(tasks, 2, per_task_budget_s=BUDGET, task_labels=["alpha", "beta"])
     assert "Abandoned 1 of 2" in caplog.text
     assert "beta" in caplog.text, "the abandoned task must be identified"
 
@@ -81,10 +87,10 @@ def test_a_generous_budget_abandons_nothing():
 def test_process_data_by_id_threads_the_budget():
     """The per-object entry point: one object grinds, the other two return."""
     t0 = time.monotonic()
-    out = process_data_by_id(ROWS, 3, _slow_for_b, "provID", per_object_budget_s=2.0)
+    out = process_data_by_id(ROWS, 3, _slow_for_b, "provID", per_object_budget_s=BUDGET)
     elapsed = time.monotonic() - t0
     assert out.tolist() == [1, 1], "objects a and c must come back"
-    assert elapsed < 25, f"returned in {elapsed:.1f}s"
+    assert elapsed < 45, f"returned in {elapsed:.1f}s"
 
 
 def test_process_data_by_id_is_unchanged_without_a_budget():


### PR DESCRIPTION
Addresses #492 (mechanism; see "What this does not do" for the half that needs a decision).

## The bug

`_run_pool` used `starmap`, which returns only once the slowest task has finished — so one object that never converges withheld **every other result in the run**. 108 short arcs in a single call took over an hour with no output; the same 108 fitted individually took under a minute, because two of them ground indefinitely.

## The change

`_run_pool` gains an optional `per_task_budget_s`.

- **Unset** — the default, and every current caller — the path is the old `starmap`, unchanged.
- **Set** — tasks are submitted with `apply_async` and collected as they finish. At a deadline of `budget × ceil(n_tasks / n_workers)`, whatever is still running is abandoned, the pool is terminated, and the results of everything that finished are returned.

`process_data_by_id` exposes it as `per_object_budget_s`. That is exactly a per-object budget there, because the function already builds **one task per object** (`pid_list` splits on the primary id, `chunksize=1`) — which is also why this turned out much smaller than the issue implies.

Abandoned objects are **named** in the warning through `task_labels`, rather than silently omitted.

## 🔴 Nothing here interrupts a running task

A fit inside the C integrator cannot be preempted from Python: a signal handler runs only at a bytecode boundary. That is why a `signal.alarm` timeout does not bound these fits **at any value**. The budget abandons the task and kills its worker; it does not unwind the call. Said in the docstring so the next reader does not expect otherwise.

## Why the budget is per-batch rather than per-task

A worker cannot report when its task *started* — the parent sees submission and completion only. A strict per-task deadline needs a fresh pool per wave of `n_workers`, which is exact but respawns a worker every wave.

🔬 Measured, that respawn is **80 ms, of which `get_ephem` is 1 ms** — the ephemeris is memory-mapped, not re-read, which I had assumed would make per-object processes unaffordable and it does not. So the strict variant costs ~13% on a 0.6 s/object run and is available if it is ever wanted.

## ⚠️ What this does NOT do

**No caller sets a budget.** The mechanism is here and tested; wiring it to a CLI flag with a default — the part that would actually save a catalogue run — is deliberately not in this PR, because it changes behaviour for `orbitfit`, `convert` and `predict` and the default value is a judgement call.

For whoever picks that up: the measured pathological rate on short MPC arcs is 1.9% at seven days and 7.2% at fourteen (#465), and with `adaptive_mode = 2` the slow tail completes in about a second. **300 s per object** would therefore be generous by more than two orders of magnitude while still bounding a grind — but it is a number worth choosing rather than inheriting from me.

## Tests

Six, of which **four fail on revert**; the two that do not are the guards asserting the default path is unchanged. The central one checks both halves of the bug: the quick tasks come back **and** the call returns in under 25 s rather than waiting out a 30 s hang.

⚠️ Helpers are module-level because spawn pickles callables by reference, so a function defined inside a test cannot reach a worker.

Full suite: **585 passed, 1 skipped**. `black` clean.

(AI-assisted implementation and analysis, reported by me.)