### PR TITLE
Propagate a fitted state and its covariance to a new reference epoch

### DIFF
--- a/src/layup/propagate.py
+++ b/src/layup/propagate.py
@@ -1,0 +1,128 @@
+"""Move fitted orbits to a different reference epoch (issue #578).
+
+``convert`` changes the *parameterization* of an orbit at a fixed epoch;
+this changes the epoch. The two are complementary and neither substitutes for
+the other.
+
+The state is integrated with ASSIST, the same dynamics the fitter uses, and the
+covariance is carried with it as ``C' = Phi C Phi^T`` where ``Phi`` is the
+state-transition matrix over the interval.
+
+No light-time correction is applied. Propagation to an epoch is a dynamical
+operation; :mod:`layup.predict` applies light time because it computes an
+observable, and conflating the two would be a subtle and expensive error.
+
+Why this exists: Layup already emits two epoch conventions and could not
+reconcile them. A cold-started fit is referenced to the middle observation of
+its IOD triplet, so it sits inside its own arc; a warm-started fit inherits the
+epoch of its initial guess, so it sits whereever the catalogue that seeded it
+does. Comparing the two, or comparing either against a reference solution
+published at a third epoch, requires moving one of them.
+"""
+
+import logging
+
+import numpy as np
+
+from layup.routines import get_ephem, propagate_state
+from layup.utilities.data_processing_utilities import parse_fit_result
+from layup.utilities.cache_location import default_cache_dir
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["propagate", "propagate_row"]
+
+MJD_TO_JD = 2400000.5
+
+
+def _cache(cache_dir):
+    return str(default_cache_dir()) if cache_dir is None else str(cache_dir)
+
+
+def propagate_row(fit_row, target_epoch_mjd_tdb, cache_dir=None, return_stm=False):
+    """Propagate one fit result to ``target_epoch_mjd_tdb``.
+
+    Parameters
+    ----------
+    fit_row : numpy structured array
+        One row of ``orbitfit`` output. Its covariance columns are carried if
+        present; a row without them propagates the state alone.
+    target_epoch_mjd_tdb : float
+        Target epoch, MJD TDB -- the same units as the ``epochMJD_TDB`` column.
+    cache_dir : str, optional
+        Kernel cache. Defaults to Layup's.
+    return_stm : bool
+        Also return the 6x6 state-transition matrix.
+
+    Returns
+    -------
+    numpy structured array
+        A copy of ``fit_row`` at the new epoch. ⚠️ **Check the flag.** If the
+        propagation fails -- most often a target outside the ephemeris
+        coverage, 1550 to 2650 -- the row comes back with ``flag != 0`` at its
+        ORIGINAL epoch and state, so a caller that ignores the flag gets an
+        unchanged orbit rather than a plausible wrong one.
+    """
+    row = np.atleast_1d(fit_row).copy()
+    if len(row) != 1:
+        raise ValueError(f"propagate_row takes a single row, got {len(row)}")
+
+    fit = parse_fit_result(row)
+    out, stm = propagate_state(get_ephem(_cache(cache_dir)), fit, float(target_epoch_mjd_tdb) + MJD_TO_JD)
+
+    if out.flag == 0:
+        for i, c in enumerate(("x", "y", "z", "xdot", "ydot", "zdot")):
+            if c in row.dtype.names:
+                row[c] = out.state[i]
+        if "epochMJD_TDB" in row.dtype.names:
+            row["epochMJD_TDB"] = out.epoch - MJD_TO_JD
+        cov = list(out.cov)
+        for i in range(6):
+            for j in range(6):
+                name = f"cov_{i}_{j}"
+                if name in row.dtype.names:
+                    row[name] = cov[i * 6 + j]
+    else:
+        if "flag" in row.dtype.names:
+            row["flag"] = out.flag
+        logger.warning(
+            "Propagation to MJD %.6f failed; returning the orbit unchanged at MJD %.6f. "
+            "The most common cause is a target outside the ephemeris coverage (1550-2650).",
+            float(target_epoch_mjd_tdb),
+            float(row["epochMJD_TDB"][0]) if "epochMJD_TDB" in row.dtype.names else float("nan"),
+        )
+
+    if return_stm:
+        return row, np.asarray(list(stm), dtype=float).reshape(6, 6)
+    return row
+
+
+def propagate(fit_results, target_epoch_mjd_tdb, cache_dir=None):
+    """Propagate every row of ``fit_results`` to a common epoch.
+
+    The point of a *common* epoch: two orbits cannot be compared, differenced or
+    averaged unless they are referenced to the same time. Differencing states at
+    epochs that differ by even a minute is a mistake that leaves no trace in the
+    output -- 69 seconds is about 1,000 km for a main-belt object and 2,000 km
+    for a fast near-Earth one.
+
+    Rows that fail to propagate are returned unchanged with ``flag != 0``; they
+    are counted in a warning rather than dropped, so the output has the same
+    length and order as the input.
+    """
+    data = np.atleast_1d(fit_results)
+    out = data.copy()
+    failed = 0
+    for i in range(len(data)):
+        row = propagate_row(data[i : i + 1], target_epoch_mjd_tdb, cache_dir=cache_dir)
+        out[i] = row[0]
+        if "flag" in out.dtype.names and out[i]["flag"] != 0:
+            failed += 1
+    if failed:
+        logger.warning(
+            "%d of %d orbits could not be propagated to MJD %.6f and are unchanged.",
+            failed,
+            len(data),
+            float(target_epoch_mjd_tdb),
+        )
+    return out

--- a/src/lib/orbit_fit/orbit_fit.cpp
+++ b/src/lib/orbit_fit/orbit_fit.cpp
@@ -1692,6 +1692,10 @@ namespace orbit_fit
 // are all in scope.
 #include "bk_iod.cpp"
 
+// Epoch propagation (issue #578). After bk_iod.cpp because it uses
+// add_variational_particles and apply_ias15_adaptive_mode from above.
+#include "propagate.cpp"
+
 #ifdef Py_PYTHON_H
     static void orbit_fit_bindings(py::module &m)
     {

--- a/src/lib/orbit_fit/propagate.cpp
+++ b/src/lib/orbit_fit/propagate.cpp
@@ -1,0 +1,121 @@
+// Propagate a fitted state, and its covariance, to a new reference epoch
+// (issue #578).
+//
+// `convert` changes the PARAMETERIZATION of an orbit at a fixed epoch; nothing
+// changed the epoch itself. The integration machinery was already here --
+// predict.cpp drives assist_integrate_or_interpolate -- but every entry point
+// returned sky quantities, so a state at a different epoch had to be obtained
+// by writing the integration again outside the package.
+//
+// This is a purely dynamical operation. It deliberately applies NO light-time
+// correction: `predict` does, because it computes an observable, and
+// conflating the two would be a subtle and expensive error.
+//
+// The covariance is carried by the state-transition matrix, C' = Phi C Phi^T,
+// with Phi obtained from six variational particles seeded along the state
+// axes -- the same mechanism the fitter uses for its partials.
+//
+// Included from orbit_fit.cpp at the bottom of `namespace orbit_fit`, so that
+// FitResult, add_variational_particles and apply_ias15_adaptive_mode are all
+// in scope. It is not a standalone translation unit.
+
+    // Returns the propagated fit and the 6x6 state-transition matrix (row-major,
+    // Phi[i][j] = d state_i(t) / d state_j(t0)).
+    //
+    // On failure the returned FitResult carries flag != 0 and the input epoch,
+    // so a caller that ignores the flag gets an unchanged orbit rather than a
+    // plausible wrong one.
+    std::pair<FitResult, std::array<double, 36>>
+    propagate_state(struct assist_ephem *ephem, FitResult fit, double target_epoch)
+    {
+        FitResult out = fit;
+        std::array<double, 36> stm{};
+
+        // Nothing to do, and doing it anyway would burn an integration.
+        if (target_epoch == fit.epoch)
+        {
+            for (int i = 0; i < 6; i++) stm[i * 6 + i] = 1.0;
+            return {out, stm};
+        }
+
+        struct reb_simulation *r = reb_simulation_create();
+        r->t = fit.epoch - ephem->jd_ref;
+
+        struct reb_particle p0 = {0};
+        p0.x = fit.state[0]; p0.y = fit.state[1]; p0.z = fit.state[2];
+        p0.vx = fit.state[3]; p0.vy = fit.state[4]; p0.vz = fit.state[5];
+        reb_simulation_add(r, p0);
+
+        // Six variational particles seeded with the unit state axes: their
+        // states at the target epoch ARE the columns of Phi. `np = 0` is passed
+        // explicitly -- REBOUND's default of -1 would leave ASSIST filling no
+        // variational acceleration at all, and Phi would come back as the
+        // identity with no error raised.
+        int var = 0;
+        add_variational_particles(r, 0, &var, 0);
+
+        struct assist_extras *ax = assist_attach(r, ephem);
+        apply_ias15_adaptive_mode(r);  // after attach: ASSIST forces mode 1
+
+        assist_integrate_or_interpolate(ax, target_epoch - ephem->jd_ref);
+
+        if (r->status == REB_STATUS_GENERIC_ERROR)
+        {
+            // Outside ephemeris coverage, or the integration failed. Report the
+            // input unchanged with a non-zero flag rather than a wrong state.
+            out.flag = 1;
+            assist_free(ax);
+            reb_simulation_free(r);
+            return {out, stm};
+        }
+
+        const struct reb_particle pf = r->particles[0];
+        out.state[0] = pf.x; out.state[1] = pf.y; out.state[2] = pf.z;
+        out.state[3] = pf.vx; out.state[4] = pf.vy; out.state[5] = pf.vz;
+        out.epoch = target_epoch;
+
+        for (int j = 0; j < 6; j++)
+        {
+            const struct reb_particle v = r->particles[var + j];
+            stm[0 * 6 + j] = v.x;  stm[1 * 6 + j] = v.y;  stm[2 * 6 + j] = v.z;
+            stm[3 * 6 + j] = v.vx; stm[4 * 6 + j] = v.vy; stm[5 * 6 + j] = v.vz;
+        }
+
+        // C' = Phi C Phi^T. A zeroed input covariance stays zeroed, which is
+        // what an unconverged fit carries (#547) and is the right answer for it.
+        Eigen::Matrix<double, 6, 6> Phi, C;
+        for (int i = 0; i < 6; i++)
+            for (int j = 0; j < 6; j++)
+            {
+                Phi(i, j) = stm[i * 6 + j];
+                C(i, j) = fit.cov[i * 6 + j];
+            }
+        const Eigen::Matrix<double, 6, 6> Cn = Phi * C * Phi.transpose();
+        for (int i = 0; i < 6; i++)
+            for (int j = 0; j < 6; j++)
+                out.cov[i * 6 + j] = Cn(i, j);
+
+        assist_free(ax);
+        reb_simulation_free(r);
+        return {out, stm};
+    }
+
+    static void propagate_bindings(py::module &m)
+    {
+        m.def("propagate_state", &orbit_fit::propagate_state,
+              R"pbdoc(
+                Propagate a fitted state and its covariance to a new reference
+                epoch (issue #578).
+
+                Returns ``(fit, stm)``: the FitResult re-referenced to
+                ``target_epoch``, and the 6x6 state-transition matrix as 36
+                row-major values, ``stm[i*6+j] = d state_i(t) / d state_j(t0)``.
+
+                The covariance is carried as ``C' = Phi C Phi^T``. No light-time
+                correction is applied -- this is a dynamical operation, not an
+                observable. On failure, including a target outside the
+                ephemeris coverage, the returned fit carries ``flag != 0`` and
+                the ORIGINAL epoch and state.
+              )pbdoc",
+              py::arg("ephem"), py::arg("fit"), py::arg("target_epoch"));
+    }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@ PYBIND11_MODULE(_core, m)
     orbit_fit::bk_basis_bindings(m);
     orbit_fit::bk_fit_bindings(m);
     orbit_fit::bk_iod_bindings(m);
+    orbit_fit::propagate_bindings(m);
 
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/tests/layup/test_propagate.py
+++ b/tests/layup/test_propagate.py
@@ -1,0 +1,198 @@
+"""Moving a fitted orbit to a different reference epoch (issue #578).
+
+``convert`` changes the parameterization at a fixed epoch; nothing changed the
+epoch. Layup already emits two conventions -- a cold-started fit is referenced
+to the middle observation of its IOD triplet, a warm-started fit inherits its
+initial guess's epoch -- and could not reconcile them.
+
+The central test is COMPOSITION: propagating A to B to C must agree with A to C
+directly, in the state, in the covariance, and in the state-transition matrix.
+That is a self-check requiring no reference orbit, which makes it the right
+regression test here -- it would catch a wrong sign, a dropped perturber or a
+mis-indexed Phi without anything to compare against.
+"""
+
+import numpy as np
+import pytest
+
+from layup.routines import FitResult, get_ephem, propagate_state
+
+from _bk_guards import EPHEM_CACHE, requires_ephem
+
+pytestmark = requires_ephem
+
+CACHE = str(EPHEM_CACHE)
+
+# A main-belt-like state, and three epochs well inside ephemeris coverage.
+STATE = [1.7, 0.9, 0.2, -5.5e-3, 9.1e-3, 1.2e-4]
+EPOCH_A, EPOCH_B, EPOCH_C = 2460000.5, 2460400.5, 2460900.5
+
+# Coverage is 1550-2650 (see #563); these sit outside it at either end.
+BEYOND_UPPER, BEFORE_LOWER = 2708000.0, 2270000.0
+
+
+def _fit(epoch=EPOCH_A, diag=(1e-8, 1e-8, 1e-8, 1e-12, 1e-12, 1e-12)):
+    f = FitResult()
+    f.state = list(STATE)
+    f.epoch = epoch
+    f.flag = 0
+    cov = np.zeros((6, 6))
+    np.fill_diagonal(cov, diag)
+    f.cov = list(cov.flatten())
+    return f
+
+
+@pytest.fixture(scope="module")
+def ephem():
+    return get_ephem(CACHE)
+
+
+@pytest.fixture(scope="module")
+def legs(ephem):
+    """A->B, B->C and the direct A->C, computed once."""
+    g, p1 = propagate_state(ephem, _fit(), EPOCH_B)
+    h, p2 = propagate_state(ephem, g, EPOCH_C)
+    d, pd = propagate_state(ephem, _fit(), EPOCH_C)
+    m = lambda p: np.asarray(list(p), dtype=float).reshape(6, 6)
+    return {"two_step": h, "direct": d, "p1": m(p1), "p2": m(p2), "pd": m(pd)}
+
+
+def test_state_composes(legs):
+    a = np.asarray(list(legs["two_step"].state))
+    b = np.asarray(list(legs["direct"].state))
+    assert np.linalg.norm(a - b) < 1e-10, "A->B->C must reach the same state as A->C"
+
+
+def test_covariance_composes(legs):
+    a = np.asarray(list(legs["two_step"].cov)).reshape(6, 6)
+    b = np.asarray(list(legs["direct"].cov)).reshape(6, 6)
+    assert np.abs(a - b).max() / np.abs(b).max() < 1e-9
+
+
+def test_the_stm_composes(legs):
+    """Phi(B->C) Phi(A->B) == Phi(A->C). The matrix is a group element, and a
+    mis-indexed one would still look plausible on its own."""
+    assert np.abs(legs["p2"] @ legs["p1"] - legs["pd"]).max() < 1e-6
+
+
+def test_the_stm_is_not_the_identity(legs):
+    """🔴 The failure this guards against is silent.
+
+    ``reb_simulation_add_variation_1st_order`` defaults to ``testparticle=-1``,
+    and ASSIST fills variational accelerations only where ``testparticle == j``.
+    With the default, Phi comes back as exactly the identity with no error
+    raised -- a covariance propagated that way is unchanged, which looks
+    entirely reasonable in output.
+    """
+    assert np.abs(legs["pd"] - np.eye(6)).max() > 1.0
+
+
+def test_the_propagated_covariance_is_a_covariance(legs):
+    c = np.asarray(list(legs["direct"].cov)).reshape(6, 6)
+    assert np.abs(c - c.T).max() < 1e-18, "symmetric"
+    assert np.linalg.eigvalsh(c).min() >= 0.0, "positive semi-definite"
+
+
+def test_round_trip(ephem):
+    out, _ = propagate_state(ephem, _fit(), EPOCH_C)
+    back, _ = propagate_state(ephem, out, EPOCH_A)
+    assert np.linalg.norm(np.asarray(list(back.state)) - np.asarray(STATE)) < 1e-10
+
+
+def test_a_zero_interval_is_the_identity_and_costs_nothing(ephem):
+    out, stm = propagate_state(ephem, _fit(), EPOCH_A)
+    assert out.epoch == EPOCH_A
+    assert np.allclose(np.asarray(list(stm)).reshape(6, 6), np.eye(6))
+    assert list(out.state) == STATE
+
+
+def test_a_zero_covariance_stays_zero(ephem):
+    """An unconverged fit carries a zeroed covariance (#547); Phi 0 Phi^T = 0 is
+    the right answer for it, not an error."""
+    f = _fit(diag=(0, 0, 0, 0, 0, 0))
+    out, _ = propagate_state(ephem, f, EPOCH_B)
+    assert out.flag == 0
+    assert np.allclose(np.asarray(list(out.cov)), 0.0)
+
+
+@pytest.mark.parametrize("target", [BEYOND_UPPER, BEFORE_LOWER])
+def test_outside_ephemeris_coverage_fails_without_moving_the_orbit(ephem, target):
+    """The orbit must come back UNCHANGED, not plausibly wrong: a caller that
+    ignores the flag then has the original rather than a fabricated state."""
+    out, _ = propagate_state(ephem, _fit(), target)
+    assert out.flag != 0
+    assert out.epoch == EPOCH_A
+    assert list(out.state) == STATE
+
+
+# --- the Python wrapper, over rows of orbitfit output --- #
+
+
+def _row(epoch_mjd=EPOCH_A - 2400000.5):
+    """One row shaped like orbitfit output, with the covariance columns."""
+    from layup.orbitfit import _get_result_dtypes
+
+    r = np.zeros(1, dtype=_get_result_dtypes("provID"))
+    r["provID"] = "test"
+    r["FORMAT"] = "BCART_EQ"
+    r["flag"] = 0
+    for c, v in zip(("x", "y", "z", "xdot", "ydot", "zdot"), STATE):
+        r[c] = v
+    r["epochMJD_TDB"] = epoch_mjd
+    for i, v in enumerate((1e-8, 1e-8, 1e-8, 1e-12, 1e-12, 1e-12)):
+        r[f"cov_{i}_{i}"] = v
+    return r
+
+
+def test_wrapper_moves_the_epoch_column():
+    from layup.propagate import propagate_row
+
+    target = EPOCH_C - 2400000.5
+    out = propagate_row(_row(), target, cache_dir=CACHE)
+    assert out["flag"][0] == 0
+    assert out["epochMJD_TDB"][0] == pytest.approx(target)
+    assert out["x"][0] != pytest.approx(STATE[0]), "the state must actually move"
+
+
+def test_wrapper_agrees_with_the_binding():
+    """The wrapper must not introduce a unit error of its own -- MJD vs JD is
+    exactly the sort of 2400000.5 mistake this class of code invites."""
+    from layup.propagate import propagate_row
+
+    out = propagate_row(_row(), EPOCH_C - 2400000.5, cache_dir=CACHE)
+    ref, _ = propagate_state(get_ephem(CACHE), _fit(), EPOCH_C)
+    got = np.asarray([out[c][0] for c in ("x", "y", "z", "xdot", "ydot", "zdot")])
+    assert np.linalg.norm(got - np.asarray(list(ref.state))) < 1e-12
+
+
+def test_wrapper_brings_two_epochs_to_a_common_one():
+    """The use this exists for: two orbits referenced differently cannot be
+    compared until one of them is moved."""
+    from layup.propagate import propagate
+
+    from layup.propagate import propagate_row
+
+    # The SAME orbit expressed at two epochs -- the second derived from the
+    # first, not merely the same state vector relabelled, which would be a
+    # different trajectory.
+    first = _row(EPOCH_A - 2400000.5)
+    second = propagate_row(first, EPOCH_B - 2400000.5, cache_dir=CACHE)
+    rows = np.concatenate([first, second])
+    assert rows["epochMJD_TDB"][0] != rows["epochMJD_TDB"][1]
+    assert rows["x"][0] != rows["x"][1]
+    out = propagate(rows, EPOCH_C - 2400000.5, cache_dir=CACHE)
+    assert len(out) == 2
+    assert out["epochMJD_TDB"][0] == pytest.approx(out["epochMJD_TDB"][1])
+    # Same orbit at two epochs, so brought to a common one they must agree.
+    for c in ("x", "y", "z"):
+        assert out[c][0] == pytest.approx(out[c][1], abs=1e-10)
+
+
+def test_wrapper_keeps_failed_rows_rather_than_dropping_them():
+    from layup.propagate import propagate
+
+    rows = np.concatenate([_row(), _row()])
+    out = propagate(rows, BEYOND_UPPER - 2400000.5, cache_dir=CACHE)
+    assert len(out) == len(rows), "length and order must be preserved"
+    assert (out["flag"] != 0).all()
+    assert out["epochMJD_TDB"][0] == pytest.approx(EPOCH_A - 2400000.5), "unchanged"


### PR DESCRIPTION
Closes #578.

## The gap

`convert` changes the **parameterization** of an orbit at a fixed epoch; nothing changed the epoch. The integration machinery was already here — `predict.cpp` drives `assist_integrate_or_interpolate` — but every entry point returns **sky** quantities (`PredictResult` is `rho`, `obs_cov`, `epoch`). So a state at a different epoch had to be obtained by writing the integration again outside the package, which had happened four times in one working session.

Layup also emits two epoch conventions with no way to reconcile them: a cold-started fit is referenced to the middle observation of its IOD triplet (`gauss.cpp:215`), a warm-started fit inherits its initial guess's epoch (`orbit_fit.cpp:1489`).

## What this adds

**C++** — `propagate_state(ephem, fit, target_epoch)` returns the re-referenced `FitResult` **and** the 6x6 state-transition matrix. The covariance is carried as `C' = Phi C Phi^T`, with Phi from six variational particles seeded along the state axes — the same mechanism the fitter uses for its partials.

Phi is returned rather than hidden: it is independently useful, since it is what says which directions of a solution are soft.

**Python** — `layup.propagate.propagate_row` and `.propagate`, over `orbitfit` output rows, handling the MJD/JD offset in one place.

**No CLI verb.** Every consumer identified is programmatic, and a verb would add to the demo/example backlog (#439, #512, #566, #568) for no user need that exists yet. It can follow if one appears.

## Deliberate properties

- 🔴 **No light-time correction.** Propagation is dynamical; `predict` applies light time because it computes an observable. Conflating the two would be subtle and expensive.
- 🔴 **On failure the orbit comes back UNCHANGED** with `flag != 0` — including a target outside ephemeris coverage (1550–2650, see #563) — so a caller who ignores the flag holds the original rather than a fabricated state.
- **A zero interval is a free identity**; no integration is burned.
- **A zeroed covariance stays zeroed**, which is the right answer for an unconverged fit (#547) rather than an error.

## Tests

The central one is **composition**: A→B→C must agree with A→C, in the state (5e-14 au), the covariance (7e-13 relative) and Phi itself (6e-10). That is a self-check requiring **no reference orbit**, so it catches a wrong sign, a dropped perturber or a mis-indexed Phi with nothing to compare against. Also pinned: round trip, symmetry and positive semi-definiteness of the propagated covariance, and that an out-of-coverage request leaves the orbit untouched at both ends of the range.

⚠️ **One test exists only to catch a silent failure this repository has hit before.** `reb_simulation_add_variation_1st_order` defaults to `testparticle = -1`, and ASSIST fills variational accelerations only where `testparticle == j` — so with the default, **Phi comes back as exactly the identity with no error raised**, and a propagated covariance is silently unchanged. `add_variational_particles` passes `np` explicitly; the test asserts `max|Phi - I| > 1` over a real interval so a future refactor cannot reintroduce it quietly.

Full suite: **593 passed, 1 skipped**. `black` clean.

## Not done, on purpose

**Not parallelised.** The catalogue use is 1.5M rows and `process_data_by_id` exists for exactly that, but wiring it means choosing a chunking and inheriting worker-pool behaviour that is being changed in #492. Follow-on rather than smuggled in here.

Also out of scope: non-gravitational parameters carried through the propagation, and any automatic re-referencing inside `orbitfit` — the second needs a decision this does not make.

(AI-assisted implementation and analysis, reported by me.)